### PR TITLE
Draw decorations using a seperate crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- MemPool: add `mmap` method
 - **[Breaking]** Keyboard: remove `modifiers` field from `keyboard::Event::Enter`, `keyboard::Event::Key` and `keyboard::KeyRepeatEvent`
 - **[Breaking]** Keyboard: add `keyboard::Event::Modifiers`
 - **[Breaking]** Upgrade to wayland-rs 0.21

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ dlib = "0.4"
 lazy_static = "1"
 memmap = "0.6"
 rand = "0.5"
+andrew = "0.1.0"
 wayland-commons = { version = "0.21" }
 wayland-client = { version = "0.21", features = ["cursor"] }
 wayland-protocols = { version = "0.21", features = ["native_client", "unstable_protocols"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ dlib = "0.4"
 lazy_static = "1"
 memmap = "0.6"
 rand = "0.5"
-andrew = "0.1.0"
+andrew = "0.1.1"
 wayland-commons = { version = "0.21" }
 wayland-client = { version = "0.21", features = ["cursor"] }
 wayland-protocols = { version = "0.21", features = ["native_client", "unstable_protocols"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate bitflags;
 extern crate dlib;
 #[macro_use]
 extern crate lazy_static;
+extern crate andrew;
 extern crate memmap;
 extern crate nix;
 extern crate rand;

--- a/src/utils/mempool.rs
+++ b/src/utils/mempool.rs
@@ -12,6 +12,7 @@ use std::os::unix::io::FromRawFd;
 use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex};
 
+use memmap;
 use rand::prelude::*;
 
 use wayland_client::protocol::{wl_buffer, wl_shm, wl_shm_pool};
@@ -188,6 +189,11 @@ impl MemPool {
                     (),
                 )
             }).unwrap()
+    }
+
+    /// Uses the memmap crate to map the underlying shared memory file
+    pub fn mmap(&self) -> Result<memmap::MmapMut, io::Error> {
+        unsafe { memmap::MmapMut::map_mut(&self.file) }
     }
 
     /// Retuns true if the pool contains buffers that are currently in use by the server otherwise it returns

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -1,6 +1,9 @@
 use std::cmp::max;
-use std::io::{BufWriter, Seek, SeekFrom, Write};
+use std::io::Write;
 use std::sync::{Arc, Mutex};
