### PR TITLE
Request frame refresh on `set_title()`

### DIFF
--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -779,6 +779,7 @@ impl Frame for BasicFrame {
 
     fn set_title(&mut self, title: String) {
         self.title = Some(title);
+        (&mut *self.inner.implem.lock().unwrap())(FrameRequest::Refresh, 0);
     }
 }
 

--- a/src/window/concept_frame.rs
+++ b/src/window/concept_frame.rs
@@ -762,6 +762,7 @@ impl Frame for ConceptFrame {
 
     fn set_title(&mut self, title: String) {
         self.title = Some(title);
+        (&mut *self.inner.implem.lock().unwrap())(FrameRequest::Refresh, 0);
     }
 }
 


### PR DESCRIPTION
Decorations now need to be refreshed on `set_title()` because the window title is displayed in the header