### PR TITLE
Shm file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ nix = "0.11"
 dlib = "0.4"
 lazy_static = "1"
 memmap = "0.6"
-tempfile = "3.0"
+rand = "0.5"
 wayland-commons = { version = "0.20.11" }
 wayland-client = { version = "0.20.11", features = ["cursor"] }
 wayland-protocols = { version = "0.20.11", features = ["client", "unstable_protocols"] }

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -1,7 +1,6 @@
 extern crate byteorder;
 extern crate image;
 extern crate smithay_client_toolkit as sctk;
-extern crate tempfile;
 
 use std::cell::Cell;
 use std::env;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate dlib;
 extern crate lazy_static;
 extern crate memmap;
 extern crate nix;
-extern crate tempfile;
+extern crate rand;
 #[doc(hidden)]
 pub extern crate wayland_client;
 #[doc(hidden)]

--- a/src/utils/mempool.rs
+++ b/src/utils/mempool.rs
@@ -1,8 +1,10 @@
 use nix;
+use nix::errno::Errno;
 use nix::fcntl;
 use nix::sys::memfd;
 use nix::sys::mman;
 use nix::sys::stat;
+use std::ffi::CStr;
 use std::fs::File;
 use std::io;
 use std::os::unix::io::FromRawFd;
@@ -69,7 +71,7 @@ impl MemPool {
             rng.gen_range(0, ::std::u32::MAX)
         );
         let mem_fd = match memfd::memfd_create(
-            ::std::ffi::CStr::from_bytes_with_nul(b"smithay-client-toolkit\0").unwrap(),
+            CStr::from_bytes_with_nul(b"smithay-client-toolkit\0").unwrap(),
             memfd::MemFdCreateFlag::MFD_CLOEXEC,
         ) {
             Ok(fd) => fd,
@@ -86,7 +88,7 @@ impl MemPool {
                         mman::shm_unlink(mem_file_handle.as_str()).unwrap();
                         break fd;
                     }
-                    Err(nix::Error::Sys(nix::errno::Errno::EEXIST)) => {
+                    Err(nix::Error::Sys(Errno::EEXIST)) => {
                         // If a file with that handle exists then change the handle
                         mem_file_handle = format!(
                             "/smithay-client-toolkit-{}",
@@ -94,7 +96,7 @@ impl MemPool {
                         );
                         continue;
                     }
-                    Err(nix::Error::Sys(nix::errno::Errno::EINTR)) => continue,
+                    Err(nix::Error::Sys(Errno::EINTR)) => continue,
                     Err(err) => panic!(err),
                 }
             },

--- a/src/utils/mempool.rs
+++ b/src/utils/mempool.rs
@@ -155,8 +155,9 @@ fn create_shm_fd() -> io::Result<RawFd> {
         ) {
             Ok(fd) => return Ok(fd),
             Err(nix::Error::Sys(Errno::EINTR)) => continue,
+            Err(nix::Error::Sys(Errno::ENOSYS)) => break,
             Err(nix::Error::Sys(errno)) => return Err(io::Error::from(errno)),
-            Err(_) => break,
+            Err(err) => panic!(err),
         }
     }
 

--- a/src/utils/mempool.rs
+++ b/src/utils/mempool.rs
@@ -8,6 +8,7 @@ use std::ffi::CStr;
 use std::fs::File;
 use std::io;
 use std::os::unix::io::FromRawFd;
+use std::os::unix::io::RawFd;
 
 use rand::prelude::*;
 
@@ -49,12 +50,9 @@ impl DoubleMemPool {
     }
 }
 
-/// A wrapper handling an SHM memory pool backed by a temporary file
+/// A wrapper handling an SHM memory pool backed by a shared memory file
 ///
