### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "smithay/client-toolkit" }
 
 [dependencies]
 bitflags = "1.0"
-nix = "0.10"
+nix = "0.11"
 dlib = "0.4"
 lazy_static = "1"
 memmap = "0.6"


### PR DESCRIPTION
Nix 0.10.0 does not work on OpenBSD, but 0.11.0 does.

Signed-off-by: Gregor Best <gbe@unobtanium.de>