### PR TITLE
Cleanup - Handle function errors, remove unnecessary assignment, pass arguments more efficiently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Pass `set_selection()` `Option<DataSource>` and `AutoThemer::init()` `Proxy<WlShm>` by reference
 - Window: add `set_theme()` function which takes an object implementing the trait `Theme` to adjust the look of window decorations
 - Window: add new `ConceptFrame` which provides an alternative to the `BasicFrame` window decorations
 - MemPool: add `mmap` method

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -69,7 +69,7 @@ fn main() {
 
     window.new_seat(&seat);
 
-    let _keyboard = map_keyboard_auto_with_repeat(
+    map_keyboard_auto_with_repeat(
         &seat,
         KeyRepeatKind::System,
         move |event: KbEvent, _| match event {
@@ -106,12 +106,12 @@ fn main() {
                 println!(" -> Received text \"{}\".", txt);
             }
         },
-    );
+    ).expect("Failed to map keyboard");
 
     if !env.shell.needs_configure() {
         // initial draw to bootstrap on wl_shell
         if let Some(pool) = pools.pool() {
-            redraw(pool, window.surface(), dimensions)
+            redraw(pool, window.surface(), dimensions).expect("Failed to draw")
         }
         window.refresh();
     }
@@ -131,7 +131,7 @@ fn main() {
                 println!("Window states: {:?}", states);
                 window.refresh();
                 if let Some(pool) = pools.pool() {
-                    redraw(pool, window.surface(), dimensions)
+                    redraw(pool, window.surface(), dimensions).expect("Failed to draw")
                 }
             }
             None => {}
@@ -142,12 +142,16 @@ fn main() {
     }
 }
 
