### PR TITLE
End key repetition when keyboard loses focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Keyboard: end key repetition when the keyboard loses focus
+
 ## 0.3.0 -- 2018-08-17
 
 - Window: the minimum window width is set to 2 pixels to circumvent a bug in mutter - https://gitlab.gnome.org/GNOME/mutter/issues/259

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -623,6 +623,10 @@ where
                     );
                 }
                 wl_keyboard::Event::Leave { serial, surface } => {
+                    if key_held.is_some() {
+                        kill_chan.lock().unwrap().0.send(()).unwrap();
+                        key_held = None;
+                    }
                     event_impl.receive(Event::Leave { serial, surface }, proxy);
                 }
                 wl_keyboard::Event::Key {


### PR DESCRIPTION
This PR ends key repetition when the keyboard loses focus as the release event will never be sent in these cases. When the keyboard loses focus it just ends the key repetition and doesn't send a release event as the key isn't actually released (in the physical sense) I can change this behavior if you want. 