+
+use andrew::shapes::rectangle;
+use andrew::Canvas;
 
 use wayland_client::protocol::{
     wl_compositor, wl_pointer, wl_seat, wl_shm, wl_subcompositor, wl_subsurface, wl_surface,
@@ -15,7 +18,7 @@ use wayland_client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
 
 use super::{Frame, FrameRequest};
 use pointer::{AutoPointer, AutoThemer};
-use utils::{DoubleMemPool, MemPool};
+use utils::DoubleMemPool;
 
 /*
  * Drawing theme definitions
@@ -24,32 +27,32 @@ use utils::{DoubleMemPool, MemPool};
 const BORDER_SIZE: u32 = 12;
 const HEADER_SIZE: u32 = 32;
 const BUTTON_SPACE: u32 = 10;
-const ROUNDING_SIZE: u32 = 3;
+const ROUNDING_SIZE: u32 = 5;
 
 // defining the color scheme
 #[cfg(target_endian = "little")]
 mod colors {
-    pub const INACTIVE_BORDER: &[u8] = &[0x60, 0x60, 0x60, 0xFF];
-    pub const ACTIVE_BORDER: &[u8] = &[0x80, 0x80, 0x80, 0xFF];
-    pub const RED_BUTTON_REGULAR: &[u8] = &[0x40, 0x40, 0xB0, 0xFF];
-    pub const RED_BUTTON_HOVER: &[u8] = &[0x40, 0x40, 0xFF, 0xFF];
-    pub const GREEN_BUTTON_REGULAR: &[u8] = &[0x40, 0xB0, 0x40, 0xFF];
-    pub const GREEN_BUTTON_HOVER: &[u8] = &[0x40, 0xFF, 0x40, 0xFF];
-    pub const YELLOW_BUTTON_REGULAR: &[u8] = &[0x40, 0xB0, 0xB0, 0xFF];
-    pub const YELLOW_BUTTON_HOVER: &[u8] = &[0x40, 0xFF, 0xFF, 0xFF];
-    pub const YELLOW_BUTTON_DISABLED: &[u8] = &[0x20, 0x80, 0x80, 0xFF];
+    pub const INACTIVE_BORDER: [u8; 4] = [0x60, 0x60, 0x60, 0xFF];
+    pub const ACTIVE_BORDER: [u8; 4] = [0x80, 0x80, 0x80, 0xFF];
+    pub const RED_BUTTON_REGULAR: [u8; 4] = [0x40, 0x40, 0xB0, 0xFF];
+    pub const RED_BUTTON_HOVER: [u8; 4] = [0x40, 0x40, 0xFF, 0xFF];
+    pub const GREEN_BUTTON_REGULAR: [u8; 4] = [0x40, 0xB0, 0x40, 0xFF];
+    pub const GREEN_BUTTON_HOVER: [u8; 4] = [0x40, 0xFF, 0x40, 0xFF];
+    pub const YELLOW_BUTTON_REGULAR: [u8; 4] = [0x40, 0xB0, 0xB0, 0xFF];
+    pub const YELLOW_BUTTON_HOVER: [u8; 4] = [0x40, 0xFF, 0xFF, 0xFF];
+    pub const YELLOW_BUTTON_DISABLED: [u8; 4] = [0x20, 0x80, 0x80, 0xFF];
 }
 #[cfg(target_endian = "big")]
 mod colors {
-    pub const INACTIVE_BORDER: &[u8] = &[0xFF, 0x60, 0x60, 0x60];
-    pub const ACTIVE_BORDER: &[u8] = &[0xFF, 0x80, 0x80, 0x80];
-    pub const RED_BUTTON_REGULAR: &[u8] = &[0xFF, 0xB0, 0x40, 0x40];
-    pub const RED_BUTTON_HOVER: &[u8] = &[0xFF, 0xFF, 0x40, 0x40];
-    pub const GREEN_BUTTON_REGULAR: &[u8] = &[0xFF, 0x40, 0xB0, 0x40];
-    pub const GREEN_BUTTON_HOVER: &[u8] = &[0xFF, 0x40, 0xFF, 0x40];
-    pub const YELLOW_BUTTON_REGULAR: &[u8] = &[0xFF, 0xB0, 0xB0, 0x40];
-    pub const YELLOW_BUTTON_HOVER: &[u8] = &[0xFF, 0xFF, 0xFF, 0x40];
-    pub const YELLOW_BUTTON_DISABLED: &[u8] = &[0xFF, 0x80, 0x80, 0x20];
+    pub const INACTIVE_BORDER: [u8; 4] = [0xFF, 0x60, 0x60, 0x60];
+    pub const ACTIVE_BORDER: [u8; 4] = [0xFF, 0x80, 0x80, 0x80];
+    pub const RED_BUTTON_REGULAR: [u8; 4] = [0xFF, 0xB0, 0x40, 0x40];
+    pub const RED_BUTTON_HOVER: [u8; 4] = [0xFF, 0xFF, 0x40, 0x40];
+    pub const GREEN_BUTTON_REGULAR: [u8; 4] = [0xFF, 0x40, 0xB0, 0x40];
+    pub const GREEN_BUTTON_HOVER: [u8; 4] = [0xFF, 0x40, 0xFF, 0x40];
+    pub const YELLOW_BUTTON_REGULAR: [u8; 4] = [0xFF, 0xB0, 0xB0, 0x40];
+    pub const YELLOW_BUTTON_HOVER: [u8; 4] = [0xFF, 0xFF, 0xFF, 0x40];
+    pub const YELLOW_BUTTON_DISABLED: [u8; 4] = [0xFF, 0x80, 0x80, 0x20];
 }
 
 /*
@@ -413,57 +416,58 @@ impl Frame for BasicFrame {
                 colors::INACTIVE_BORDER
             };
 
-            let _ = pool.seek(SeekFrom::Start(0));
+            let mut mmap = pool.mmap().unwrap();
             // draw the grey background
             {
-                let mut writer = BufWriter::new(&mut *pool);
+                {
+                    let mut header_canvas = Canvas::new(
+                        &mut mmap[0..HEADER_SIZE as usize * width as usize * 4],
+                        width as usize,
+                        HEADER_SIZE as usize,
+                        width as usize * 4,
+                    );
+                    header_canvas.clear();
 
-                // For every pixel in header
-                for y in 0..HEADER_SIZE {
-                    if y < ROUNDING_SIZE && !*self.inner.maximized.lock().unwrap() {
-                        // Calculate the circle width at y using trigonometry and pythagoras theorem
-                        let circle_width = ROUNDING_SIZE
-                            - ((ROUNDING_SIZE as f32).powi(2)
-                                - ((ROUNDING_SIZE - y) as f32).powi(2)).sqrt()
-                                as u32;
+                    let header_bar = rectangle::Rectangle::new(
+                        (0, 0),
+                        (width as usize - 1, HEADER_SIZE as usize - 1),
+                        Some((
+                            HEADER_SIZE as usize,
+                            color,
+                            rectangle::Sides::TOP,
+                            Some(ROUNDING_SIZE as usize),
+                        )),
+                        None,
+                    );
+                    header_canvas.draw(&header_bar);
 
-                        for x in 0..width {
-                            if x >= circle_width && x < width - circle_width {
-                                let _ = writer.write(color);
-                            } else {
-                                let _ = writer.write(&[0x00, 0x00, 0x00, 0x00]);
-                            }
-                        }
-                    } else {
-                        for _ in 0..width {
-                            let _ = writer.write(color);
-                        }
-                    }
+                    draw_buttons(
+                        &mut header_canvas,
+                        width,
+                        true,
+                        &self
+                            .pointers
+                            .iter()
+                            .flat_map(|p| {
+                                if p.is_alive() {
+                                    let data: &Mutex<
+                                        PointerUserData,
+                                    > = p.user_data().unwrap();
+                                    Some(data.lock().unwrap().location)
+                                } else {
+                                    None
+                                }
+                            }).collect(),
+                    );
                 }
 
-                // For every pixel in borders
-                for _ in BORDER_SIZE * width..pxcount {
+                // For each pixel in borders
+                let mut writer = &mut mmap[HEADER_SIZE as usize * width as usize * 4..];
+                for _ in 0..pxcount {
                     let _ = writer.write(&[0x00, 0x00, 0x00, 0x00]);
                 }
-
-                draw_buttons(
-                    &mut writer,
-                    width,
-                    true,
-                    &self
-                        .pointers
-                        .iter()
-                        .flat_map(|p| {
-                            if p.is_alive() {
-                                let data: &Mutex<PointerUserData> = p.user_data().unwrap();
-                                Some(data.lock().unwrap().location)
-                            } else {
-                                None
-                            }
-                        }).collect(),
-                );
-                let _ = writer.flush();
             }
+            let _ = mmap.flush();
 
             // Create the buffers
             // -> head-subsurface
@@ -709,12 +713,7 @@ fn request_for_location(
     }
 }
 
-fn draw_buttons(
-    pool: &mut BufWriter<&mut MemPool>,
-    width: u32,
-    maximizable: bool,
-    mouses: &Vec<Location>,
-) {
+fn draw_buttons(canvas: &mut Canvas, width: u32, maximizable: bool, mouses: &Vec<Location>) {
     // draw up to 3 buttons, depending on the width of the window
     // color of the button depends on whether a pointer is on it, and the maximizable
     // button can be disabled
@@ -729,15 +728,16 @@ fn draw_buttons(
         } else {
             colors::RED_BUTTON_REGULAR
         };
-        let _ = pool.seek(SeekFrom::Start(
-            4 * u64::from(width * (HEADER_SIZE / 2 - 8) + width - 24 - BUTTON_SPACE),
-        ));
-        for _ in 0..16 {
-            for _ in 0..24 {
-                let _ = pool.write(color);
-            }
-            let _ = pool.seek(SeekFrom::Current(4 * i64::from(width - 24)));
-        }
+        let red_button = rectangle::Rectangle::new(
+            (
+                (width - 24 - BUTTON_SPACE) as usize,
+                (HEADER_SIZE / 2 - 8) as usize,
+            ),
+            (24, 16),
+            None,
+            Some(color),
+        );
+        canvas.draw(&red_button);
     }
 
     if width >= 56 + 2 * BUTTON_SPACE {
@@ -752,15 +752,16 @@ fn draw_buttons(
         } else {
             colors::YELLOW_BUTTON_REGULAR
         };
-        let _ = pool.seek(SeekFrom::Start(
-            4 * u64::from(width * (HEADER_SIZE / 2 - 8) + width - 56 - BUTTON_SPACE),
-        ));
-        for _ in 0..16 {
-            for _ in 0..24 {
-                let _ = pool.write(color);
-            }
-            let _ = pool.seek(SeekFrom::Current(4 * i64::from(width - 24)));
-        }
+        let yellow_button = rectangle::Rectangle::new(
+            (
+                (width - 56 - BUTTON_SPACE) as usize,
+                (HEADER_SIZE / 2 - 8) as usize,
+            ),
+            (24, 16),
+            None,
+            Some(color),
+        );
+        canvas.draw(&yellow_button);
     }
 
     if width >= 88 + 2 * BUTTON_SPACE {
@@ -773,14 +774,15 @@ fn draw_buttons(
         } else {
             colors::GREEN_BUTTON_REGULAR
         };
-        let _ = pool.seek(SeekFrom::Start(
-            4 * u64::from(width * (HEADER_SIZE / 2 - 8) + width - 88 - BUTTON_SPACE),
-        ));
-        for _ in 0..16 {
-            for _ in 0..24 {
-                let _ = pool.write(color);
-            }
-            let _ = pool.seek(SeekFrom::Current(4 * i64::from(width - 24)));
-        }
+        let green_button = rectangle::Rectangle::new(
+            (
+                (width - 88 - BUTTON_SPACE) as usize,
+                (HEADER_SIZE / 2 - 8) as usize,
+            ),
+            (24, 16),
+            None,
+            Some(color),
+        );
+        canvas.draw(&green_button);
     }
 }

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -1,5 +1,4 @@
 use std::cmp::max;
-use std::io::Write;
 use std::sync::{Arc, Mutex};
 
 use andrew::shapes::rectangle;
@@ -418,7 +417,7 @@ impl Frame for BasicFrame {
 
             // draw the grey background
             {
-                let mut mmap = pool.mmap();
+                let mmap = pool.mmap();
                 {
                     let mut header_canvas = Canvas::new(
                         &mut mmap[0..HEADER_SIZE as usize * width as usize * 4],
@@ -463,9 +462,8 @@ impl Frame for BasicFrame {
 
                 // For each pixel in borders
                 {
-                    let mut writer = &mut mmap[HEADER_SIZE as usize * width as usize * 4..];
-                    for _ in 0..pxcount {
-                        let _ = writer.write(&[0x00, 0x00, 0x00, 0x00]);
+                    for b in &mut mmap[HEADER_SIZE as usize * width as usize * 4..] {
+                        *b = 0x00;
                     }
                 }
                 let _ = mmap.flush();

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -416,9 +416,9 @@ impl Frame for BasicFrame {
                 colors::INACTIVE_BORDER
             };
 
-            let mut mmap = pool.mmap().unwrap();
             // draw the grey background
             {
+                let mut mmap = pool.mmap();
                 {
                     let mut header_canvas = Canvas::new(
                         &mut mmap[0..HEADER_SIZE as usize * width as usize * 4],
@@ -462,12 +462,14 @@ impl Frame for BasicFrame {
                 }
 
                 // For each pixel in borders
-                let mut writer = &mut mmap[HEADER_SIZE as usize * width as usize * 4..];
-                for _ in 0..pxcount {
-                    let _ = writer.write(&[0x00, 0x00, 0x00, 0x00]);
+                {
+                    let mut writer = &mut mmap[HEADER_SIZE as usize * width as usize * 4..];
+                    for _ in 0..pxcount {
+                        let _ = writer.write(&[0x00, 0x00, 0x00, 0x00]);
+                    }
                 }
+                let _ = mmap.flush();
             }
-            let _ = mmap.flush();
 
             // Create the buffers
             // -> head-subsurface


### PR DESCRIPTION
I've done some work on moving the decoration drawing code to a new crate called andrew (the name is a play on 'drew' being the past tense of 'draw'). Currently the crate is quite basic with its only functionality being bresenham lines and bordered/rounded rectangles or squares. I hope to add some more geometric objects and effects before the 0.1 release, most important being circles, circular sectors, shadows and gradients. 

The current fork doesn't work yet as andrew isn't released but I can tell you that it looks the exact same as before. The main purpose of this pull request is so that the crate's api can be reviewed and reworked while its still in a non-release stage. I'll give a little explanation on the crates api so far.

The Draw trait which looks like this
```
pub trait Draw {
    fn draw(&self, canvas: &mut [u8], canvas_size: (usize, usize));
}
```
allows an object to be drawn to the screen. This trait has many benefits but one of the biggest I can think of is the ability to have whole decorations contained in one object. 

The crate is currently split into two modules, line and shape. The only public object that the line module contains at the moment is the Line struct that can be drawn with the syntax of
```
Line::new( pt1: (usize, usize), pt2: (usize, usize) ).draw(canvas: &mut [u8], canvas_size: (usize, usize))
```
this syntax will probably be changed in the future to support antialising.

The shape module currently only contains the rectangle submodule, which contains the main Rectangle struct as well a bitflag Sides struct with the flags of TOP, BOTTOM, LEFT, RIGHT, ALL. The api for drawing a rectangle looks like this
```
Rectangle {
    position of rectangle: (usize, usize),
    size of rectangle: (usize, usize),
    a option for a border with a width, color, side and roundness: Option<(usize, [u8; 4], Sides, Option<usize>)>,
    a option for a colored fill: Option<[u8; 4]>,
}
```
The Sides struct allows only parts of the rectangle to be bordered. Its worth mentioning that colors passed to andrew are automatically reversed (only once, so minuscule runtime cost) when on a little endian machine, this means that all colors that are passed are in the [A, R, G, B] format. 

I would like feedback on the api of the crate such as whether the drawing of objects should be done through a struct + trait or just functions and whether co-orientates and sizes should be stored as usizes or u32s like in the client-toolkit. I would also be happy to change the name to something more technical like BufDraw or something if you'd like :) 