-fn redraw(pool: &mut MemPool, surface: &Proxy<wl_surface::WlSurface>, (buf_x, buf_y): (u32, u32)) {
+fn redraw(
+    pool: &mut MemPool,
+    surface: &Proxy<wl_surface::WlSurface>,
+    (buf_x, buf_y): (u32, u32),
+) -> Result<(), ::std::io::Error> {
     // resize the pool if relevant
     pool.resize((4 * buf_x * buf_y) as usize)
         .expect("Failed to resize the memory pool.");
     // write the contents, a nice color gradient =)
-    let _ = pool.seek(SeekFrom::Start(0));
+    pool.seek(SeekFrom::Start(0))?;
     {
         let mut writer = BufWriter::new(&mut *pool);
         for i in 0..(buf_x * buf_y) {
@@ -156,9 +160,9 @@ fn redraw(pool: &mut MemPool, surface: &Proxy<wl_surface::WlSurface>, (buf_x, bu
             let r: u32 = min(((buf_x - x) * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
             let g: u32 = min((x * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
             let b: u32 = min(((buf_x - x) * 0xFF) / buf_x, (y * 0xFF) / buf_y);
-            let _ = writer.write_u32::<NativeEndian>((0xFF << 24) + (r << 16) + (g << 8) + b);
+            writer.write_u32::<NativeEndian>((0xFF << 24) + (r << 16) + (g << 8) + b)?;
         }
-        let _ = writer.flush();
+        writer.flush()?;
     }
     // get a buffer and attach it
     let new_buffer = pool.buffer(
@@ -170,4 +174,5 @@ fn redraw(pool: &mut MemPool, surface: &Proxy<wl_surface::WlSurface>, (buf_x, bu
     );
     surface.attach(Some(&new_buffer), 0, 0);
     surface.commit();
+    Ok(())
 }

--- a/examples/pointer_input.rs
+++ b/examples/pointer_input.rs
@@ -103,7 +103,7 @@ fn main() {
     if !env.shell.needs_configure() {
         // initial draw to bootstrap on wl_shell
         if let Some(pool) = pools.pool() {
-            redraw(pool, window.surface(), dimensions)
+            redraw(pool, window.surface(), dimensions).expect("Failed to draw")
         }
         window.refresh();
     }
@@ -123,7 +123,7 @@ fn main() {
                 println!("Window states: {:?}", states);
                 window.refresh();
                 if let Some(pool) = pools.pool() {
-                    redraw(pool, window.surface(), dimensions)
+                    redraw(pool, window.surface(), dimensions).expect("Failed to draw")
                 }
             }
             None => {}
@@ -134,12 +134,16 @@ fn main() {
     }
 }
 
-fn redraw(pool: &mut MemPool, surface: &Proxy<wl_surface::WlSurface>, (buf_x, buf_y): (u32, u32)) {
+fn redraw(
+    pool: &mut MemPool,
+    surface: &Proxy<wl_surface::WlSurface>,
+    (buf_x, buf_y): (u32, u32),
+) -> Result<(), ::std::io::Error> {
     // resize the pool if relevant
     pool.resize((4 * buf_x * buf_y) as usize)
         .expect("Failed to resize the memory pool.");
     // write the contents, a nice color gradient =)
-    let _ = pool.seek(SeekFrom::Start(0));
+    pool.seek(SeekFrom::Start(0))?;
     {
         let mut writer = BufWriter::new(&mut *pool);
         for i in 0..(buf_x * buf_y) {
@@ -148,9 +152,9 @@ fn redraw(pool: &mut MemPool, surface: &Proxy<wl_surface::WlSurface>, (buf_x, bu
             let r: u32 = min(((buf_x - x) * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
             let g: u32 = min((x * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
             let b: u32 = min(((buf_x - x) * 0xFF) / buf_x, (y * 0xFF) / buf_y);
-            let _ = writer.write_u32::<NativeEndian>((0xFF << 24) + (r << 16) + (g << 8) + b);
+            writer.write_u32::<NativeEndian>((0xFF << 24) + (r << 16) + (g << 8) + b)?;
         }
-        let _ = writer.flush();
+        writer.flush()?;
     }
     // get a buffer and attach it
     let new_buffer = pool.buffer(
@@ -162,4 +166,5 @@ fn redraw(pool: &mut MemPool, surface: &Proxy<wl_surface::WlSurface>, (buf_x, bu
     );
     surface.attach(Some(&new_buffer), 0, 0);
     surface.commit();
+    Ok(())
 }

--- a/src/data_device/data_device.rs
+++ b/src/data_device/data_device.rs
@@ -260,7 +260,7 @@ impl DataDevice {
     ///
     /// Correspond to traditional copy/paste behavior. Setting the
     /// source to `None` will clear the selection.
-    pub fn set_selection(&self, source: Option<DataSource>, serial: u32) {
+    pub fn set_selection(&self, source: &Option<DataSource>, serial: u32) {
         self.device
             .set_selection(source.as_ref().map(|s| &s.source), serial);
     }

--- a/src/data_device/data_offer.rs
+++ b/src/data_device/data_offer.rs
@@ -98,7 +98,10 @@ impl DataOffer {
         let (readfd, writefd) = pipe2(OFlag::O_CLOEXEC).map_err(|_| ())?;
 
         self.offer.receive(mime_type, writefd);
-        let _ = close(writefd);
+
+        if let Err(err) = close(writefd) {
+            eprintln!("[SCTK] Data offer: failed to close write pipe: {}", err);
+        }
 
         Ok(unsafe { FromRawFd::from_raw_fd(readfd) })
     }

--- a/src/data_device/data_source.rs
+++ b/src/data_device/data_source.rs
@@ -80,7 +80,7 @@ pub enum DataSourceEvent {
 
 fn data_source_impl<Impl>(
     evt: wl_data_source::Event,
-    source: Proxy<wl_data_source::WlDataSource>,
+    source: &Proxy<wl_data_source::WlDataSource>,
     implem: &mut Impl,
 ) where
     Impl: FnMut(DataSourceEvent),
@@ -124,7 +124,7 @@ impl DataSource {
         let source = mgr
             .create_data_source(|source| {
                 source.implement(
-                    move |evt, source: Proxy<_>| data_source_impl(evt, source, &mut implem),
+                    move |evt, source: Proxy<_>| data_source_impl(evt, &source, &mut implem),
                     (),
                 )
             }).expect("Provided a dead data device manager to create a data source.");
@@ -154,7 +154,7 @@ impl DataSource {
         let source = mgr
             .create_data_source(|source| {
                 source.implement_nonsend(
-                    move |evt, source: Proxy<_>| data_source_impl(evt, source, &mut implem),
+                    move |evt, source: Proxy<_>| data_source_impl(evt, &source, &mut implem),
                     (),
                     token,
                 )

--- a/src/keyboard/ffi.rs
+++ b/src/keyboard/ffi.rs
@@ -38,6 +38,7 @@ pub const XKB_LED_INVALID     :u32 = 0xffffffff;
 pub const XKB_KEYCODE_MAX     :u32 = 0xffffffff - 1;
 
 #[repr(C)]
+#[derive(Copy, Clone)]
 pub struct xkb_rule_names {
     pub rules:   *const c_char,
     pub model:   *const c_char ,

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -655,7 +655,6 @@ where
                                 state.get_utf8_raw(key)
                             }
                         };
-                        let modifiers = state.mods_state;
 
                         if key_state == wl_keyboard::KeyState::Pressed {
                             event_impl(

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -35,9 +35,9 @@ impl AutoThemer {
     pub fn init(
         name: Option<&str>,
         compositor: Proxy<wl_compositor::WlCompositor>,
-        shm: Proxy<wl_shm::WlShm>,
+        shm: &Proxy<wl_shm::WlShm>,
     ) -> AutoThemer {
-        match ThemeManager::init(name, compositor, shm) {
+        match ThemeManager::init(name, compositor, &shm) {
             Ok(mgr) => AutoThemer::Themed(mgr),
             Err(()) => AutoThemer::UnThemed,
         }

--- a/src/pointer/theme.rs
+++ b/src/pointer/theme.rs
@@ -32,7 +32,7 @@ impl ThemeManager {
     pub fn init(
         name: Option<&str>,
         compositor: Proxy<wl_compositor::WlCompositor>,
-        shm: Proxy<wl_shm::WlShm>,
+        shm: &Proxy<wl_shm::WlShm>,
     ) -> Result<ThemeManager, ()> {
         if !is_available() {
             return Err(());

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -521,7 +521,12 @@ impl Frame for BasicFrame {
                         *b = 0x00;
                     }
                 }
-                let _ = mmap.flush();
+                if let Err(err) = mmap.flush() {
+                    eprintln!(
+                        "[SCTK] Basic frame: failed to flush frame memory map: {}",
+                        err
+                    );
+                }
             }
 
             // Create the buffers
@@ -731,7 +736,9 @@ fn change_pointer(pointer: &AutoPointer, location: Location, serial: Option<u32>
         Location::TopLeft => "top_left_corner",
         _ => "left_ptr",
     };
-    let _ = pointer.set_cursor(name, serial);
+    if pointer.set_cursor(name, serial).is_err() {
+        eprintln!("[SCTK] Basic frame: failed to set cursor");
+    }
 }
 
 fn request_for_location(

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -316,7 +316,7 @@ impl Frame for BasicFrame {
             active: false,
             hidden: false,
             pointers: Vec::new(),
-            themer: AutoThemer::init(None, compositor.clone(), shm.clone()),
+            themer: AutoThemer::init(None, compositor.clone(), &shm),
             surface_version: compositor.version(),
             theme: Box::new(DefaultTheme),
         })
@@ -510,8 +510,8 @@ impl Frame for BasicFrame {
                                 } else {
                                     None
                                 }
-                            }).collect(),
-                        &self.theme,
+                            }).collect::<Vec<Location>>(),
+                        &*self.theme,
                     );
                 }
 
@@ -776,8 +776,8 @@ fn draw_buttons(
     canvas: &mut Canvas,
     width: u32,
     maximizable: bool,
-    mouses: &Vec<Location>,
-    theme: &Box<Theme>,
+    mouses: &[Location],
+    theme: &Theme,
 ) {
     // draw up to 3 buttons, depending on the width of the window
     // color of the button depends on whether a pointer is on it, and the maximizable

--- a/src/window/concept_frame.rs
+++ b/src/window/concept_frame.rs
@@ -305,7 +305,7 @@ impl Frame for ConceptFrame {
             active: false,
             hidden: false,
             pointers: Vec::new(),
-            themer: AutoThemer::init(None, compositor.clone(), shm.clone()),
+            themer: AutoThemer::init(None, compositor.clone(), &shm),
             surface_version: compositor.version(),
             theme: Box::new(DefaultTheme),
         })
@@ -494,7 +494,7 @@ impl Frame for ConceptFrame {
                                     None
                                 }
                             }).collect::<Vec<Location>>(),
-                        &self.theme,
+                        &*self.theme,
                     );
                 }
 
@@ -760,7 +760,7 @@ fn draw_buttons(
     width: u32,
     maximizable: bool,
     mouses: &[Location],
-    theme: &Box<Theme>,
+    theme: &Theme,
 ) {
     // Draw seperator between header and window contents
     let division_line = line::Line::new(

--- a/src/window/concept_frame.rs
+++ b/src/window/concept_frame.rs
@@ -504,7 +504,12 @@ impl Frame for ConceptFrame {
                         *b = 0x00;
                     }
                 }
-                mmap.flush().unwrap();
+                if let Err(err) = mmap.flush() {
+                    eprintln!(
+                        "[SCTK] Basic frame: failed to flush frame memory map: {}",
+                        err
+                    );
+                }
             }
 
             // Create the buffers
@@ -714,7 +719,9 @@ fn change_pointer(pointer: &AutoPointer, location: Location, serial: Option<u32>
         Location::TopLeft => "top_left_corner",
         _ => "left_ptr",
     };
-    pointer.set_cursor(name, serial).unwrap()
+    if pointer.set_cursor(name, serial).is_err() {
+        eprintln!("[SCTK] Basic frame: failed to set cursor");
+    }
 }
 
 fn request_for_location(


### PR DESCRIPTION
I think its better to panic on functions that return results even if it doesn't matter too much if the function fails, or at least they should be printed to stderr to log the failure.

A few arguments can be passed more efficiently, proxies by reference probably don't save a lot performance wise but are more idiomatic and now's probably a good time to change these considering the next release will be breaking.