### PR TITLE
Add `keyboard::Event::Modifiers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **[Breaking]** Keyboard: remove `modifiers` field from `keyboard::Event::Enter`, `keyboard::Event::Key` and `keyboard::KeyRepeatEvent`
 - **[Breaking]** Keyboard: add `keyboard::Event::Modifiers`
 - **[Breaking]** Upgrade to wayland-rs 0.21
 - Keyboard: end key repetition when the keyboard loses focus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **[Breaking]** Keyboard: add `keyboard::Event::Modifiers`
 - **[Breaking]** Upgrade to wayland-rs 0.21
 - Keyboard: end key repetition when the keyboard loses focus
 

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -74,12 +74,11 @@ fn main() {
         KeyRepeatKind::System,
         move |event: KbEvent, _| match event {
             KbEvent::Enter {
-                modifiers, keysyms, ..
+                keysyms, ..
             } => {
                 println!(
-                    "Gained focus while {} keys pressed and modifiers are {:?}.",
+                    "Gained focus while {} keys pressed.",
                     keysyms.len(),
-                    modifiers
                 );
             }
             KbEvent::Leave { .. } => {
@@ -89,11 +88,9 @@ fn main() {
                 keysym,
                 state,
                 utf8,
-                modifiers,
                 ..
             } => {
                 println!("Key {:?}: {:x}.", state, keysym);
-                println!(" -> Modifers are {:?}", modifiers);
                 if let Some(txt) = utf8 {
                     println!(" -> Received text \"{}\".", txt);
                 }
@@ -110,7 +107,6 @@ fn main() {
         },
         move |repeat_event: KeyRepeatEvent, _| {
             println!("Repeated key {:x}.", repeat_event.keysym);
-            println!(" -> Modifers are {:?}", repeat_event.modifiers);
             if let Some(txt) = repeat_event.utf8 {
                 println!(" -> Received text \"{}\".", txt);
             }

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -73,13 +73,8 @@ fn main() {
         &seat,
         KeyRepeatKind::System,
         move |event: KbEvent, _| match event {
-            KbEvent::Enter {
-                keysyms, ..
-            } => {
-                println!(
-                    "Gained focus while {} keys pressed.",
-                    keysyms.len(),
-                );
+            KbEvent::Enter { keysyms, .. } => {
+                println!("Gained focus while {} keys pressed.", keysyms.len(),);
             }
             KbEvent::Leave { .. } => {
                 println!("Lost focus.");

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -104,6 +104,9 @@ fn main() {
                         rate, delay
                     );
             }
+            KbEvent::Modifiers { modifiers } => {
+                println!("Modifiers changed {:?}", modifiers);
+            }
         },
         move |repeat_event: KeyRepeatEvent, _| {
             println!("Repeated key {:x}.", repeat_event.keysym);

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -447,6 +447,11 @@ pub enum Event<'a> {
         /// delay (in milisecond) between a key press and the start of repetition
         delay: i32,
     },
+    /// The key modifiers have changed state
+    Modifiers {
+        /// current state of the modifiers
+        modifiers: ModifiersState,
+    }
 }
 
 /// An event sent at repeated intervals for certain keys determined by xkb_keymap_key_repeats
@@ -775,6 +780,7 @@ where
                         ..
                     } => {
                         state.update_modifiers(mods_depressed, mods_latched, mods_locked, group);
+                        event_impl(Event::Modifiers { modifiers: state.mods_state }, proxy);
                         if key_held.is_some() {
                             state_chan.lock().unwrap().0.send(()).unwrap();
                         }

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -447,7 +447,7 @@ pub enum Event<'a> {
     Modifiers {
         /// current state of the modifiers
         modifiers: ModifiersState,
-    }
+    },
 }
 
 /// An event sent at repeated intervals for certain keys determined by xkb_keymap_key_repeats
@@ -765,7 +765,12 @@ where
                         ..
                     } => {
                         state.update_modifiers(mods_depressed, mods_latched, mods_locked, group);
-                        event_impl(Event::Modifiers { modifiers: state.mods_state }, proxy);
+                        event_impl(
+                            Event::Modifiers {
+                                modifiers: state.mods_state,
+                            },
+                            proxy,
+                        );
                         if key_held.is_some() {
                             state_chan.lock().unwrap().0.send(()).unwrap();
                         }


### PR DESCRIPTION
When a modifier key is pressed then the modifiers will not show that key as active, for example pressing the shift key will show shift as inactive in the `Event::Key { modifiers, .. }`, therefore a modifiers event allows access to modifiers even when that modifier is the key being pressed.