### PR TITLE
Round window corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - BasicFrame: remove side and bottom border decorations
+- BasicFrame: round window corners
 
 ## 0.2.5 -- 2018-07-10
 


### PR DESCRIPTION
### Changes
* Window corners are rounded by calculating circle_width (X) from y and also ROUNDING_SIZE which sets the radius.
- diagram
![drawing](https://user-images.githubusercontent.com/40879396/42702368-de87b9be-86fb-11e8-9e77-b44a2972feab.png)

### Effects
* Windows look more standard as gtk, qt and x11 also round their windows by default
* The const ROUNDING_SIZE can be used to set the amount of rounding, I found that without shading 3 works best however once shading is done it will probably increase to 4-8 like gtk.

### Issues
* Corners can look slightly pixelated as I have yet to try and implement window shading.
* At a ROUNDING_SIZE of higher than 3 the window doesn't fit nicely in the corners of mutter (should be fixed with shading).

### Improvements
* The calculation of circle_width could be cached instead of recalculated on every redraw however all redraw calculations aren't cached I think.

I think both the rounded and 'boxy' style look alright (it could maybe even be a setting as ROUNDING_SIZE=0 sets the boxy style), however as rounded is more standard with gtk, qt, x11, I would say it is a better default.

- Comparing gtk, client-toolkit and client toolkit rounded
![screenshot from 2018-07-13 17-52-24](https://user-images.githubusercontent.com/40879396/42702708-e6bcb340-86fc-11e8-8e92-6fef8bde185d.png)