### PR TITLE
Remove borders from windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- BasicFrame: remove side and bottom border decorations
+
 ## 0.2.5 -- 2018-07-10
 
 - Keyboard: try to load `libxkbcommon.so.0` as well to improve compatibility

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -393,19 +393,19 @@ impl Frame for BasicFrame {
                 // For every pixel in top border
                 for y in 0..DECORATION_TOP_SIZE {
                     for _ in 0..DECORATION_SIZE {
-                        writer.write_u32::<NativeEndian>(0x00_00_00_00);
+                        let _ = writer.write_u32::<NativeEndian>(0x00_00_00_00);
                     }
                     for _ in 0..width {
-                            writer.write_u32::<NativeEndian>(color);
+                        let _ = writer.write_u32::<NativeEndian>(color);
                     }
                     for _ in 0..DECORATION_SIZE {
-                        writer.write_u32::<NativeEndian>(0x00_00_00_00);
+                        let _ = writer.write_u32::<NativeEndian>(0x00_00_00_00);
                     }
                 }
 
                 // For every pixel in the other borders
                 for _ in DECORATION_TOP_SIZE * (width + 2 * DECORATION_SIZE)..pxcount {
-                    writer.write_u32::<NativeEndian>(0x00_00_00_00);
+                    let _ = writer.write_u32::<NativeEndian>(0x00_00_00_00);
                 }
 
                 draw_buttons(
@@ -570,12 +570,8 @@ impl Frame for BasicFrame {
         }
     }
 
-    fn headless_geometry(&self, x: i32, y: i32, width: i32, height: i32) -> (i32, i32, i32, i32) {
-        if self.hidden {
-            (x, y, width, height)
-        } else {
-            (x, y - DECORATION_TOP_SIZE as i32, width, height)
-        }
+    fn location(&self) -> (i32, i32) {
+        if self.hidden { (0, 0) } else { (0, -(DECORATION_TOP_SIZE as i32)) }
     }
 }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -181,6 +181,7 @@ impl<F: Frame + 'static> Window<F> {
             shell_surface.set_min_size(Some((minw, minh)));
             let (w, h) = frame.add_borders(initial_dims.0 as i32, initial_dims.1 as i32);
             let (x, y) = frame.location();
+            let (x, y, w, h) = frame.headless_geometry(x, y, w, h);
             shell_surface.set_geometry(x, y, w, h);
         }
 
@@ -312,6 +313,7 @@ impl<F: Frame + 'static> Window<F> {
         frame.resize((w, h));
         let (w, h) = frame.add_borders(w as i32, h as i32);
         let (x, y) = frame.location();
+        let (x, y, w, h) = frame.headless_geometry(x, y, w, h);
         self.shell_surface.set_geometry(x, y, w, h);
     }
 
@@ -452,4 +454,6 @@ pub trait Frame: Sized + Send {
     fn location(&self) -> (i32, i32) {
         (0, 0)
     }
+
+    fn headless_geometry(&self, i32, i32, i32, i32) -> (i32, i32, i32, i32);
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -181,7 +181,6 @@ impl<F: Frame + 'static> Window<F> {
             shell_surface.set_min_size(Some((minw, minh)));
             let (w, h) = frame.add_borders(initial_dims.0 as i32, initial_dims.1 as i32);
             let (x, y) = frame.location();
-            let (x, y, w, h) = frame.headless_geometry(x, y, w, h);
             shell_surface.set_geometry(x, y, w, h);
         }
 
@@ -313,7 +312,6 @@ impl<F: Frame + 'static> Window<F> {
         frame.resize((w, h));
         let (w, h) = frame.add_borders(w as i32, h as i32);
         let (x, y) = frame.location();
-        let (x, y, w, h) = frame.headless_geometry(x, y, w, h);
         self.shell_surface.set_geometry(x, y, w, h);
     }
 
@@ -454,6 +452,4 @@ pub trait Frame: Sized + Send {
     fn location(&self) -> (i32, i32) {
         (0, 0)
     }
-
-    fn headless_geometry(&self, i32, i32, i32, i32) -> (i32, i32, i32, i32);
 }


### PR DESCRIPTION
I think that following the lead of GTK, QT..etc borders around windows should not be rendered as it uses up screen space and can look ugly. 

This pull request changes the drawing of the decorations so that the sides and bottom borders become invisible (it doesn't remove them because they are needed for window resizing). 
![screenshot from 2018-07-12 14-09-11](https://user-images.githubusercontent.com/40879396/42616104-8a0c08b2-85df-11e8-8d1e-be280079dbfe.png)

DECORATION_SIZE now controls how far away your mouse can be from the window to resize it (warning that it still plays a part in the positioning of buttons though)

Because of the adjustments to window geometry which is calculated with headless_geometry() the compositor can snap the inner surface to the sides of the screen and show it correctly in the gnome activities view
![screenshot from 2018-07-12 14-10-26](https://user-images.githubusercontent.com/40879396/42616315-61520ae2-85e0-11e8-9e88-6ce574e35d55.png)

Full screen works without borders as you would expect any other window to do
![screenshot from 2018-07-12 14-10-39](https://user-images.githubusercontent.com/40879396/42616353-810567e4-85e0-11e8-9729-6f701ab62db0.png)

I've also tested that it works with decorations set to hidden.

I can only test on gnome so I'm unsure whether these changes will work properly for all compositors and I didn't really spend a lot of time testing windows with other settings but it seems to work perfectly with alacritty and the selection example. I set this as default behavior that cannot be changed as I couldn't think of any downsides, although it would be easy to make this a setting with something like set_borders(bool). Thanks