-/// On Linux, temporary files like this are never mapped on the disk, and
-/// as such stay in RAM, allowing for an efficient memory sharing.
-///
-/// This wrapper handles for you the creation of the tempfile and its synchronisation
+/// This wrapper handles for you the creation of the shared memory file and its synchronisation
 /// with the protocol.
 pub struct MemPool {
     file: File,
@@ -65,44 +63,8 @@ pub struct MemPool {
 impl MemPool {
     /// Create a new memory pool associated with given shm
     pub fn new(shm: &Proxy<wl_shm::WlShm>) -> io::Result<MemPool> {
-        let mut rng = thread_rng();
-        let mut mem_file_handle = format!(
-            "/smithay-client-toolkit-{}",
-            rng.gen_range(0, ::std::u32::MAX)
-        );
-        let mem_fd = match memfd::memfd_create(
-            CStr::from_bytes_with_nul(b"smithay-client-toolkit\0").unwrap(),
-            memfd::MemFdCreateFlag::MFD_CLOEXEC,
-        ) {
-            Ok(fd) => fd,
-            Err(_) => loop {
-                match mman::shm_open(
-                    mem_file_handle.as_str(),
-                    fcntl::OFlag::O_CREAT
-                        | fcntl::OFlag::O_EXCL
-                        | fcntl::OFlag::O_RDWR
-                        | fcntl::OFlag::O_CLOEXEC,
-                    stat::Mode::S_IRUSR | stat::Mode::S_IWUSR,
-                ) {
-                    Ok(fd) => {
-                        mman::shm_unlink(mem_file_handle.as_str()).unwrap();
-                        break fd;
-                    }
-                    Err(nix::Error::Sys(Errno::EEXIST)) => {
-                        // If a file with that handle exists then change the handle
-                        mem_file_handle = format!(
-                            "/smithay-client-toolkit-{}",
-                            rng.gen_range(0, ::std::u32::MAX)
-                        );
-                        continue;
-                    }
-                    Err(nix::Error::Sys(Errno::EINTR)) => continue,
-                    Err(err) => panic!(err),
-                }
-            },
-        };
+        let mem_fd = create_shm_fd()?;
         let mem_file = unsafe { File::from_raw_fd(mem_fd) };
-
         mem_file.set_len(128)?;
 
         let pool = shm
@@ -181,5 +143,54 @@ impl io::Write for MemPool {
 impl io::Seek for MemPool {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
         io::Seek::seek(&mut self.file, pos)
+    }
+}
+
+fn create_shm_fd() -> io::Result<RawFd> {
+    let mut rng = thread_rng();
+
+    loop {
+        match memfd::memfd_create(
+            CStr::from_bytes_with_nul(b"smithay-client-toolkit\0").unwrap(),
+            memfd::MemFdCreateFlag::MFD_CLOEXEC,
+        ) {
+            Ok(fd) => break Ok(fd),
+            Err(nix::Error::Sys(Errno::EINTR)) => continue,
+            Err(nix::Error::Sys(errno)) => break Err(io::Error::from(errno)),
+            Err(_) => {
+                // Fallback to using shm_open
+                let mut mem_file_handle = format!(
+                    "/smithay-client-toolkit-{}",
+                    rng.gen_range(0, ::std::u32::MAX)
+                );
+                break loop {
+                    match mman::shm_open(
+                        mem_file_handle.as_str(),
+                        fcntl::OFlag::O_CREAT
+                            | fcntl::OFlag::O_EXCL
+                            | fcntl::OFlag::O_RDWR
+                            | fcntl::OFlag::O_CLOEXEC,
+                        stat::Mode::S_IRUSR | stat::Mode::S_IWUSR,
+                    ) {
+                        Ok(fd) => match mman::shm_unlink(mem_file_handle.as_str()) {
+                            Ok(_) => break Ok(fd),
+                            Err(nix::Error::Sys(errno)) => break Err(io::Error::from(errno)),
+                            Err(err) => panic!(err),
+                        },
+                        Err(nix::Error::Sys(Errno::EEXIST)) => {
+                            // If a file with that handle exists then change the handle
+                            mem_file_handle = format!(
+                                "/smithay-client-toolkit-{}",
+                                rng.gen_range(0, ::std::u32::MAX)
+                            );
+                            continue;
+                        }
+                        Err(nix::Error::Sys(Errno::EINTR)) => continue,
+                        Err(nix::Error::Sys(errno)) => break Err(io::Error::from(errno)),
+                        Err(err) => panic!(err),
+                    }
+                };
+            }
+        };
     }
 }

--- a/src/utils/mempool.rs
+++ b/src/utils/mempool.rs
@@ -157,7 +157,7 @@ fn create_shm_fd() -> io::Result<RawFd> {
             Err(nix::Error::Sys(Errno::EINTR)) => continue,
             Err(nix::Error::Sys(Errno::ENOSYS)) => break,
             Err(nix::Error::Sys(errno)) => return Err(io::Error::from(errno)),
-            Err(err) => panic!(err),
+            Err(err) => unreachable!(err),
         }
     }
 
@@ -195,7 +195,7 @@ fn create_shm_fd() -> io::Result<RawFd> {
             }
             Err(nix::Error::Sys(Errno::EINTR)) => continue,
             Err(nix::Error::Sys(errno)) => return Err(io::Error::from(errno)),
-            Err(err) => panic!(err),
+            Err(err) => unreachable!(err),
         }
     }
 }


### PR DESCRIPTION
After inspection of the GTK wayland backend I'm convinced that the memory file used by wayland for pixel buffering should be an anonymous shared memory file and not a temp file, [relevant GTK code](https://gitlab.gnome.org/GNOME/gtk/blob/master/gdk/wayland/gdkdisplay-wayland.c#L1229). The code I wrote uses memfd by default which is available on new linux kernel versions and shm_open as a fallback for older kernels. I think this is the standard way to implement the shared file for wayland.