### PR TITLE
Only destroy buffers when not in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- *Breaking* MemPool: MemPool now requires an implementation to be called when the pool becomes free
+- *Breaking* DoubleMemPool: DoubleMemPool now requires an implementation to be called when one of its pools becomes free
+- *Breaking* DoubleMemPool: `swap()` is removed as `pool()` will now automatically track and return any free pools avaliable or return None
 - Keyboard: add key repetition with 'map_keyboard_auto_with_repeat' and 'map_keyboard_rmlvo_with_repeat'
 - Window: add `init_with_decorations` to allow the use of server-side decorations
 

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, Mutex};
 
 use byteorder::{NativeEndian, WriteBytesExt};
 
-use sctk::reexports::client::protocol::wl_buffer::RequestsTrait as BufferRequests;
 use sctk::reexports::client::protocol::wl_compositor::RequestsTrait as CompositorRequests;
 use sctk::reexports::client::protocol::wl_display::RequestsTrait as DisplayRequests;
 use sctk::reexports::client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
@@ -165,7 +164,8 @@ fn main() {
     // DoubleMemPool::new() requires access to the wl_shm global, which represents
     // the capability of the server to use shared memory (SHM). All wayland servers
     // are required to support it.
-    let mut pools = DoubleMemPool::new(&env.shm).expect("Failed to create the memory pools.");
+    let mut pools =
+        DoubleMemPool::new(&env.shm, |_, _| {}).expect("Failed to create the memory pools.");
 
     /*
      * Event Loop preparation and running
@@ -369,9 +369,6 @@ fn redraw(
         4 * buf_x as i32, // stride: number of bytes between the start of two
         //   consecutive rows of pixels
         wl_shm::Format::Argb8888, // the pixel format we wrote in
-        |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
-            wl_buffer::Event::Release => buffer.destroy(),
-        },
     );
     surface.attach(Some(&new_buffer), 0, 0);
     surface.commit();

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -180,8 +180,6 @@ fn main() {
     // - the size of our contents
     let mut dimensions = image.dimensions();
 
-    let mut buffer = None;
-
     // if our shell does not need to ait for a configure event, we draw right away.
     //
     // Note that this is only the case for the old wl_shell protocol, which is now
@@ -252,20 +250,19 @@ fn main() {
             // at next iteration of the loop.
             // Draw the contents in the pool and retrieve the buffer
             match pools.pool() {
-                Some(pool) => redraw(
-                    pool,
-                    &mut buffer,
-                    window.surface(),
-                    dimensions,
-                    if resizing { None } else { Some(&image) },
-                ),
+                Some(pool) => {
+                    // We don't need to redraw or refresh anymore =)
+                    need_redraw = false;
+                    redraw(
+                        pool,
+                        &mut buffer,
+                        window.surface(),
+                        dimensions,
+                        if resizing { None } else { Some(&image) },
+                    )
+                }
                 None => {}
             }
-            // We commit our drawing surface, so that the server atomically applies
-            // all the changes we previously did.
-            window.surface().commit();
-            // We don't need to redraw or refresh anymore =)
-            need_redraw = false;
         }
 
         // These last two calls are necessary for the processing of wayland messages:

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -11,7 +11,7 @@ use byteorder::{NativeEndian, WriteBytesExt};
 use sctk::reexports::client::protocol::wl_compositor::RequestsTrait as CompositorRequests;
 use sctk::reexports::client::protocol::wl_display::RequestsTrait as DisplayRequests;
 use sctk::reexports::client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
-use sctk::reexports::client::protocol::{wl_buffer, wl_seat, wl_shm, wl_surface};
+use sctk::reexports::client::protocol::{wl_seat, wl_shm, wl_surface};
 use sctk::reexports::client::{Display, Proxy};
 use sctk::utils::{DoubleMemPool, MemPool};
 use sctk::window::{BasicFrame, Event as WEvent, State, Window};
@@ -193,7 +193,6 @@ fn main() {
         if let Some(pool) = pools.pool() {
             redraw(
                 pool,
-                &mut buffer,
                 window.surface(),
                 dimensions,
                 if resizing { None } else { Some(&image) },
@@ -255,7 +254,6 @@ fn main() {
                     need_redraw = false;
                     redraw(
                         pool,
-                        &mut buffer,
                         window.surface(),
                         dimensions,
                         if resizing { None } else { Some(&image) },
@@ -289,7 +287,6 @@ fn main() {
 // just draw black contents to not feel laggy.
 fn redraw(
     pool: &mut MemPool,
-    buffer: &mut Option<Proxy<wl_buffer::WlBuffer>>,
     surface: &Proxy<wl_surface::WlSurface>,
     (buf_x, buf_y): (u32, u32),
     base_image: Option<&image::ImageBuffer<image::Rgba<u8>, Vec<u8>>>,
@@ -369,5 +366,4 @@ fn redraw(
     );
     surface.attach(Some(&new_buffer), 0, 0);
     surface.commit();
-    *buffer = Some(new_buffer);
 }

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -14,7 +14,7 @@ use sctk::reexports::client::protocol::wl_compositor::RequestsTrait as Composito
 use sctk::reexports::client::protocol::wl_display::RequestsTrait as DisplayRequests;
 use sctk::reexports::client::protocol::wl_seat::RequestsTrait as SeatRequests;
 use sctk::reexports::client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
-use sctk::reexports::client::protocol::{wl_buffer, wl_seat, wl_shm, wl_surface};
+use sctk::reexports::client::protocol::{wl_seat, wl_shm, wl_surface};
 use sctk::reexports::client::{Display, Proxy};
 use sctk::utils::{DoubleMemPool, MemPool};
 use sctk::window::{BasicFrame, Event as WEvent, Window};
@@ -70,7 +70,6 @@ fn main() {
 
     let mut pools =
         DoubleMemPool::new(&env.shm, |_, _| {}).expect("Failed to create a memory pool !");
-    let mut buffer = None;
 
     /*
      * Keyboard initialization
@@ -133,7 +132,7 @@ fn main() {
     if !env.shell.needs_configure() {
         // initial draw to bootstrap on wl_shell
         if let Some(pool) = pools.pool() {
-            redraw(pool, &mut buffer, window.surface(), dimensions)
+            redraw(pool, window.surface(), dimensions)
         }
         window.refresh();
     }
@@ -153,7 +152,7 @@ fn main() {
                 println!("Window states: {:?}", states);
                 window.refresh();
                 if let Some(pool) = pools.pool() {
-                    redraw(pool, &mut buffer, window.surface(), dimensions)
+                    redraw(pool, window.surface(), dimensions)
                 }
             }
             None => {}
@@ -164,12 +163,7 @@ fn main() {
     }
 }
 
-fn redraw(
-    pool: &mut MemPool,
-    buffer: &mut Option<Proxy<wl_buffer::WlBuffer>>,
-    surface: &Proxy<wl_surface::WlSurface>,
-    (buf_x, buf_y): (u32, u32),
-) {
+fn redraw(pool: &mut MemPool, surface: &Proxy<wl_surface::WlSurface>, (buf_x, buf_y): (u32, u32)) {
     // resize the pool if relevant
     pool.resize((4 * buf_x * buf_y) as usize)
         .expect("Failed to resize the memory pool.");
@@ -197,5 +191,4 @@ fn redraw(
     );
     surface.attach(Some(&new_buffer), 0, 0);
     surface.commit();
-    *buffer = Some(new_buffer);
 }

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -10,7 +10,6 @@ use byteorder::{NativeEndian, WriteBytesExt};
 use sctk::keyboard::{
     map_keyboard_auto_with_repeat, Event as KbEvent, KeyRepeatEvent, KeyRepeatKind,
 };
-use sctk::reexports::client::protocol::wl_buffer::RequestsTrait as BufferRequests;
 use sctk::reexports::client::protocol::wl_compositor::RequestsTrait as CompositorRequests;
 use sctk::reexports::client::protocol::wl_display::RequestsTrait as DisplayRequests;
 use sctk::reexports::client::protocol::wl_seat::RequestsTrait as SeatRequests;
@@ -69,7 +68,8 @@ fn main() {
         },
     ).expect("Failed to create a window !");
 
-    let mut pools = DoubleMemPool::new(&env.shm).expect("Failed to create a memory pool !");
+    let mut pools =
+        DoubleMemPool::new(&env.shm, |_, _| {}).expect("Failed to create a memory pool !");
     let mut buffer = None;
 
     /*
@@ -194,9 +194,6 @@ fn redraw(
         buf_y as i32,
         4 * buf_x as i32,
         wl_shm::Format::Argb8888,
-        |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
-            wl_buffer::Event::Release => buffer.destroy(),
-        },
     );
     surface.attach(Some(&new_buffer), 0, 0);
     surface.commit();

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -16,7 +16,7 @@ use sctk::reexports::client::protocol::wl_compositor::RequestsTrait as Composito
 use sctk::reexports::client::protocol::wl_display::RequestsTrait as DisplayRequests;
 use sctk::reexports::client::protocol::wl_seat::RequestsTrait as SeatRequests;
 use sctk::reexports::client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
-use sctk::reexports::client::protocol::{wl_buffer, wl_seat, wl_shm, wl_surface};
+use sctk::reexports::client::protocol::{wl_seat, wl_shm, wl_surface};
 use sctk::reexports::client::{Display, Proxy};
 
 fn main() {
@@ -82,7 +82,6 @@ fn main() {
 
     let mut pools =
         DoubleMemPool::new(&env.shm, |_, _| {}).expect("Failed to create a memory pool !");
-    let mut buffer = None;
 
     let reader = Arc::new(Mutex::new(None::<ReadPipe>));
 
@@ -128,7 +127,7 @@ fn main() {
     if !env.shell.needs_configure() {
         // initial draw to bootstrap on wl_shell
         if let Some(pool) = pools.pool() {
-            redraw(pool, &mut buffer, window.surface(), dimensions)
+            redraw(pool, window.surface(), dimensions)
         }
         window.refresh();
     }
@@ -147,7 +146,7 @@ fn main() {
                 }
                 window.refresh();
                 if let Some(pool) = pools.pool() {
-                    redraw(pool, &mut buffer, window.surface(), dimensions)
+                    redraw(pool, window.surface(), dimensions)
                 }
             }
             None => {}
@@ -166,12 +165,7 @@ fn main() {
     }
 }
 
-fn redraw(
-    pool: &mut MemPool,
-    buffer: &mut Option<Proxy<wl_buffer::WlBuffer>>,
-    surface: &Proxy<wl_surface::WlSurface>,
-    (buf_x, buf_y): (u32, u32),
-) {
+fn redraw(pool: &mut MemPool, surface: &Proxy<wl_surface::WlSurface>, (buf_x, buf_y): (u32, u32)) {
     // resize the pool if relevant
     pool.resize((4 * buf_x * buf_y) as usize)
         .expect("Failed to resize the memory pool.");
@@ -194,5 +188,4 @@ fn redraw(
     );
     surface.attach(Some(&new_buffer), 0, 0);
     surface.commit();
-    *buffer = Some(new_buffer);
 }

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -127,8 +127,9 @@ fn main() {
 
     if !env.shell.needs_configure() {
         // initial draw to bootstrap on wl_shell
-        redraw(pools.pool(), &mut buffer, window.surface(), dimensions);
-        pools.swap();
+        if let Some(pool) = pools.pool() {
+            redraw(pool, &mut buffer, window.surface(), dimensions)
+        }
         window.refresh();
     }
 
@@ -145,8 +146,9 @@ fn main() {
                     dimensions = (w, h)
                 }
                 window.refresh();
-                redraw(pools.pool(), &mut buffer, window.surface(), dimensions);
-                pools.swap();
+                if let Some(pool) = pools.pool() {
+                    redraw(pool, &mut buffer, window.surface(), dimensions)
+                }
             }
             None => {}
         }
@@ -170,10 +172,6 @@ fn redraw(
     surface: &Proxy<wl_surface::WlSurface>,
     (buf_x, buf_y): (u32, u32),
 ) {
-    // destroy the old buffer if any
-    if let Some(b) = buffer.take() {
-        b.destroy();
-    }
     // resize the pool if relevant
     pool.resize((4 * buf_x * buf_y) as usize)
         .expect("Failed to resize the memory pool.");
@@ -187,14 +185,16 @@ fn redraw(
         let _ = writer.flush();
     }
     // get a buffer and attach it
-    let new_buffer =
-        pool.buffer(
-            0,
-            buf_x as i32,
-            buf_y as i32,
-            4 * buf_x as i32,
-            wl_shm::Format::Argb8888,
-        ).implement(|_, _| {});
+    let new_buffer = pool.buffer(
+        0,
+        buf_x as i32,
+        buf_y as i32,
+        4 * buf_x as i32,
+        wl_shm::Format::Argb8888,
+        |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
+            wl_buffer::Event::Release => buffer.destroy(),
+        },
+    );
     surface.attach(Some(&new_buffer), 0, 0);
     surface.commit();
     *buffer = Some(new_buffer);

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -12,7 +12,6 @@ use sctk::utils::{DoubleMemPool, MemPool};
 use sctk::window::{BasicFrame, Event as WEvent, Window};
 use sctk::Environment;
 
-use sctk::reexports::client::protocol::wl_buffer::RequestsTrait as BufferRequests;
 use sctk::reexports::client::protocol::wl_compositor::RequestsTrait as CompositorRequests;
 use sctk::reexports::client::protocol::wl_display::RequestsTrait as DisplayRequests;
 use sctk::reexports::client::protocol::wl_seat::RequestsTrait as SeatRequests;
@@ -81,7 +80,8 @@ fn main() {
 
     window.new_seat(&seat);
 
-    let mut pools = DoubleMemPool::new(&env.shm).expect("Failed to create a memory pool !");
+    let mut pools =
+        DoubleMemPool::new(&env.shm, |_, _| {}).expect("Failed to create a memory pool !");
     let mut buffer = None;
 
     let reader = Arc::new(Mutex::new(None::<ReadPipe>));
@@ -191,9 +191,6 @@ fn redraw(
         buf_y as i32,
         4 * buf_x as i32,
         wl_shm::Format::Argb8888,
-        |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
-            wl_buffer::Event::Release => buffer.destroy(),
-        },
     );
     surface.attach(Some(&new_buffer), 0, 0);
     surface.commit();

--- a/src/utils/mempool.rs
+++ b/src/utils/mempool.rs
@@ -18,6 +18,7 @@ use wayland_client::commons::Implementation;
 use wayland_client::protocol::{wl_buffer, wl_shm, wl_shm_pool};
 use wayland_client::Proxy;
 
+use wayland_client::protocol::wl_buffer::RequestsTrait;
 use wayland_client::protocol::wl_shm::RequestsTrait as ShmRequests;
 use wayland_client::protocol::wl_shm_pool::RequestsTrait as PoolRequests;
 
@@ -27,28 +28,55 @@ use wayland_client::protocol::wl_shm_pool::RequestsTrait as PoolRequests;
 /// use for conveniently implementing double-buffering in your
 /// apps.
 ///
-/// Just access the current drawing pool with the `pool()` method,
-/// and swap them using the `swap()` method between two frames.
+/// DoubleMemPool requires a implementation that is called when
+/// one of the two internal memory pools becomes free after None
+/// was returned from the `pool()` method.
 pub struct DoubleMemPool {
     pool1: MemPool,
     pool2: MemPool,
+    free: Arc<Mutex<bool>>,
 }
 
 impl DoubleMemPool {
     /// Create a double memory pool
-    pub fn new(shm: &Proxy<wl_shm::WlShm>) -> io::Result<DoubleMemPool> {
-        let pool1 = MemPool::new(shm)?;
-        let pool2 = MemPool::new(shm)?;
-        Ok(DoubleMemPool { pool1, pool2 })
+    pub fn new<Impl>(shm: &Proxy<wl_shm::WlShm>, implementation: Impl) -> io::Result<DoubleMemPool>
+    where
+        Impl: Implementation<(), ()> + Send,
+    {
+        let free = Arc::new(Mutex::new(true));
+        let implementation = Arc::new(Mutex::new(implementation));
+        let my_free = free.clone();
+        let my_implementation = implementation.clone();
+        let pool1 = MemPool::new(shm, move |_, _| {
+            let mut my_free = my_free.lock().unwrap();
+            if !*my_free {
+                my_implementation.lock().unwrap().receive((), ());
+                *my_free = true
+            }
+        })?;
+        let my_free = free.clone();
+        let my_implementation = implementation.clone();
+        let pool2 = MemPool::new(shm, move |_, _| {
+            let mut my_free = my_free.lock().unwrap();
+            if !*my_free {
+                my_implementation.lock().unwrap().receive((), ());
+                *my_free = true
+            }
+        })?;
+        Ok(DoubleMemPool { pool1, pool2, free })
     }
 
-    /// Access the current drawing pool
+    /// This method checks both its internal memory pools and returns
+    /// one if that pool does not contain any buffers that are still in use
+    /// by the server. If both the memory pools contain buffers that are currently
+    /// in use by the server None will be returned.
     pub fn pool(&mut self) -> Option<&mut MemPool> {
         if !self.pool1.is_used() {
             Some(&mut self.pool1)
         } else if !self.pool2.is_used() {
             Some(&mut self.pool2)
         } else {
+            *self.free.lock().unwrap() = false;
             None
         }
     }
@@ -58,16 +86,30 @@ impl DoubleMemPool {
 ///
 /// This wrapper handles for you the creation of the shared memory file and its synchronisation
 /// with the protocol.
+///
+/// Mempool internally tracks the lifetime of all buffers created from it and to ensure that
+/// this buffer count is correct all buffers must be attached to a surface. Once a buffer is attached to
+/// a surface it must be immediately commited to that surface before another buffer is attached.
+///
+/// Mempool will also handle the destruction of buffers and as such the `destroy()` method should not
+/// be used on buffers created from Mempool.
+///
+/// Mempool requires an implementation that will be called when the pool becomes free, this
+/// happens when all the pools buffers are released by the server.
 pub struct MemPool {
     file: File,
     len: usize,
     pool: Proxy<wl_shm_pool::WlShmPool>,
     buffer_count: Arc<Mutex<u32>>,
+    implementation: Arc<Mutex<Implementation<(), ()> + Send>>,
 }
 
 impl MemPool {
     /// Create a new memory pool associated with given shm
-    pub fn new(shm: &Proxy<wl_shm::WlShm>) -> io::Result<MemPool> {
+    pub fn new<Impl>(shm: &Proxy<wl_shm::WlShm>, implementation: Impl) -> io::Result<MemPool>
+    where
+        Impl: Implementation<(), ()> + Send,
+    {
         let mem_fd = create_shm_fd()?;
         let mem_file = unsafe { File::from_raw_fd(mem_fd) };
         mem_file.set_len(128)?;
@@ -82,6 +124,7 @@ impl MemPool {
             len: 128,
             pool: pool,
             buffer_count: Arc::new(Mutex::new(0)),
+            implementation: Arc::new(Mutex::new(implementation)),
         })
     }
 
@@ -117,32 +160,32 @@ impl MemPool {
     /// - `format`: the encoding format of the pixels. Using a format that was not
     ///   advertized to the `wl_shm` global by the server is a protocol error and will
     ///   terminate your connexion
-    pub fn buffer<Impl>(
+    pub fn buffer(
         &self,
         offset: i32,
         width: i32,
         height: i32,
         stride: i32,
         format: wl_shm::Format,
-        implementation: Impl,
-    ) -> Proxy<wl_buffer::WlBuffer>
-    where
-        Impl: Implementation<Proxy<wl_buffer::WlBuffer>, wl_buffer::Event> + Send,
-    {
-        let implementation = Arc::new(Mutex::new(implementation));
+    ) -> Proxy<wl_buffer::WlBuffer> {
         *self.buffer_count.lock().unwrap() += 1;
         let my_buffer_count = self.buffer_count.clone();
+        let my_implementation = self.implementation.clone();
         self.pool
             .create_buffer(offset, width, height, stride, format)
             .unwrap()
-            .implement(move |event, buffer| {
-                match event {
+            .implement(
+                move |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
                     wl_buffer::Event::Release => {
-                        *my_buffer_count.lock().unwrap() -= 1;
+                        buffer.destroy();
+                        let mut my_buffer_count = my_buffer_count.lock().unwrap();
+                        *my_buffer_count -= 1;
+                        if *my_buffer_count == 0 {
+                            my_implementation.lock().unwrap().receive((), ());
+                        }
                     }
-                }
-                implementation.lock().unwrap().receive(event, buffer);
-            })
+                },
+            )
     }
 
     /// Retuns true if the pool contains buffers that are currently in use by the server otherwise it returns

--- a/src/utils/mempool.rs
+++ b/src/utils/mempool.rs
@@ -94,6 +94,9 @@ impl DoubleMemPool {
 /// Mempool will also handle the destruction of buffers and as such the `destroy()` method should not
 /// be used on buffers created from Mempool.
 ///
+/// Overwriting the contents of the memory pool before it is completely freed may cause graphical
+/// glitches due to the possible corruption of data while the compositor is reading it.
+///
 /// Mempool requires an implementation that will be called when the pool becomes free, this
 /// happens when all the pools buffers are released by the server.
 pub struct MemPool {

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -245,6 +245,8 @@ impl Frame for BasicFrame {
             maximized: Mutex::new(false),
         });
         let my_inner = inner.clone();
+        // Send a Refresh request on callback from DoubleMemPool as it will be fired when
+        // None was previously returned from `pool()` and the draw was postponed
         let pools = DoubleMemPool::new(&shm, move |_, _| {
             my_inner
                 .implem

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -393,7 +393,7 @@ impl Frame for BasicFrame {
             return;
         }
         let (width, height) = *(self.inner.size.lock().unwrap());
-        let swappable = { *self.swappable.lock().unwrap() };
+        let swappable = *self.swappable.lock().unwrap();
         // destroy old inactive buffers
         if !swappable {
             for b in self.inactive_buffers.drain(..) {

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -479,7 +479,8 @@ impl Frame for BasicFrame {
             // Create the buffers
             // -> head-subsurface
             let my_buffers = self.buffers.clone();
-            let my_current_pool = current_pool.clone();
+            let my_current_pool = self.current_pool.clone();
+            let my_pool = current_pool.clone();
             let my_pending_swap = self.pending_swap.clone();
             let my_pools = self.pools.clone();
             let buffer =
@@ -493,14 +494,12 @@ impl Frame for BasicFrame {
                     move |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
                         wl_buffer::Event::Release => {
                             buffer.destroy();
-                            my_buffers
-                                .lock()
-                                .unwrap()
-                                .get_mut(my_current_pool)
-                                .unwrap()
-                                .pop();
-                            if *my_pending_swap.lock().unwrap() {
+                            my_buffers.lock().unwrap().get_mut(my_pool).unwrap().pop();
+                            if *my_pending_swap.lock().unwrap()
+                                && my_buffers.lock().unwrap().get(my_pool).unwrap().len() == 0
+                            {
                                 my_pools.lock().unwrap().swap();
+                                *my_current_pool.lock().unwrap() = (my_pool + 1 % 2 + 2) % 2;
                                 *my_pending_swap.lock().unwrap() = false;
                             }
                         }
@@ -529,7 +528,8 @@ impl Frame for BasicFrame {
 
             // -> top-subsurface
             let my_buffers = self.buffers.clone();
-            let my_current_pool = current_pool.clone();
+            let my_current_pool = self.current_pool.clone();
+            let my_pool = current_pool.clone();
             let my_pending_swap = self.pending_swap.clone();
             let my_pools = self.pools.clone();
             let buffer =
@@ -543,14 +543,12 @@ impl Frame for BasicFrame {
                     move |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
                         wl_buffer::Event::Release => {
                             buffer.destroy();
-                            my_buffers
-                                .lock()
-                                .unwrap()
-                                .get_mut(my_current_pool)
-                                .unwrap()
-                                .pop();
-                            if *my_pending_swap.lock().unwrap() {
+                            my_buffers.lock().unwrap().get_mut(my_pool).unwrap().pop();
+                            if *my_pending_swap.lock().unwrap()
+                                && my_buffers.lock().unwrap().get(my_pool).unwrap().len() == 0
+                            {
                                 my_pools.lock().unwrap().swap();
+                                *my_current_pool.lock().unwrap() = (my_pool + 1 % 2 + 2) % 2;
                                 *my_pending_swap.lock().unwrap() = false;
                             }
                         }
@@ -583,7 +581,8 @@ impl Frame for BasicFrame {
 
             // -> bottom-subsurface
             let my_buffers = self.buffers.clone();
-            let my_current_pool = current_pool.clone();
+            let my_current_pool = self.current_pool.clone();
+            let my_pool = current_pool.clone();
             let my_pending_swap = self.pending_swap.clone();
             let my_pools = self.pools.clone();
             let buffer =
@@ -597,14 +596,12 @@ impl Frame for BasicFrame {
                     move |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
                         wl_buffer::Event::Release => {
                             buffer.destroy();
-                            my_buffers
-                                .lock()
-                                .unwrap()
-                                .get_mut(my_current_pool)
-                                .unwrap()
-                                .pop();
-                            if *my_pending_swap.lock().unwrap() {
+                            my_buffers.lock().unwrap().get_mut(my_pool).unwrap().pop();
+                            if *my_pending_swap.lock().unwrap()
+                                && my_buffers.lock().unwrap().get(my_pool).unwrap().len() == 0
+                            {
                                 my_pools.lock().unwrap().swap();
+                                *my_current_pool.lock().unwrap() = (my_pool + 1 % 2 + 2) % 2;
                                 *my_pending_swap.lock().unwrap() = false;
                             }
                         }
@@ -636,7 +633,8 @@ impl Frame for BasicFrame {
 
             // -> left-subsurface
             let my_buffers = self.buffers.clone();
-            let my_current_pool = current_pool.clone();
+            let my_current_pool = self.current_pool.clone();
+            let my_pool = current_pool.clone();
             let my_pending_swap = self.pending_swap.clone();
             let my_pools = self.pools.clone();
             let buffer =
@@ -650,14 +648,12 @@ impl Frame for BasicFrame {
                     move |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
                         wl_buffer::Event::Release => {
                             buffer.destroy();
-                            my_buffers
-                                .lock()
-                                .unwrap()
-                                .get_mut(my_current_pool)
-                                .unwrap()
-                                .pop();
-                            if *my_pending_swap.lock().unwrap() {
+                            my_buffers.lock().unwrap().get_mut(my_pool).unwrap().pop();
+                            if *my_pending_swap.lock().unwrap()
+                                && my_buffers.lock().unwrap().get(my_pool).unwrap().len() == 0
+                            {
                                 my_pools.lock().unwrap().swap();
+                                *my_current_pool.lock().unwrap() = (my_pool + 1 % 2 + 2) % 2;
                                 *my_pending_swap.lock().unwrap() = false;
                             }
                         }
@@ -689,7 +685,8 @@ impl Frame for BasicFrame {
 
             // -> right-subsurface
             let my_buffers = self.buffers.clone();
-            let my_current_pool = current_pool.clone();
+            let my_current_pool = self.current_pool.clone();
+            let my_pool = current_pool.clone();
             let my_pending_swap = self.pending_swap.clone();
             let my_pools = self.pools.clone();
             let buffer =
@@ -703,14 +700,12 @@ impl Frame for BasicFrame {
                     move |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
                         wl_buffer::Event::Release => {
                             buffer.destroy();
-                            my_buffers
-                                .lock()
-                                .unwrap()
-                                .get_mut(my_current_pool)
-                                .unwrap()
-                                .pop();
-                            if *my_pending_swap.lock().unwrap() {
+                            my_buffers.lock().unwrap().get_mut(my_pool).unwrap().pop();
+                            if *my_pending_swap.lock().unwrap()
+                                && my_buffers.lock().unwrap().get(my_pool).unwrap().len() == 0
+                            {
                                 my_pools.lock().unwrap().swap();
+                                *my_current_pool.lock().unwrap() = (my_pool + 1 % 2 + 2) % 2;
                                 *my_pending_swap.lock().unwrap() = false;
                             }
                         }


### PR DESCRIPTION
This pull request makes it so that buffers aren't destroyed when they are in use by the server. Inactive buffer proxies (buffers not in the current memory pool) are stored in a vec so that they can destroyed if another redraw is called before the buffers can be swapped. All active buffers must be released before a mempool swap can occur. Please note that this code is based on my understanding that release events will only be sent to buffers in the current memory pool.