### PR TITLE
Upgrade to wayland-rs 0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **[Breaking]** Upgrade to wayland-rs 0.21
 - Keyboard: end key repetition when the keyboard loses focus
 
 ## 0.3.0 -- 2018-08-17

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ dlib = "0.4"
 lazy_static = "1"
 memmap = "0.6"
 rand = "0.5"
-wayland-commons = { version = "0.20.11" }
-wayland-client = { version = "0.20.11", features = ["cursor"] }
-wayland-protocols = { version = "0.20.11", features = ["client", "unstable_protocols"] }
+wayland-commons = { version = "0.21" }
+wayland-client = { version = "0.21", features = ["cursor"] }
+wayland-protocols = { version = "0.21", features = ["native_client", "unstable_protocols"] }
 
 [dev-dependencies]
 image = "0.19"
-wayland-client = { version = "0.20.11", features = ["dlopen"] }
+wayland-client = { version = "0.21", features = ["dlopen"] }
 byteorder = "1.0"

--- a/examples/compositor_info.rs
+++ b/examples/compositor_info.rs
@@ -3,15 +3,12 @@ extern crate smithay_client_toolkit as sctk;
 use sctk::reexports::client::Display;
 use sctk::{Environment, Shell};
 
-use sctk::reexports::client::protocol::wl_display::RequestsTrait as DisplayRequests;
-
 // This is a small program that queries the compositor for
 // various information and prints them on the console before exiting.
 
 fn main() {
     let (display, mut event_queue) = Display::connect_to_env().unwrap();
-    let env =
-        Environment::from_registry(display.get_registry().unwrap(), &mut event_queue).unwrap();
+    let env = Environment::from_display(&*display, &mut event_queue).unwrap();
 
     println!("== Smithay's compositor info tool ==\n");
 

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -39,22 +39,21 @@ fn main() {
     let image = image.to_rgba();
 
     /*
-     * Initalize the wayland connexion
+     * Initalize the wayland connection
      */
     let (display, mut event_queue) =
         Display::connect_to_env().expect("Failed to connect to the wayland server.");
 
-    // All request method of wayland objects return a result, as wayland-client
+    // All request methods of wayland objects return a result, as wayland-client
     // returns an error if you try to send a message on an object that has already
-    // been destroyed by a previous message. We know our display has not been
-    // destroyed, so we unwrap().
-
-    // The Environment takes a registry and a mutable borrow of the wayland event
+    // been destroyed by a previous message.
+    //
+    // The Environment takes a proxy to the display and a mutable borrow of the wayland event
     // queue. It uses the event queue internally to exchange messages with the server
     // to process the registry event.
-    // Like all manipulation of the event loop, it can fail (if the connexion is
+    // Like all manipulation of the event loop, it can fail (if the connection is
     // unexpectedly lost), and thus returns a result. This failing would prevent
-    // us to continue though, so we unrap().
+    // us to continue though, so we unwrap().
     let env = Environment::from_display(&*display, &mut event_queue).unwrap();
 
     // Use the compositor global to create a new surface

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -102,7 +102,7 @@ fn main() {
         &env,               // the environment containing the wayland globals
         surface,            // the wl_surface that serves as the basis of this window
         image.dimensions(), // the initial internal dimensions of the window
-        move |_, evt| {
+        move |evt| {
             // This is the closure that process the Window events.
             // There are 3 possible events:
             // - Close: the user requested the window to be closed, we'll then quit
@@ -149,7 +149,7 @@ fn main() {
     // Thus, we just automatically bind the first seat we find.
     let seat = env
         .manager
-        .instantiate_auto(|seat| seat.implement(move |_, _| {}, ()))
+        .instantiate_auto(|seat| seat.implement(|_, _| {}, ()))
         .unwrap();
     // And advertize it to the Window so it knows of it and can process the
     // required pointer events.
@@ -163,7 +163,7 @@ fn main() {
     // the capability of the server to use shared memory (SHM). All wayland servers
     // are required to support it.
     let mut pools =
-        DoubleMemPool::new(&env.shm, |_, _| {}).expect("Failed to create the memory pools.");
+        DoubleMemPool::new(&env.shm, || {}).expect("Failed to create the memory pools.");
 
     /*
      * Event Loop preparation and running

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -72,7 +72,7 @@ fn main() {
     let _keyboard = map_keyboard_auto_with_repeat(
         &seat,
         KeyRepeatKind::System,
-        move |_, event: KbEvent| match event {
+        move |event: KbEvent, _| match event {
             KbEvent::Enter {
                 modifiers, keysyms, ..
             } => {
@@ -105,7 +105,7 @@ fn main() {
                     );
             }
         },
-        move |_, repeat_event: KeyRepeatEvent| {
+        move |repeat_event: KeyRepeatEvent, _| {
             println!("Repeated key {:x}.", repeat_event.keysym);
             println!(" -> Modifers are {:?}", repeat_event.modifiers);
             if let Some(txt) = repeat_event.utf8 {

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -40,24 +40,22 @@ fn main() {
     let next_action = Arc::new(Mutex::new(None::<WEvent>));
 
     let waction = next_action.clone();
-    let mut window =
-        Window::<BasicFrame>::init_from_env(&env, surface, dimensions, move |_, evt| {
-            let mut next_action = waction.lock().unwrap();
-            // Keep last event in priority order : Close > Configure > Refresh
-            let replace = match (&evt, &*next_action) {
-                (_, &None)
-                | (_, &Some(WEvent::Refresh))
-                | (&WEvent::Configure { .. }, &Some(WEvent::Configure { .. }))
-                | (&WEvent::Close, _) => true,
-                _ => false,
-            };
-            if replace {
-                *next_action = Some(evt);
-            }
-        }).expect("Failed to create a window !");
+    let mut window = Window::<BasicFrame>::init_from_env(&env, surface, dimensions, move |evt| {
+        let mut next_action = waction.lock().unwrap();
+        // Keep last event in priority order : Close > Configure > Refresh
+        let replace = match (&evt, &*next_action) {
+            (_, &None)
+            | (_, &Some(WEvent::Refresh))
+            | (&WEvent::Configure { .. }, &Some(WEvent::Configure { .. }))
+            | (&WEvent::Close, _) => true,
+            _ => false,
+        };
+        if replace {
+            *next_action = Some(evt);
+        }
+    }).expect("Failed to create a window !");
 
-    let mut pools =
-        DoubleMemPool::new(&env.shm, |_, _| {}).expect("Failed to create a memory pool !");
+    let mut pools = DoubleMemPool::new(&env.shm, || {}).expect("Failed to create a memory pool !");
 
     /*
      * Keyboard initialization

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -67,7 +67,7 @@ fn main() {
     let reader = Arc::new(Mutex::new(None::<ReadPipe>));
 
     let reader2 = reader.clone();
-    map_keyboard_auto(&seat, move |_, event: KbEvent| {
+    map_keyboard_auto(&seat, move |event: KbEvent, _| {
         match event {
             KbEvent::Key {
                 state,

--- a/src/data_device/data_offer.rs
+++ b/src/data_device/data_offer.rs
@@ -31,21 +31,24 @@ impl DataOffer {
             serial: 0,
         }));
         let inner2 = inner.clone();
-        let offer = offer.implement(move |event, _: Proxy<_>| {
-            use self::wl_data_offer::Event;
-            let mut inner = inner2.lock().unwrap();
-            match event {
-                Event::Offer { mime_type } => {
-                    inner.mime_types.push(mime_type);
+        let offer = offer.implement(
+            move |event, _: Proxy<_>| {
+                use self::wl_data_offer::Event;
+                let mut inner = inner2.lock().unwrap();
+                match event {
+                    Event::Offer { mime_type } => {
+                        inner.mime_types.push(mime_type);
+                    }
+                    Event::SourceActions { source_actions } => {
+                        inner.actions = DndAction::from_bits_truncate(source_actions);
+                    }
+                    Event::Action { dnd_action } => {
+                        inner.current_action = DndAction::from_bits_truncate(dnd_action);
+                    }
                 }
-                Event::SourceActions { source_actions } => {
-                    inner.actions = DndAction::from_bits_truncate(source_actions);
-                }
-                Event::Action { dnd_action } => {
-                    inner.current_action = DndAction::from_bits_truncate(dnd_action);
-                }
-            }
-        });
+            },
+            (),
+        );
 
         DataOffer { offer, inner }
     }

--- a/src/data_device/data_offer.rs
+++ b/src/data_device/data_offer.rs
@@ -32,7 +32,7 @@ impl DataOffer {
         }));
         let inner2 = inner.clone();
         let offer = offer.implement(
-            move |event, _: Proxy<_>| {
+            move |event, _| {
                 use self::wl_data_offer::Event;
                 let mut inner = inner2.lock().unwrap();
                 match event {

--- a/src/data_device/data_source.rs
+++ b/src/data_device/data_source.rs
@@ -80,10 +80,10 @@ pub enum DataSourceEvent {
 
 fn data_source_impl<Impl>(
     evt: wl_data_source::Event,
-    source: &Proxy<wl_data_source::WlDataSource>,
+    source: Proxy<wl_data_source::WlDataSource>,
     implem: &mut Impl,
 ) where
-    Impl: FnMut((), DataSourceEvent),
+    Impl: FnMut(DataSourceEvent),
 {
     use self::wl_data_source::Event;
     let event = match evt {
@@ -105,7 +105,7 @@ fn data_source_impl<Impl>(
             DataSourceEvent::Finished
         }
     };
-    implem((), event);
+    implem(event);
 }
 
 impl DataSource {
@@ -119,12 +119,12 @@ impl DataSource {
         mut implem: Impl,
     ) -> DataSource
     where
-        Impl: FnMut((), DataSourceEvent) + Send + 'static,
+        Impl: FnMut(DataSourceEvent) + Send + 'static,
     {
         let source =
             mgr.create_data_source(|source| {
                 source.implement(
-                    move |evt, source: Proxy<_>| data_source_impl(evt, &source, &mut implem),
+                    move |evt, source: Proxy<_>| data_source_impl(evt, source, &mut implem),
                     (),
                 )
             }).expect("Provided a dead data device manager to create a data source.");
@@ -149,12 +149,12 @@ impl DataSource {
         token: &QueueToken,
     ) -> DataSource
     where
-        Impl: FnMut((), DataSourceEvent) + 'static,
+        Impl: FnMut(DataSourceEvent) + 'static,
     {
         let source =
             mgr.create_data_source(|source| {
                 source.implement_nonsend(
-                    move |evt, source: Proxy<_>| data_source_impl(evt, &source, &mut implem),
+                    move |evt, source: Proxy<_>| data_source_impl(evt, source, &mut implem),
                     (),
                     token,
                 )

--- a/src/data_device/data_source.rs
+++ b/src/data_device/data_source.rs
@@ -112,7 +112,7 @@ impl DataSource {
     /// Create a new data source
     ///
     /// You'll then need to provide it to a data device to send it
-    /// either wia selection (aka copy/paste) or via a drag and drop.
+    /// either via selection (aka copy/paste) or via a drag and drop.
     pub fn new<Impl>(
         mgr: &Proxy<wl_data_device_manager::WlDataDeviceManager>,
         mime_types: &[&str],

--- a/src/env.rs
+++ b/src/env.rs
@@ -90,7 +90,7 @@ impl Environment {
         mut cb: Impl,
     ) -> io::Result<Environment>
     where
-        Impl: FnMut(Proxy<wl_registry::WlRegistry>, GlobalEvent) + Send + 'static,
+        Impl: FnMut(GlobalEvent, Proxy<wl_registry::WlRegistry>) + Send + 'static,
     {
         let outputs = ::output::OutputMgr::new();
         let outputs2 = outputs.clone();
@@ -108,7 +108,7 @@ impl Environment {
                     outputs2.output_removed(id)
                 },
             }
-            cb(registry, event);
+            cb(event, registry);
         });
 
         // double sync to retrieve the global list

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,17 +1,14 @@
 use std::io;
 use std::sync::{Arc, Mutex};
 
-use wayland_client::commons::Implementation;
 use wayland_client::protocol::{
-    wl_compositor, wl_data_device_manager, wl_output, wl_registry, wl_shell, wl_shm,
+    wl_compositor, wl_data_device_manager, wl_display, wl_registry, wl_shell, wl_shm,
     wl_subcompositor,
 };
-use wayland_client::{EventQueue, GlobalEvent, GlobalManager, NewProxy, Proxy};
+use wayland_client::{EventQueue, GlobalEvent, GlobalManager, Proxy};
 use wayland_protocols::unstable::xdg_decoration::v1::client::zxdg_decoration_manager_v1;
 use wayland_protocols::unstable::xdg_shell::v6::client::zxdg_shell_v6;
 use wayland_protocols::xdg_shell::client::xdg_wm_base;
-
-use wayland_client::protocol::wl_registry::RequestsTrait;
 
 /// Possible shell globals
 pub enum Shell {
@@ -77,11 +74,11 @@ impl Environment {
     ///
     /// This may panic or fail if you do not provide the EventQueue hosting
     /// the registry you provided.
-    pub fn from_registry(
-        registry: NewProxy<wl_registry::WlRegistry>,
+    pub fn from_display(
+        display: &Proxy<wl_display::WlDisplay>,
         evq: &mut EventQueue,
     ) -> io::Result<Environment> {
-        Environment::from_registry_with_cb(registry, evq, |_, _| {})
+        Environment::from_display_with_cb(display, evq, |_, _| {})
     }
 
     /// Create an environment wrapping a new registry
@@ -90,34 +87,31 @@ impl Environment {
     /// a callback to be notified of global events, just like
     /// `GlobalManager::new_with_cb`. Note that you will still
     /// receive events even if they are processed by this `Environment`.
-    pub fn from_registry_with_cb<Impl>(
-        registry: NewProxy<wl_registry::WlRegistry>,
+    pub fn from_display_with_cb<Impl>(
+        display: &Proxy<wl_display::WlDisplay>,
         evq: &mut EventQueue,
         mut cb: Impl,
     ) -> io::Result<Environment>
     where
-        Impl: Implementation<Proxy<wl_registry::WlRegistry>, GlobalEvent> + Send + 'static,
+        Impl: FnMut(Proxy<wl_registry::WlRegistry>, GlobalEvent) + Send + 'static,
     {
         let outputs = ::output::OutputMgr::new();
         let outputs2 = outputs.clone();
 
-        let manager = GlobalManager::new_with_cb(registry, move |event, registry: Proxy<_>| {
+        let manager = GlobalManager::new_with_cb(&display, move |event, registry| {
             match event {
                 GlobalEvent::New {
                     id,
                     ref interface,
                     version,
                 } => if let "wl_output" = &interface[..] {
-                    outputs2.new_output(
-                        id,
-                        registry.bind::<wl_output::WlOutput>(version, id).unwrap(),
-                    )
+                    outputs2.new_output(id, version, &registry)
                 },
                 GlobalEvent::Removed { id, ref interface } => if let "wl_output" = &interface[..] {
                     outputs2.output_removed(id)
                 },
             }
-            cb.receive(event, registry);
+            cb(registry, event);
         });
 
         // double sync to retrieve the global list
@@ -127,48 +121,57 @@ impl Environment {
 
         // wl_compositor
         let compositor = manager
-            .instantiate_auto::<wl_compositor::WlCompositor>()
-            .expect("Server didn't advertize `wl_compositor`?!")
-            .implement(|e, _| match e {});
+            .instantiate_auto(|compositor| compositor.implement(|_, _| {}, ()))
+            .expect("Server didn't advertize `wl_compositor`?!");
 
         // wl_subcompositor
         let subcompositor = manager
-            .instantiate_auto::<wl_subcompositor::WlSubcompositor>()
-            .expect("Server didn't advertize `wl_subcompositor`?!")
-            .implement(|e, _| match e {});
+            .instantiate_auto(|subcompositor| subcompositor.implement(|_, _| {}, ()))
+            .expect("Server didn't advertize `wl_subcompositor`?!");
 
         // wl_shm
         let shm_formats = Arc::new(Mutex::new(Vec::new()));
         let shm_formats2 = shm_formats.clone();
         let shm = manager
-            .instantiate_auto::<wl_shm::WlShm>()
-            .expect("Server didn't advertize `wl_shm`?!")
-            .implement(move |wl_shm::Event::Format { format }, _| {
-                shm_formats2.lock().unwrap().push(format);
-            });
+            .instantiate_auto(|shm| {
+                shm.implement(
+                    move |wl_shm::Event::Format { format }, _| {
+                        shm_formats2.lock().unwrap().push(format);
+                    },
+                    (),
+                )
+            })
+            .expect("Server didn't advertize `wl_shm`?!");
 
         let data_device_manager = manager
-            .instantiate_auto::<wl_data_device_manager::WlDataDeviceManager>()
-            .expect("Server didn't advertize `wl_data_device_manager`?!")
-            .implement(|e, _| match e {});
+            .instantiate_auto(|data_device_manager| data_device_manager.implement(|_, _| {}, ()))
+            .expect("Server didn't advertize `wl_data_device_manager`?!");
 
         // shells
-        let shell = if let Ok(wm_base) = manager.instantiate_auto::<xdg_wm_base::XdgWmBase>() {
-            Shell::Xdg(
-                wm_base.implement(|xdg_wm_base::Event::Ping { serial }, proxy: Proxy<_>| {
+        let shell = if let Ok(wm_base) = manager.instantiate_auto(|wm_base| {
+            wm_base.implement(
+                |xdg_wm_base::Event::Ping { serial }, proxy: Proxy<_>| {
                     use self::xdg_wm_base::RequestsTrait;
                     proxy.pong(serial)
-                }),
+                },
+                (),
             )
-        } else if let Ok(xdg_shell) = manager.instantiate_auto::<zxdg_shell_v6::ZxdgShellV6>() {
-            Shell::Zxdg(xdg_shell.implement(
+        }) {
+            Shell::Xdg(wm_base)
+        } else if let Ok(xdg_shell) = manager.instantiate_auto(|xdg_shell| {
+            xdg_shell.implement(
                 |zxdg_shell_v6::Event::Ping { serial }, proxy: Proxy<_>| {
                     use self::zxdg_shell_v6::RequestsTrait;
                     proxy.pong(serial)
                 },
-            ))
-        } else if let Ok(shell) = manager.instantiate_auto::<wl_shell::WlShell>() {
-            Shell::Wl(shell.implement(|e, _| match e {}))
+                (),
+            )
+        }) {
+            Shell::Zxdg(xdg_shell)
+        } else if let Ok(wl_shell) =
+            manager.instantiate_auto(|wl_shell| wl_shell.implement(|_, _| {}, ()))
+        {
+            Shell::Wl(wl_shell)
         } else {
             panic!("Server didn't advertize neither `xdg_wm_base` nor `wl_shell`?!");
         };
@@ -176,9 +179,8 @@ impl Environment {
         // try to retrieve the decoration manager
         let decorations_mgr = if let Shell::Xdg(_) = shell {
             manager
-                .instantiate_auto::<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1>()
+                .instantiate_auto(|mgr| mgr.implement(|_, _| {}, ()))
                 .ok()
-                .map(|mgr| mgr.implement(|evt, _| match evt {}))
         } else {
             None
         };

--- a/src/env.rs
+++ b/src/env.rs
@@ -95,7 +95,8 @@ impl Environment {
         let outputs = ::output::OutputMgr::new();
         let outputs2 = outputs.clone();
 
-        let manager = GlobalManager::new_with_cb(&display, move |event, registry| {
+        let display_wrapper = display.make_wrapper(&evq.get_token()).unwrap();
+        let manager = GlobalManager::new_with_cb(&display_wrapper, move |event, registry| {
             match event {
                 GlobalEvent::New {
                     id,

--- a/src/env.rs
+++ b/src/env.rs
@@ -71,9 +71,6 @@ impl Environment {
     /// It requires you to provide the `EventQueue` as well because
     /// the initialization process does a few roundtrip to the server
     /// to initialize all the globals.
-    ///
-    /// This may panic or fail if you do not provide the EventQueue hosting
-    /// the registry you provided.
     pub fn from_display(
         display: &Proxy<wl_display::WlDisplay>,
         evq: &mut EventQueue,
@@ -83,7 +80,7 @@ impl Environment {
 
     /// Create an environment wrapping a new registry
     ///
-    /// Additionnaly to `from_registry`, this allows you to provide
+    /// Additionnaly to `from_display`, this allows you to provide
     /// a callback to be notified of global events, just like
     /// `GlobalManager::new_with_cb`. Note that you will still
     /// receive events even if they are processed by this `Environment`.

--- a/src/output.rs
+++ b/src/output.rs
@@ -3,10 +3,8 @@
 use std::sync::{Arc, Mutex};
 
 use wayland_client::protocol::wl_output::{self, Event, RequestsTrait, WlOutput};
-use wayland_client::protocol::wl_registry;
+use wayland_client::protocol::wl_registry::{self, RequestsTrait as RegistryRequest};
 use wayland_client::Proxy;
-
-use wayland_client::protocol::wl_registry::RequestsTrait as RegistryRequest;
 
 pub use wayland_client::protocol::wl_output::{Subpixel, Transform};
 

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -2,9 +2,10 @@
 
 use std::ops::Deref;
 
-use wayland_client::commons::Implementation;
-use wayland_client::protocol::{wl_compositor, wl_pointer, wl_shm};
+use wayland_client::protocol::{wl_compositor, wl_pointer, wl_seat, wl_shm};
 use wayland_client::{NewProxy, Proxy, QueueToken};
+
+use wayland_client::protocol::wl_seat::RequestsTrait as SeatRequests;
 
 mod theme;
 
@@ -34,9 +35,9 @@ impl AutoThemer {
     pub fn init(
         name: Option<&str>,
         compositor: Proxy<wl_compositor::WlCompositor>,
-        shm: Proxy<wl_shm::WlShm>,
+        shm: &Proxy<wl_shm::WlShm>,
     ) -> AutoThemer {
-        match ThemeManager::init(name, compositor, shm) {
+        match ThemeManager::init(name, compositor, &shm) {
             Ok(mgr) => AutoThemer::Themed(mgr),
             Err(()) => AutoThemer::UnThemed,
         }
@@ -55,25 +56,33 @@ impl AutoThemer {
     /// You need to provide an implementation as if implementing a `wl_pointer`, but
     /// it will receive as `meta` argument an `AutoPointer` wrapping your pointer,
     /// rather than a `Proxy<WlPointer>`.
-    pub fn theme_pointer_with_impl<Impl>(
+    pub fn theme_pointer_with_impl<Impl, UD>(
         &self,
-        pointer: NewProxy<wl_pointer::WlPointer>,
+        seat: &Proxy<wl_seat::WlSeat>,
         mut implementation: Impl,
+        user_data: UD,
     ) -> AutoPointer
     where
-        Impl: Implementation<AutoPointer, wl_pointer::Event> + Send + 'static,
+        Impl: FnMut(AutoPointer, wl_pointer::Event) + Send + 'static,
+        UD: Send + Sync + 'static,
     {
         match *self {
             AutoThemer::Themed(ref mgr) => {
-                let pointer = mgr.theme_pointer_with_impl(pointer, move |event, pointer| {
-                    implementation.receive(event, AutoPointer::Themed(pointer))
-                });
+                let pointer = mgr.theme_pointer_with_impl(
+                    seat,
+                    move |seat, event| implementation(AutoPointer::Themed(seat), event),
+                    user_data,
+                );
                 AutoPointer::Themed(pointer)
             }
             AutoThemer::UnThemed => {
-                let pointer = pointer.implement(move |event, pointer| {
-                    implementation.receive(event, AutoPointer::UnThemed(pointer))
-                });
+                let pointer =
+                    seat.get_pointer(|pointer| {
+                        pointer.implement(
+                            move |event, seat| implementation(AutoPointer::UnThemed(seat), event),
+                            user_data,
+                        )
+                    }).unwrap();
                 AutoPointer::UnThemed(pointer)
             }
         }
@@ -84,31 +93,31 @@ impl AutoThemer {
     /// Like `theme_pointer_with_impl` but allows you to have a non-`Send` implementation.
     ///
     /// **Unsafe** for the same reasons as `NewProxy::implement_nonsend`.
-    pub unsafe fn theme_pointer_with_nonsend_impl<Impl>(
+    pub unsafe fn theme_pointer_with_nonsend_impl<Impl, UD>(
         &self,
         pointer: NewProxy<wl_pointer::WlPointer>,
         mut implementation: Impl,
+        user_data: UD,
         token: &QueueToken,
     ) -> AutoPointer
     where
-        Impl: Implementation<AutoPointer, wl_pointer::Event> + Send + 'static,
+        Impl: FnMut(AutoPointer, wl_pointer::Event) + Send + 'static,
+        UD: Send + Sync + 'static,
     {
         match *self {
             AutoThemer::Themed(ref mgr) => {
                 let pointer = mgr.theme_pointer_with_nonsend_impl(
                     pointer,
-                    move |event, pointer| {
-                        implementation.receive(event, AutoPointer::Themed(pointer))
-                    },
+                    move |pointer, event| implementation(AutoPointer::Themed(pointer), event),
+                    user_data,
                     token,
                 );
                 AutoPointer::Themed(pointer)
             }
             AutoThemer::UnThemed => {
                 let pointer = pointer.implement_nonsend(
-                    move |event, pointer| {
-                        implementation.receive(event, AutoPointer::UnThemed(pointer))
-                    },
+                    move |event, pointer| implementation(AutoPointer::UnThemed(pointer), event),
+                    user_data,
                     token,
                 );
                 AutoPointer::UnThemed(pointer)

--- a/src/pointer/theme.rs
+++ b/src/pointer/theme.rs
@@ -32,7 +32,7 @@ impl ThemeManager {
     pub fn init(
         name: Option<&str>,
         compositor: Proxy<wl_compositor::WlCompositor>,
-        shm: &Proxy<wl_shm::WlShm>,
+        shm: Proxy<wl_shm::WlShm>,
     ) -> Result<ThemeManager, ()> {
         if !is_available() {
             return Err(());
@@ -72,7 +72,7 @@ impl ThemeManager {
         user_data: UD,
     ) -> ThemedPointer
     where
-        Impl: FnMut(ThemedPointer, wl_pointer::Event) + Send + 'static,
+        Impl: FnMut(wl_pointer::Event, ThemedPointer) + Send + 'static,
         UD: Send + Sync + 'static,
     {
         let surface = self
@@ -92,11 +92,11 @@ impl ThemeManager {
                 pointer.implement(
                     move |event, ptr| {
                         implementation(
+                            event,
                             ThemedPointer {
                                 pointer: ptr,
                                 inner: inner.clone(),
                             },
-                            event,
                         )
                     },
                     user_data,
@@ -122,7 +122,7 @@ impl ThemeManager {
         token: &QueueToken,
     ) -> ThemedPointer
     where
-        Impl: FnMut(ThemedPointer, wl_pointer::Event) + 'static,
+        Impl: FnMut(wl_pointer::Event, ThemedPointer) + 'static,
         UD: Send + Sync + 'static,
     {
         let surface = self
@@ -140,11 +140,11 @@ impl ThemeManager {
         let pointer = pointer.implement_nonsend(
             move |event, ptr| {
                 implementation(
+                    event,
                     ThemedPointer {
                         pointer: ptr,
                         inner: inner.clone(),
                     },
-                    event,
                 )
             },
             user_data,

--- a/src/utils/mempool.rs
+++ b/src/utils/mempool.rs
@@ -14,7 +14,6 @@ use std::sync::{Arc, Mutex};
 
 use rand::prelude::*;
 
-use wayland_client::commons::Implementation;
 use wayland_client::protocol::{wl_buffer, wl_shm, wl_shm_pool};
 use wayland_client::Proxy;
 
@@ -41,7 +40,7 @@ impl DoubleMemPool {
     /// Create a double memory pool
     pub fn new<Impl>(shm: &Proxy<wl_shm::WlShm>, implementation: Impl) -> io::Result<DoubleMemPool>
     where
-        Impl: Implementation<(), ()> + Send,
+        Impl: FnMut((), ()) + Send + 'static,
     {
         let free = Arc::new(Mutex::new(true));
         let implementation = Arc::new(Mutex::new(implementation));
@@ -50,7 +49,7 @@ impl DoubleMemPool {
         let pool1 = MemPool::new(shm, move |_, _| {
             let mut my_free = my_free.lock().unwrap();
             if !*my_free {
-                my_implementation.lock().unwrap().receive((), ());
+                (&mut *my_implementation.lock().unwrap())((), ());
                 *my_free = true
             }
         })?;
@@ -59,7 +58,7 @@ impl DoubleMemPool {
         let pool2 = MemPool::new(shm, move |_, _| {
             let mut my_free = my_free.lock().unwrap();
             if !*my_free {
-                my_implementation.lock().unwrap().receive((), ());
+                (&mut *my_implementation.lock().unwrap())((), ());
                 *my_free = true
             }
         })?;
@@ -104,23 +103,22 @@ pub struct MemPool {
     len: usize,
     pool: Proxy<wl_shm_pool::WlShmPool>,
     buffer_count: Arc<Mutex<u32>>,
-    implementation: Arc<Mutex<Implementation<(), ()> + Send>>,
+    implementation: Arc<Mutex<FnMut((), ()) + Send>>,
 }
 
 impl MemPool {
     /// Create a new memory pool associated with given shm
     pub fn new<Impl>(shm: &Proxy<wl_shm::WlShm>, implementation: Impl) -> io::Result<MemPool>
     where
-        Impl: Implementation<(), ()> + Send,
+        Impl: FnMut((), ()) + Send + 'static,
     {
         let mem_fd = create_shm_fd()?;
         let mem_file = unsafe { File::from_raw_fd(mem_fd) };
         mem_file.set_len(128)?;
 
         let pool = shm
-            .create_pool(mem_fd, 128)
-            .unwrap()
-            .implement(|e, _| match e {});
+            .create_pool(mem_fd, 128, |pool| pool.implement(|e, _| match e {}, ()))
+            .unwrap();
 
         Ok(MemPool {
             file: mem_file,
@@ -175,20 +173,22 @@ impl MemPool {
         let my_buffer_count = self.buffer_count.clone();
         let my_implementation = self.implementation.clone();
         self.pool
-            .create_buffer(offset, width, height, stride, format)
-            .unwrap()
-            .implement(
-                move |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
-                    wl_buffer::Event::Release => {
-                        buffer.destroy();
-                        let mut my_buffer_count = my_buffer_count.lock().unwrap();
-                        *my_buffer_count -= 1;
-                        if *my_buffer_count == 0 {
-                            my_implementation.lock().unwrap().receive((), ());
+            .create_buffer(offset, width, height, stride, format, |buffer| {
+                buffer.implement(
+                    move |event, buffer: Proxy<wl_buffer::WlBuffer>| match event {
+                        wl_buffer::Event::Release => {
+                            buffer.destroy();
+                            let mut my_buffer_count = my_buffer_count.lock().unwrap();
+                            *my_buffer_count -= 1;
+                            if *my_buffer_count == 0 {
+                                (&mut *my_implementation.lock().unwrap())((), ());
+                            }
                         }
-                    }
-                },
-            )
+                    },
+                    (),
+                )
+            })
+            .unwrap()
     }
 
     /// Retuns true if the pool contains buffers that are currently in use by the server otherwise it returns

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -2,7 +2,6 @@ use std::cmp::max;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::sync::{Arc, Mutex};
 
-use wayland_client::commons::Implementation;
 use wayland_client::protocol::{
     wl_compositor, wl_pointer, wl_seat, wl_shm, wl_subcompositor, wl_subsurface, wl_surface,
 };
@@ -10,7 +9,6 @@ use wayland_client::Proxy;
 
 use wayland_client::protocol::wl_compositor::RequestsTrait as CompositorRequests;
 use wayland_client::protocol::wl_pointer::RequestsTrait as PointerRequests;
-use wayland_client::protocol::wl_seat::RequestsTrait as SeatRequests;
 use wayland_client::protocol::wl_subcompositor::RequestsTrait as SubcompRequests;
 use wayland_client::protocol::wl_subsurface::RequestsTrait as SubsurfaceRequests;
 use wayland_client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
@@ -97,11 +95,14 @@ impl Part {
         compositor: &Proxy<wl_compositor::WlCompositor>,
         subcompositor: &Proxy<wl_subcompositor::WlSubcompositor>,
     ) -> Part {
-        let surface = compositor.create_surface().unwrap().implement(|_, _| {});
+        let surface = compositor
+            .create_surface(|surface| surface.implement(|_, _| {}, ()))
+            .unwrap();
         let subsurface = subcompositor
-            .get_subsurface(&surface, parent)
-            .unwrap()
-            .implement(|_, _| {});
+            .get_subsurface(&surface, parent, |subsurface| {
+                subsurface.implement(|_, _| {}, ())
+            })
+            .unwrap();
         Part {
             surface,
             subsurface,
@@ -130,7 +131,7 @@ struct Inner {
     parts: [Part; 5],
     size: Mutex<(u32, u32)>,
     resizable: Arc<Mutex<bool>>,
-    implem: Mutex<Box<Implementation<u32, FrameRequest> + Send>>,
+    implem: Mutex<Box<FnMut(u32, FrameRequest) + Send>>,
     maximized: Arc<Mutex<bool>>,
 }
 
@@ -228,7 +229,7 @@ impl Frame for BasicFrame {
         compositor: &Proxy<wl_compositor::WlCompositor>,
         subcompositor: &Proxy<wl_subcompositor::WlSubcompositor>,
         shm: &Proxy<wl_shm::WlShm>,
-        implementation: Box<Implementation<u32, FrameRequest> + Send>,
+        implementation: Box<FnMut(u32, FrameRequest) + Send>,
     ) -> Result<BasicFrame, ::std::io::Error> {
         let parts = [
             Part::new(base_surface, compositor, subcompositor),
@@ -248,11 +249,7 @@ impl Frame for BasicFrame {
         // Send a Refresh request on callback from DoubleMemPool as it will be fired when
         // None was previously returned from `pool()` and the draw was postponed
         let pools = DoubleMemPool::new(&shm, move |_, _| {
-            my_inner
-                .implem
-                .lock()
-                .unwrap()
-                .receive(FrameRequest::Refresh, 0);
+            (&mut *my_inner.implem.lock().unwrap())(0, FrameRequest::Refresh);
         })?;
         Ok(BasicFrame {
             inner,
@@ -260,7 +257,7 @@ impl Frame for BasicFrame {
             active: false,
             hidden: false,
             pointers: Vec::new(),
-            themer: AutoThemer::init(None, compositor.clone(), shm.clone()),
+            themer: AutoThemer::init(None, compositor.clone(), &shm),
             surface_version: compositor.version(),
         })
     }
@@ -269,9 +266,10 @@ impl Frame for BasicFrame {
         use self::wl_pointer::Event;
         let inner = self.inner.clone();
         let pointer = self.themer.theme_pointer_with_impl(
-            seat.get_pointer().unwrap(),
-            move |event, pointer: AutoPointer| {
-                let data = unsafe { &mut *(pointer.get_user_data() as *mut PointerUserData) };
+            seat,
+            move |pointer: AutoPointer, event| {
+                let data: &Mutex<PointerUserData> = pointer.user_data().unwrap();
+                let data = &mut *data.lock().unwrap();
                 let (width, _) = *(inner.size.lock().unwrap());
                 let resizable = *(inner.resizable.lock().unwrap());
                 match event {
@@ -309,11 +307,7 @@ impl Frame for BasicFrame {
                             match (newpos, data.location) {
                                 (Location::Button(_), _) | (_, Location::Button(_)) => {
                                     // pointer movement involves a button, request refresh
-                                    inner
-                                        .implem
-                                        .lock()
-                                        .unwrap()
-                                        .receive(FrameRequest::Refresh, 0);
+                                    (&mut *inner.implem.lock().unwrap())(0, FrameRequest::Refresh);
                                 }
                                 _ => (),
                             }
@@ -340,19 +334,19 @@ impl Frame for BasicFrame {
                                 resizable,
                             );
                             if let Some(req) = req {
-                                inner.implem.lock().unwrap().receive(req, serial);
+                                (&mut *inner.implem.lock().unwrap())(serial, req);
                             }
                         }
                     }
                     _ => {}
                 }
             },
+            Mutex::new(PointerUserData {
+                location: Location::None,
+                position: (0.0, 0.0),
+                seat: seat.clone(),
+            }),
         );
-        pointer.set_user_data(Box::into_raw(Box::new(PointerUserData {
-            location: Location::None,
-            position: (0.0, 0.0),
-            seat: seat.clone(),
-        })) as *mut ());
         self.pointers.push(pointer);
     }
 
@@ -463,9 +457,8 @@ impl Frame for BasicFrame {
                         .iter()
                         .flat_map(|p| {
                             if p.is_alive() {
-                                let data =
-                                    unsafe { &mut *(p.get_user_data() as *mut PointerUserData) };
-                                Some(data.location)
+                                let data: &Mutex<PointerUserData> = p.user_data().unwrap();
+                                Some(data.lock().unwrap().location)
                             } else {
                                 None
                             }
@@ -659,8 +652,6 @@ impl Frame for BasicFrame {
 impl Drop for BasicFrame {
     fn drop(&mut self) {
         for ptr in self.pointers.drain(..) {
-            let _data = unsafe { Box::from_raw(ptr.get_user_data() as *mut PointerUserData) };
-            ptr.set_user_data(::std::ptr::null_mut());
             if ptr.version() >= 3 {
                 ptr.release();
             }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, Mutex};
 
-use wayland_client::commons::Implementation;
 use wayland_client::protocol::{
     wl_compositor, wl_output, wl_seat, wl_shm, wl_subcompositor, wl_surface,
 };
@@ -60,7 +59,7 @@ pub enum Event {
 struct WindowInner<F> {
     frame: Arc<Mutex<F>>,
     shell_surface: Arc<Box<shell::ShellSurface>>,
-    user_impl: Box<Implementation<(), Event> + Send>,
+    user_impl: Box<FnMut((), Event) + Send>,
     min_size: (u32, u32),
     max_size: Option<(u32, u32)>,
     current_size: (u32, u32),
@@ -102,7 +101,7 @@ impl<F: Frame + 'static> Window<F> {
         implementation: Impl,
     ) -> Result<Window<F>, F::Error>
     where
-        Impl: Implementation<(), Event> + Send,
+        Impl: FnMut((), Event) + Send + 'static,
     {
         Self::init_with_decorations(
             surface,
@@ -130,7 +129,7 @@ impl<F: Frame + 'static> Window<F> {
         implementation: Impl,
     ) -> Result<Window<F>, F::Error>
     where
-        Impl: Implementation<(), Event> + Send,
+        Impl: FnMut((), Event) + Send + 'static,
     {
         Self::init_with_decorations(
             surface,
@@ -160,7 +159,7 @@ impl<F: Frame + 'static> Window<F> {
         implementation: Impl,
     ) -> Result<Window<F>, F::Error>
     where
-        Impl: Implementation<(), Event> + Send,
+        Impl: FnMut((), Event) + Send + 'static,
     {
         let inner = Arc::new(Mutex::new(None::<WindowInner<F>>));
         let frame_inner = inner.clone();
@@ -170,7 +169,7 @@ impl<F: Frame + 'static> Window<F> {
             compositor,
             subcompositor,
             shm,
-            Box::new(move |req, serial| {
+            Box::new(move |serial, req| {
                 if let Some(ref mut inner) = *shell_inner.lock().unwrap() {
                     match req {
                         FrameRequest::Minimize => inner.shell_surface.set_minimized(),
@@ -180,8 +179,8 @@ impl<F: Frame + 'static> Window<F> {
                         FrameRequest::Resize(seat, edges) => {
                             inner.shell_surface.resize(&seat, serial, edges)
                         }
-                        FrameRequest::Close => inner.user_impl.receive(Event::Close, ()),
-                        FrameRequest::Refresh => inner.user_impl.receive(Event::Refresh, ()),
+                        FrameRequest::Close => (inner.user_impl)((), Event::Close),
+                        FrameRequest::Refresh => (inner.user_impl)((), Event::Refresh),
                     }
                 }
             }) as Box<_>,
@@ -191,7 +190,7 @@ impl<F: Frame + 'static> Window<F> {
         let shell_surface = Arc::new(shell::create_shell_surface(
             shell,
             &surface,
-            move |evt, ()| {
+            move |(), evt| {
                 if let Some(ref mut inner) = *frame_inner.lock().unwrap() {
                     if let Event::Configure {
                         states,
@@ -227,13 +226,11 @@ impl<F: Frame + 'static> Window<F> {
                         }
                         need_refresh |= frame.set_active(states.contains(&State::Activated));
                         if need_refresh {
-                            inner.user_impl.receive(Event::Refresh, ());
+                            (inner.user_impl)((), Event::Refresh);
                         }
-                        inner
-                            .user_impl
-                            .receive(Event::Configure { states, new_size }, ());
+                        (inner.user_impl)((), Event::Configure { states, new_size });
                     } else {
-                        inner.user_impl.receive(evt, ());
+                        (inner.user_impl)((), evt);
                     }
                 }
             },
@@ -296,28 +293,31 @@ impl<F: Frame + 'static> Window<F> {
         let decoration_frame = self.frame.clone();
         let decoration_inner = self.inner.clone();
         *decoration = match (self.shell_surface.get_xdg(), &self.decoration_mgr) {
-            (Some(toplevel), &Some(ref mgr)) => mgr.get_toplevel_decoration(toplevel).ok().map(
-                move |newdec| {
-                    newdec.implement(move |event, _| {
-                        use self::zxdg_toplevel_decoration_v1::{Event, Mode};
-                        let Event::Configure { mode } = event;
-                        match mode {
-                            Mode::ServerSide => {
-                                decoration_frame.lock().unwrap().set_hidden(true);
+            (Some(toplevel), &Some(ref mgr)) => {
+                mgr.get_toplevel_decoration(toplevel, |newdec| {
+                    newdec.implement(
+                        move |event, _| {
+                            use self::zxdg_toplevel_decoration_v1::{Event, Mode};
+                            let Event::Configure { mode } = event;
+                            match mode {
+                                Mode::ServerSide => {
+                                    decoration_frame.lock().unwrap().set_hidden(true);
+                                }
+                                Mode::ClientSide => {
+                                    let want_decorate = decoration_inner
+                                        .lock()
+                                        .unwrap()
+                                        .as_ref()
+                                        .map(|inner| inner.decorated)
+                                        .unwrap_or(false);
+                                    decoration_frame.lock().unwrap().set_hidden(!want_decorate);
+                                }
                             }
-                            Mode::ClientSide => {
-                                let want_decorate = decoration_inner
-                                    .lock()
-                                    .unwrap()
-                                    .as_ref()
-                                    .map(|inner| inner.decorated)
-                                    .unwrap_or(false);
-                                decoration_frame.lock().unwrap().set_hidden(!want_decorate);
-                            }
-                        }
-                    })
-                },
-            ),
+                        },
+                        (),
+                    )
+                }).ok()
+            }
             _ => None,
         };
     }
@@ -548,7 +548,7 @@ pub trait Frame: Sized + Send {
         compositor: &Proxy<wl_compositor::WlCompositor>,
         subcompositor: &Proxy<wl_subcompositor::WlSubcompositor>,
         shm: &Proxy<wl_shm::WlShm>,
-        implementation: Box<Implementation<u32, FrameRequest> + Send>,
+        implementation: Box<FnMut(u32, FrameRequest) + Send>,
     ) -> Result<Self, Self::Error>;
     /// Set whether the decorations should be drawn as active or not
     ///

--- a/src/window/shell/mod.rs
+++ b/src/window/shell/mod.rs
@@ -16,7 +16,7 @@ pub(crate) fn create_shell_surface<Impl>(
     implem: Impl,
 ) -> Box<ShellSurface>
 where
-    Impl: FnMut((), Event) + Send + 'static,
+    Impl: FnMut(Event) + Send + 'static,
 {
     match *shell {
         Shell::Wl(ref shell) => Box::new(wl::Wl::create(surface, shell, implem)) as Box<_>,

--- a/src/window/shell/mod.rs
+++ b/src/window/shell/mod.rs
@@ -1,4 +1,3 @@
-use wayland_client::commons::Implementation;
 use wayland_client::protocol::{wl_output, wl_seat, wl_surface};
 use wayland_client::Proxy;
 
@@ -17,7 +16,7 @@ pub(crate) fn create_shell_surface<Impl>(
     implem: Impl,
 ) -> Box<ShellSurface>
 where
-    Impl: Implementation<(), Event> + Send,
+    Impl: FnMut((), Event) + Send + 'static,
 {
     match *shell {
         Shell::Wl(ref shell) => Box::new(wl::Wl::create(surface, shell, implem)) as Box<_>,

--- a/src/window/shell/wl.rs
+++ b/src/window/shell/wl.rs
@@ -1,4 +1,3 @@
-use wayland_client::commons::Implementation;
 use wayland_client::protocol::{wl_output, wl_seat, wl_shell, wl_shell_surface, wl_surface};
 use wayland_client::Proxy;
 
@@ -20,28 +19,33 @@ impl Wl {
         mut implementation: Impl,
     ) -> Wl
     where
-        Impl: Implementation<(), Event> + Send,
+        Impl: FnMut((), Event) + Send + 'static,
     {
-        let shell_surface = shell.get_shell_surface(surface).unwrap().implement(
-            move |event, shell_surface: Proxy<_>| match event {
-                wl_shell_surface::Event::Ping { serial } => {
-                    shell_surface.pong(serial);
-                }
-                wl_shell_surface::Event::Configure { width, height, .. } => {
-                    use std::cmp::max;
-                    implementation.receive(
-                        Event::Configure {
-                            new_size: Some((max(width, 1) as u32, max(height, 1) as u32)),
-                            states: Vec::new(),
-                        },
-                        (),
-                    );
-                }
-                wl_shell_surface::Event::PopupDone => {
-                    unreachable!();
-                }
-            },
-        );
+        let shell_surface = shell
+            .get_shell_surface(surface, |shell_surface| {
+                shell_surface.implement(
+                    move |event, shell_surface: Proxy<_>| match event {
+                        wl_shell_surface::Event::Ping { serial } => {
+                            shell_surface.pong(serial);
+                        }
+                        wl_shell_surface::Event::Configure { width, height, .. } => {
+                            use std::cmp::max;
+                            implementation(
+                                (),
+                                Event::Configure {
+                                    new_size: Some((max(width, 1) as u32, max(height, 1) as u32)),
+                                    states: Vec::new(),
+                                },
+                            );
+                        }
+                        wl_shell_surface::Event::PopupDone => {
+                            unreachable!();
+                        }
+                    },
+                    (),
+                )
+            })
+            .unwrap();
         shell_surface.set_toplevel();
         Wl { shell_surface }
     }

--- a/src/window/shell/wl.rs
+++ b/src/window/shell/wl.rs
@@ -19,7 +19,7 @@ impl Wl {
         mut implementation: Impl,
     ) -> Wl
     where
-        Impl: FnMut((), Event) + Send + 'static,
+        Impl: FnMut(Event) + Send + 'static,
     {
         let shell_surface = shell
             .get_shell_surface(surface, |shell_surface| {
@@ -30,13 +30,10 @@ impl Wl {
                         }
                         wl_shell_surface::Event::Configure { width, height, .. } => {
                             use std::cmp::max;
-                            implementation(
-                                (),
-                                Event::Configure {
-                                    new_size: Some((max(width, 1) as u32, max(height, 1) as u32)),
-                                    states: Vec::new(),
-                                },
-                            );
+                            implementation(Event::Configure {
+                                new_size: Some((max(width, 1) as u32, max(height, 1) as u32)),
+                                states: Vec::new(),
+                            });
                         }
                         wl_shell_surface::Event::PopupDone => {
                             unreachable!();

--- a/src/window/shell/xdg.rs
+++ b/src/window/shell/xdg.rs
@@ -22,7 +22,7 @@ impl Xdg {
         mut implementation: Impl,
     ) -> Xdg
     where
-        Impl: FnMut((), Event) + Send + 'static,
+        Impl: FnMut(Event) + Send + 'static,
     {
         let xdgs = shell
             .get_xdg_surface(surface, |xdgs| {
@@ -41,7 +41,7 @@ impl Xdg {
                 toplevel.implement(
                     move |evt, _| {
                         match evt {
-                            xdg_toplevel::Event::Close => implementation((), Event::Close),
+                            xdg_toplevel::Event::Close => implementation(Event::Close),
                             xdg_toplevel::Event::Configure {
                                 width,
                                 height,
@@ -65,7 +65,7 @@ impl Xdg {
                                     .cloned()
                                     .flat_map(xdg_toplevel::State::from_raw)
                                     .collect::<Vec<_>>();
-                                implementation((), Event::Configure { new_size, states });
+                                implementation(Event::Configure { new_size, states });
                             }
                         }
                     },

--- a/src/window/shell/xdg.rs
+++ b/src/window/shell/xdg.rs
@@ -1,4 +1,3 @@
-use wayland_client::commons::Implementation;
 use wayland_client::protocol::{wl_output, wl_seat, wl_surface};
 use wayland_client::Proxy;
 
@@ -23,42 +22,56 @@ impl Xdg {
         mut implementation: Impl,
     ) -> Xdg
     where
-        Impl: Implementation<(), Event> + Send,
+        Impl: FnMut((), Event) + Send + 'static,
     {
-        let xdgs = shell.get_xdg_surface(surface).unwrap().implement(
-            |evt, xdgs: Proxy<_>| match evt {
-                xdg_surface::Event::Configure { serial } => {
-                    xdgs.ack_configure(serial);
-                }
-            },
-        );
-        let toplevel = xdgs.get_toplevel().unwrap().implement(move |evt, _| {
-            match evt {
-                xdg_toplevel::Event::Close => implementation.receive(Event::Close, ()),
-                xdg_toplevel::Event::Configure {
-                    width,
-                    height,
-                    states,
-                } => {
-                    use std::cmp::max;
-                    let new_size = if width == 0 || height == 0 {
-                        // if either w or h is zero, then we get to choose our size
-                        None
-                    } else {
-                        Some((max(width, 1) as u32, max(height, 1) as u32))
-                    };
-                    let view: &[u32] = unsafe {
-                        ::std::slice::from_raw_parts(states.as_ptr() as *const _, states.len() / 4)
-                    };
-                    let states = view
-                        .iter()
-                        .cloned()
-                        .flat_map(xdg_toplevel::State::from_raw)
-                        .collect::<Vec<_>>();
-                    implementation.receive(Event::Configure { new_size, states }, ());
-                }
-            }
-        });
+        let xdgs = shell
+            .get_xdg_surface(surface, |xdgs| {
+                xdgs.implement(
+                    |evt, xdgs: Proxy<_>| match evt {
+                        xdg_surface::Event::Configure { serial } => {
+                            xdgs.ack_configure(serial);
+                        }
+                    },
+                    (),
+                )
+            })
+            .unwrap();
+        let toplevel =
+            xdgs.get_toplevel(|toplevel| {
+                toplevel.implement(
+                    move |evt, _| {
+                        match evt {
+                            xdg_toplevel::Event::Close => implementation((), Event::Close),
+                            xdg_toplevel::Event::Configure {
+                                width,
+                                height,
+                                states,
+                            } => {
+                                use std::cmp::max;
+                                let new_size = if width == 0 || height == 0 {
+                                    // if either w or h is zero, then we get to choose our size
+                                    None
+                                } else {
+                                    Some((max(width, 1) as u32, max(height, 1) as u32))
+                                };
+                                let view: &[u32] = unsafe {
+                                    ::std::slice::from_raw_parts(
+                                        states.as_ptr() as *const _,
+                                        states.len() / 4,
+                                    )
+                                };
+                                let states = view
+                                    .iter()
+                                    .cloned()
+                                    .flat_map(xdg_toplevel::State::from_raw)
+                                    .collect::<Vec<_>>();
+                                implementation((), Event::Configure { new_size, states });
+                            }
+                        }
+                    },
+                    (),
+                )
+            }).unwrap();
         surface.commit();
         Xdg {
             surface: xdgs,

--- a/src/window/shell/zxdg.rs
+++ b/src/window/shell/zxdg.rs
@@ -26,7 +26,7 @@ impl Zxdg {
         mut implementation: Impl,
     ) -> Zxdg
     where
-        Impl: FnMut((), Event) + Send + 'static,
+        Impl: FnMut(Event) + Send + 'static,
     {
         let xdgs = shell
             .get_xdg_surface(surface, |xdgs| {
@@ -45,7 +45,7 @@ impl Zxdg {
                 toplevel.implement(
                     move |evt, _| {
                         match evt {
-                            zxdg_toplevel_v6::Event::Close => implementation((), Event::Close),
+                            zxdg_toplevel_v6::Event::Close => implementation(Event::Close),
                             zxdg_toplevel_v6::Event::Configure {
                                 width,
                                 height,
@@ -69,7 +69,7 @@ impl Zxdg {
                         // bit representation of xdg_toplevel_v6 and zxdg_toplevel_v6 matches
                         .flat_map(xdg_toplevel::State::from_raw)
                         .collect::<Vec<_>>();
-                                implementation((), Event::Configure { new_size, states });
+                                implementation(Event::Configure { new_size, states });
                             }
                         }
                     },

--- a/src/window/shell/zxdg.rs
+++ b/src/window/shell/zxdg.rs
@@ -1,4 +1,3 @@
-use wayland_client::commons::Implementation;
 use wayland_client::protocol::{wl_output, wl_seat, wl_surface};
 use wayland_client::Proxy;
 
@@ -27,42 +26,56 @@ impl Zxdg {
         mut implementation: Impl,
     ) -> Zxdg
     where
-        Impl: Implementation<(), Event> + Send,
+        Impl: FnMut((), Event) + Send + 'static,
     {
-        let xdgs = shell.get_xdg_surface(surface).unwrap().implement(
-            |evt, xdgs: Proxy<_>| match evt {
-                zxdg_surface_v6::Event::Configure { serial } => {
-                    xdgs.ack_configure(serial);
-                }
-            },
-        );
-        let toplevel = xdgs.get_toplevel().unwrap().implement(move |evt, _| {
-            match evt {
-                zxdg_toplevel_v6::Event::Close => implementation.receive(Event::Close, ()),
-                zxdg_toplevel_v6::Event::Configure {
-                    width,
-                    height,
-                    states,
-                } => {
-                    use std::cmp::max;
-                    let new_size = if width == 0 || height == 0 {
-                        // if either w or h is zero, then we get to choose our size
-                        None
-                    } else {
-                        Some((max(width, 1) as u32, max(height, 1) as u32))
-                    };
-                    let view: &[u32] = unsafe {
-                        ::std::slice::from_raw_parts(states.as_ptr() as *const _, states.len() / 4)
-                    };
-                    let states = view.iter()
+        let xdgs = shell
+            .get_xdg_surface(surface, |xdgs| {
+                xdgs.implement(
+                    |evt, xdgs: Proxy<_>| match evt {
+                        zxdg_surface_v6::Event::Configure { serial } => {
+                            xdgs.ack_configure(serial);
+                        }
+                    },
+                    (),
+                )
+            })
+            .unwrap();
+        let toplevel =
+            xdgs.get_toplevel(|toplevel| {
+                toplevel.implement(
+                    move |evt, _| {
+                        match evt {
+                            zxdg_toplevel_v6::Event::Close => implementation((), Event::Close),
+                            zxdg_toplevel_v6::Event::Configure {
+                                width,
+                                height,
+                                states,
+                            } => {
+                                use std::cmp::max;
+                                let new_size = if width == 0 || height == 0 {
+                                    // if either w or h is zero, then we get to choose our size
+                                    None
+                                } else {
+                                    Some((max(width, 1) as u32, max(height, 1) as u32))
+                                };
+                                let view: &[u32] = unsafe {
+                                    ::std::slice::from_raw_parts(
+                                        states.as_ptr() as *const _,
+                                        states.len() / 4,
+                                    )
+                                };
+                                let states = view.iter()
                         .cloned()
                         // bit representation of xdg_toplevel_v6 and zxdg_toplevel_v6 matches
                         .flat_map(xdg_toplevel::State::from_raw)
                         .collect::<Vec<_>>();
-                    implementation.receive(Event::Configure { new_size, states }, ());
-                }
-            }
-        });
+                                implementation((), Event::Configure { new_size, states });
+                            }
+                        }
+                    },
+                    (),
+                )
+            }).unwrap();
         surface.commit();
         Zxdg {
             surface: xdgs,


### PR DESCRIPTION
This PR upgrades the smithay-client-toolkit to use wayland-rs 0.21 (pure rust implementation :tada:)

This PR makes necessary breaking modifications to the API but I've tried to minimize the changes, the API can be changed to better fit wayland-rs 0.21 if you'd like. I've run this through clippy and tested the examples but I'll be porting winit to use this PR to test the changes in more depth as well as reading through the diff a bit more.