### PR TITLE
Bump minimum rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ script:
         cargo fmt -- --write-mode=diff
       elif [ -n "$BUILD_DOC" ]; then
         cargo doc --no-deps --all-features
+      elif [[ "$TRAVIS_RUST_VERSION" = "1.22.0" ]]; then
+        # Only build, no tests on 1.22.0, as our dev-deps 'image' does not build on 1.22.0
+        env LD_LIBRARY_PATH=~/install/lib:$LD_LIBRARY_PATH cargo build --all-features
       else
         env LD_LIBRARY_PATH=~/install/lib:$LD_LIBRARY_PATH cargo test --all-features
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: trusty
 sudo: required
 
 rust:
-  - 1.20.0
+  - 1.22.0
   - stable
   - beta
   - nightly
@@ -48,9 +48,6 @@ script:
         cargo fmt -- --write-mode=diff
       elif [ -n "$BUILD_DOC" ]; then
         cargo doc --no-deps --all-features
-      elif [[ "$TRAVIS_RUST_VERSION" = "1.20.0" ]]; then
-        # Only build, no tests on 1.20.0, as our dev-deps 'image' does not build on 1.20.0
-        env LD_LIBRARY_PATH=~/install/lib:$LD_LIBRARY_PATH cargo build --all-features
       else
         env LD_LIBRARY_PATH=~/install/lib:$LD_LIBRARY_PATH cargo test --all-features
       fi

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ The documentation for the releases can be found on [docs.rs](https://docs.rs/smi
 
 ## Requirements
 
-Requires at least rust 1.20 to be used (using bitflags 1.0 for associated constants), and version 1.12 of the
+Requires at least rust 1.22 to be used (using bitflags 1.0 for associated constants), and version 1.12 of the
 wayland system libraries.


### PR DESCRIPTION
The update of tempfile 3.0.3 bumps rand to 0.5 which means that the client toolkit won't compile on rust 1.20. This pull request shows that the minimum rust version needed to compile the client toolkit is rust 1.22.