### PR TITLE
Display title in the window header decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- BasicFrame: Display the title of the window in the window header
 - Pass `set_selection()` `Option<DataSource>` and `AutoThemer::init()` `Proxy<WlShm>` by reference
 - Window: add `set_theme()` function which takes an object implementing the trait `Theme` to adjust the look of window decorations
 - Window: add new `ConceptFrame` which provides an alternative to the `BasicFrame` window decorations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ dlib = "0.4"
 lazy_static = "1"
 memmap = "0.6"
 rand = "0.5"
-andrew = "0.1.1"
+andrew = "0.1.2"
 wayland-commons = { version = "0.21" }
 wayland-client = { version = "0.21", features = ["cursor"] }
 wayland-protocols = { version = "0.21", features = ["native_client", "unstable_protocols"] }

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -136,6 +136,11 @@ fn main() {
         // unless the system is utterly broken, though.
     ).expect("Failed to create a window !");
 
+    // Setting the windows title allows the compositor to know what your
+    // window should be called and the title will be display on the header bar
+    // of the windows decorations
+    window.set_title("Image Viewer".to_string());
+
     // The window needs access to pointer inputs to handle the user interaction
     // with it: resizing/moving the window, or clicking its button.
     // user interaction in wayland is done via the wl_seat object, which represent

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -55,6 +55,8 @@ fn main() {
         }
     }).expect("Failed to create a window !");
 
+    window.set_title("Kbd Input".to_string());
+
     let mut pools = DoubleMemPool::new(&env.shm, || {}).expect("Failed to create a memory pool !");
 
     /*

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -61,6 +61,7 @@ fn main() {
     }).expect("Failed to create a window !");
 
     window.new_seat(&seat);
+    window.set_title("Selection".to_string());
 
     let mut pools = DoubleMemPool::new(&env.shm, || {}).expect("Failed to create a memory pool !");
 

--- a/src/window/concept_frame.rs
+++ b/src/window/concept_frame.rs
@@ -1,8 +1,11 @@
 use std::cmp::max;
+use std::io::Read;
 use std::sync::{Arc, Mutex};
 
 use andrew::line;
 use andrew::shapes::rectangle;
+use andrew::text;
+use andrew::text::fontconfig;
 use andrew::Canvas;
 
 use wayland_client::protocol::{
@@ -268,6 +271,8 @@ pub struct ConceptFrame {
     themer: AutoThemer,
     surface_version: u32,
     theme: Box<Theme>,
+    title: Option<String>,
+    font_data: Option<Vec<u8>>,
 }
 
 impl Frame for ConceptFrame {
@@ -308,6 +313,8 @@ impl Frame for ConceptFrame {
             themer: AutoThemer::init(None, compositor.clone(), &shm),
             surface_version: compositor.version(),
             theme: Box::new(DefaultTheme),
+            title: None,
+            font_data: None,
         })
     }
 
@@ -496,6 +503,63 @@ impl Frame for ConceptFrame {
                             }).collect::<Vec<Location>>(),
                         &*self.theme,
                     );
+
+                    if let Some(title) = self.title.clone() {
+                        // If theres no stored font data, find the first ttf regular sans font and
+                        // store it
+                        if self.font_data.is_none() {
+                            if let Some(font) = fontconfig::FontConfig::new()
+                                .unwrap()
+                                .get_regular_family_fonts("sans")
+                                .unwrap()
+                                .iter()
+                                .filter_map(|p| {
+                                    if p.extension().unwrap() == "ttf" {
+                                        Some(p)
+                                    } else {
+                                        None
+                                    }
+                                }).nth(0)
+                            {
+                                let mut font_data = Vec::new();
+                                if let Ok(mut file) = ::std::fs::File::open(font) {
+                                    match file.read_to_end(&mut font_data) {
+                                        Ok(_) => self.font_data = Some(font_data),
+                                        Err(err) => eprintln!("Could not read font file: {}", err),
+                                    }
+                                }
+                            }
+                        }
+
+                        // Create text from stored title and font data
+                        if let Some(ref font_data) = self.font_data {
+                            let mut title_text = text::Text::new(
+                                (0, HEADER_SIZE as usize / 2 - 8),
+                                [0, 0, 0, 255],
+                                font_data,
+                                17.0,
+                                1.0,
+                                title,
+                            );
+
+                            // Check if text is bigger then the avaliable width
+                            if (width as isize - 88 - 4 * BUTTON_SPACE as isize)
+                                > (title_text.get_width() + BUTTON_SPACE as usize) as isize
+                            {
+                                title_text.pos.0 =
+                                    (width as usize) / 2 - (title_text.get_width() / 2);
+                                // Adjust position for buttons if both compete for space
+                                if (width as usize) / 2 + (title_text.get_width() / 2)
+                                    > (width - 88 - 2 * 2 * BUTTON_SPACE) as usize
+                                {
+                                    title_text.pos.0 -= ((width as usize) / 2
+                                        + (title_text.get_width() / 2))
+                                        - (width - 88 - 2 * 2 * BUTTON_SPACE) as usize;
+                                }
+                                header_canvas.draw(&title_text);
+                            }
+                        }
+                    }
                 }
 
                 // For each pixel in borders
@@ -694,6 +758,10 @@ impl Frame for ConceptFrame {
 
     fn set_theme<T: Theme>(&mut self, theme: T) {
         self.theme = Box::new(theme)
+    }
+
+    fn set_title(&mut self, title: String) {
+        self.title = Some(title);
     }
 }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -380,6 +380,7 @@ impl<F: Frame + 'static> Window<F> {
     /// This string may be used to identify the surface in a task bar, window list, or other
     /// user interface elements provided by the compositor.
     pub fn set_title(&self, title: String) {
+        self.frame.lock().unwrap().set_title(title.clone());
         self.shell_surface.set_title(title);
     }
 
@@ -621,6 +622,10 @@ pub trait Frame: Sized + Send {
     fn location(&self) -> (i32, i32) {
         (0, 0)
     }
+
     /// Sets the theme for the frame
     fn set_theme<T: Theme>(&mut self, theme: T);
+
+    /// Sets the frames title
+    fn set_title(&mut self, title: String);
 }


### PR DESCRIPTION
This is a work in progress PR for titled windows. It currently uses rusttype and fontconfig-rs to draw text and select fonts.

![screenshot from 2018-09-17 18-25-46](https://user-images.githubusercontent.com/40879396/45618159-66b14b00-baa7-11e8-8d14-9cef4ffb97ee.png)

This PR currently has some issues with the loading of '.otf' fonts (this seems to be to do with rusttype) as well as the use of font_loader which depends on fontconfig-rs meaning projects using both the client-toolkit and fontconfig-rs will get a cargo multiple native link error.

Are titled windows something you think would be nice to have BasicFrame support or do you think its too complex?

- [x] Better selection of window fonts (using gsettings and kde equivalent to find default window title font) (wont fix for the time being)
- [ ] Have the title shrink to 'part_of_title...' (for example 'alacrit...') instead of completely disappearing
- [x] Try to remove fontconfig-rs dependency
- [x] Investigate rusttype '.otf' support (going to just use '.ttf' for now)