### PR TITLE
Cursor scaling

### DIFF
--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -78,8 +78,8 @@ fn main() {
     // Now we actually create the window. The type parameter `ConceptFrame` here
     // specifies the type we want to use to draw the borders. To create your own
     // decorations you just need an object to implement the `Frame` trait.
-    let mut window = Window::<ConceptFrame>::init_from_env(
-        &env,               // the environment containing the wayland globals
+    let mut window = Window::<ConceptFrame>::init(
+        &env,        // the environment containing the wayland globals
         surface,            // the wl_surface that serves as the basis of this window
         image.dimensions(), // the initial internal dimensions of the window
         move |evt| {

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -10,7 +10,6 @@ use byteorder::{NativeEndian, WriteBytesExt};
 use sctk::keyboard::{
     map_keyboard_auto_with_repeat, Event as KbEvent, KeyRepeatEvent, KeyRepeatKind,
 };
-use sctk::reexports::client::protocol::wl_compositor::RequestsTrait as CompositorRequests;
 use sctk::reexports::client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
 use sctk::reexports::client::protocol::{wl_shm, wl_surface};
 use sctk::reexports::client::{Display, Proxy};
@@ -32,15 +31,12 @@ fn main() {
      * Init wayland objects
      */
 
-    let surface = env
-        .compositor
-        .create_surface(|surface| surface.implement(|_, _| {}, ()))
-        .unwrap();
+    let surface = env.create_surface(|_, _| {});
 
     let next_action = Arc::new(Mutex::new(None::<WEvent>));
 
     let waction = next_action.clone();
-    let mut window = Window::<ConceptFrame>::init_from_env(&env, surface, dimensions, move |evt| {
+    let mut window = Window::<ConceptFrame>::init(&env, surface, dimensions, move |evt| {
         let mut next_action = waction.lock().unwrap();
         // Keep last event in priority order : Close > Configure > Refresh
         let replace = match (&evt, &*next_action) {

--- a/examples/pointer_input.rs
+++ b/examples/pointer_input.rs
@@ -81,7 +81,7 @@ fn main() {
     let mut window = {
         let window_config = window_config.clone();
         let dimensions = window_config.lock().unwrap().dimensions();
-        Window::<ConceptFrame>::init_from_env(&env, surface, dimensions, move |event| {
+        Window::<ConceptFrame>::init(&env, surface, dimensions, move |event| {
             let mut guard = window_config.lock().unwrap();
             if let WEvent::Configure { new_size, .. } = event {
                 if let Some((width, height)) = new_size {

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -45,7 +45,7 @@ fn main() {
     let next_action = Arc::new(Mutex::new(None::<WEvent>));
 
     let waction = next_action.clone();
-    let mut window = Window::<ConceptFrame>::init_from_env(&env, surface, dimensions, move |evt| {
+    let mut window = Window::<ConceptFrame>::init(&env, surface, dimensions, move |evt| {
         let mut next_action = waction.lock().unwrap();
         // Keep last event in priority order : Close > Configure > Refresh
         let replace = match (&evt, &*next_action) {

--- a/src/pointer/theme.rs
+++ b/src/pointer/theme.rs
@@ -2,12 +2,75 @@ use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use wayland_client::cursor::{is_available, load_theme, CursorTheme};
 use wayland_client::protocol::{wl_compositor, wl_pointer, wl_seat, wl_shm, wl_surface};
-use wayland_client::{NewProxy, Proxy, QueueToken};
+use wayland_client::Proxy;
 
-use wayland_client::protocol::wl_compositor::RequestsTrait as CompositorRequests;
 use wayland_client::protocol::wl_pointer::RequestsTrait as PointerRequests;
 use wayland_client::protocol::wl_seat::RequestsTrait as SeatRequests;
 use wayland_client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
+
+use env::Environment;
+use output::OutputMgr;
+use surface::SurfaceManager;
+
+pub struct DpiCursorTheme {
+    output_manager: OutputMgr,
+    shm: Proxy<wl_shm::WlShm>,
+    theme_name: Option<String>,
+    theme: CursorTheme,
+    dpi_factor: i32,
+}
+
+impl DpiCursorTheme {
+    pub fn new(environment: &Environment, theme_name: Option<String>) -> Self {
+        let output_manager = environment.outputs.clone();
+        let shm = environment.shm.clone();
+        let (dpi_factor, theme) = DpiCursorTheme::load(&output_manager, &shm, theme_name.as_ref());
+
+        DpiCursorTheme {
+            output_manager,
+            shm,
+            theme_name,
+            theme,
+            dpi_factor,
+        }
+    }
+
+    pub fn load(output_manager: &OutputMgr, shm: &Proxy<wl_shm::WlShm>, name: Option<&String>) -> (i32, CursorTheme) {
+        let dpi_factor = output_manager
+            .with_all(|outputs| {
+                outputs
+                    .iter()
+                    .map(|&(_, _, ref info)| info.scale_factor)
+                    .max()
+            })
+            .unwrap_or(1);
+
+        // No way to find the cursor size
+        // Good cursor size for scale factors 1, 2 where determined
+        // to be 16 and 48. A linear function is fitted to those points.
+        // 32 * 1 - 16 = 16
+        // 32 * 2 - 16 = 48
+        let size = 32 * dpi_factor - 16;
+
+        let theme = load_theme(name.map(|s| &**s), size as u32, shm);
+
+        (dpi_factor, theme)
+    }
+
+    pub fn theme(&self) -> &CursorTheme {
+        &self.theme
+    }
+
+    pub fn dpi_factor(&self) -> i32 {
+        self.dpi_factor
+    }
+
+    pub fn reload(&mut self) {
+        let (dpi_factor, theme) = DpiCursorTheme::load(&self.output_manager, &self.shm, self.theme_name.as_ref());
+        self.dpi_factor = dpi_factor;
+        self.theme = theme;
+    }
+}
 
 /// Wrapper managing a system theme for pointer images
 ///
@@ -19,8 +82,9 @@ use wayland_client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
 ///
 /// Note that it is however not `Send` nor `Sync`
 pub struct ThemeManager {
-    theme: Arc<Mutex<CursorTheme>>,
     compositor: Proxy<wl_compositor::WlCompositor>,
+    surface_manager: SurfaceManager,
+    theme: Arc<Mutex<DpiCursorTheme>>,
 }
 
 impl ThemeManager {
@@ -29,35 +93,19 @@ impl ThemeManager {
     /// Will use the default theme of the system if name is `None`.
     ///
     /// Fails if `libwayland-cursor` is not available.
-    pub fn init(
-        name: Option<&str>,
-        compositor: Proxy<wl_compositor::WlCompositor>,
-        shm: &Proxy<wl_shm::WlShm>,
-    ) -> Result<ThemeManager, ()> {
+    pub fn init(environment: &Environment, theme_name: Option<String>) -> Result<Self, ()> {
         if !is_available() {
             return Err(());
         }
 
-        Ok(ThemeManager {
-            compositor,
-            theme: Arc::new(Mutex::new(load_theme(name, 16, &shm))),
-        })
-    }
+        let theme = Arc::new(Mutex::new(DpiCursorTheme::new(
+            environment,
+            theme_name,
+        )));
 
-    /// Wrap a pointer to theme it
-    pub fn theme_pointer(&self, pointer: Proxy<wl_pointer::WlPointer>) -> ThemedPointer {
-        let surface = self
-            .compositor
-            .create_surface(|surface| surface.implement(|_, _| {}, ()))
-            .unwrap();
-        ThemedPointer {
-            pointer,
-            inner: Arc::new(Mutex::new(PointerInner {
-                surface,
-                theme: self.theme.clone(),
-                last_serial: 0,
-            })),
-        }
+        let compositor = environment.compositor.clone();
+        let surface_manager = environment.surface_manager.clone();
+        Ok(ThemeManager { compositor, surface_manager, theme })
     }
 
     /// Initialize a new pointer as a ThemedPointer with an adapter implementation
@@ -75,10 +123,15 @@ impl ThemeManager {
         Impl: FnMut(wl_pointer::Event, ThemedPointer) + Send + 'static,
         UD: Send + Sync + 'static,
     {
-        let surface = self
-            .compositor
-            .create_surface(|surface| surface.implement(|_, _| {}, ()))
-            .unwrap();
+        let surface = {
+            let theme = self.theme.clone();
+            self.surface_manager.create_surface(&self.compositor, move |dpi, _surface| {
+                let mut theme = theme.lock().unwrap();
+                if dpi > theme.dpi_factor() {
+                    theme.reload();
+                }
+            })
+        };
 
         let inner = Arc::new(Mutex::new(PointerInner {
             surface,
@@ -109,59 +162,11 @@ impl ThemeManager {
             inner: inner2,
         }
     }
-
-    /// Initialize a new pointer as a ThemedPointer with an adapter implementation
-    ///
-    /// Like `theme_pointer_with_impl` but allows you to have a non-`Send` implementation.
-    ///
-    /// **Unsafe** for the same reasons as `NewProxy::implement_nonsend`.
-    pub unsafe fn theme_pointer_with_nonsend_impl<Impl, UD>(
-        &self,
-        pointer: NewProxy<wl_pointer::WlPointer>,
-        mut implementation: Impl,
-        user_data: UD,
-        token: &QueueToken,
-    ) -> ThemedPointer
-    where
-        Impl: FnMut(wl_pointer::Event, ThemedPointer) + 'static,
-        UD: Send + Sync + 'static,
-    {
-        let surface = self
-            .compositor
-            .create_surface(|surface| surface.implement(|_, _| {}, ()))
-            .unwrap();
-
-        let inner = Arc::new(Mutex::new(PointerInner {
-            surface,
-            theme: self.theme.clone(),
-            last_serial: 0,
-        }));
-        let inner2 = inner.clone();
-
-        let pointer = pointer.implement_nonsend(
-            move |event, ptr| {
-                implementation(
-                    event,
-                    ThemedPointer {
-                        pointer: ptr,
-                        inner: inner.clone(),
-                    },
-                )
-            },
-            user_data,
-            token,
-        );
-
-        ThemedPointer {
-            pointer,
-            inner: inner2,
-        }
-    }
 }
 
 struct PointerInner {
     surface: Proxy<wl_surface::WlSurface>,
-    theme: Arc<Mutex<CursorTheme>>,
+    theme: Arc<Mutex<DpiCursorTheme>>,
     last_serial: u32,
 }
 
@@ -194,7 +199,7 @@ impl ThemedPointer {
         } = *inner;
 
         let theme = theme.lock().unwrap();
-        let cursor = theme.get_cursor(name).ok_or(())?;
+        let cursor = theme.theme().get_cursor(name).ok_or(())?;
         let buffer = cursor.frame_buffer(0).ok_or(())?;
         let (w, h, hx, hy) = cursor
             .frame_info(0)
@@ -206,6 +211,7 @@ impl ThemedPointer {
         }
 
         surface.attach(Some(&buffer), 0, 0);
+        surface.set_buffer_scale(theme.dpi_factor());
         if surface.version() >= 4 {
             surface.damage_buffer(0, 0, w, h);
         } else {

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -19,6 +19,7 @@ use wayland_client::protocol::wl_subsurface::RequestsTrait as SubsurfaceRequests
 use wayland_client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
 
 use super::{ButtonState, Frame, FrameRequest, Theme};
+use env::Environment;
 use pointer::{AutoPointer, AutoThemer};
 use utils::DoubleMemPool;
 
@@ -289,13 +290,15 @@ pub struct BasicFrame {
 
 impl Frame for BasicFrame {
     type Error = ::std::io::Error;
+
     fn init(
+        environment: &Environment,
         base_surface: &Proxy<wl_surface::WlSurface>,
-        compositor: &Proxy<wl_compositor::WlCompositor>,
-        subcompositor: &Proxy<wl_subcompositor::WlSubcompositor>,
-        shm: &Proxy<wl_shm::WlShm>,
         implementation: Box<FnMut(FrameRequest, u32) + Send>,
     ) -> Result<BasicFrame, ::std::io::Error> {
+        let compositor = &environment.compositor;
+        let subcompositor = &environment.subcompositor;
+        let shm = &environment.shm;
         let parts = [
             Part::new(base_surface, compositor, subcompositor),
             Part::new(base_surface, compositor, subcompositor),
@@ -322,7 +325,7 @@ impl Frame for BasicFrame {
             active: false,
             hidden: false,
             pointers: Vec::new(),
-            themer: AutoThemer::init(None, compositor.clone(), &shm),
+            themer: AutoThemer::init(environment, None),
             surface_version: compositor.version(),
             theme: Box::new(DefaultTheme),
             title: None,

--- a/src/window/concept_frame.rs
+++ b/src/window/concept_frame.rs
@@ -20,6 +20,7 @@ use wayland_client::protocol::wl_subsurface::RequestsTrait as SubsurfaceRequests
 use wayland_client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
 
 use super::{ButtonState, Frame, FrameRequest, Theme};
+use env::Environment;
 use pointer::{AutoPointer, AutoThemer};
 use utils::DoubleMemPool;
 
@@ -278,13 +279,15 @@ pub struct ConceptFrame {
 
 impl Frame for ConceptFrame {
     type Error = ::std::io::Error;
+
     fn init(
+        environment: &Environment,
         base_surface: &Proxy<wl_surface::WlSurface>,
-        compositor: &Proxy<wl_compositor::WlCompositor>,
-        subcompositor: &Proxy<wl_subcompositor::WlSubcompositor>,
-        shm: &Proxy<wl_shm::WlShm>,
         implementation: Box<FnMut(FrameRequest, u32) + Send>,
     ) -> Result<ConceptFrame, ::std::io::Error> {
+        let compositor = &environment.compositor;
+        let subcompositor = &environment.subcompositor;
+        let shm = &environment.shm;
         let parts = [
             Part::new(base_surface, compositor, subcompositor),
             Part::new(base_surface, compositor, subcompositor),
@@ -311,7 +314,7 @@ impl Frame for ConceptFrame {
             active: false,
             hidden: false,
             pointers: Vec::new(),
-            themer: AutoThemer::init(None, compositor.clone(), &shm),
+            themer: AutoThemer::init(environment.clone(), None),
             surface_version: compositor.version(),
             theme: Box::new(DefaultTheme),
             title: None,


### PR DESCRIPTION
Implements dpi aware cursor loading.

* The theme manager api has changed, but that doesn't affect the andrew or winit crates (the only ones published on crates.io) I also removed a bunch of code that isn't used anywhere in the crates.io universe. This can be avoided if there is really a reason to keep it around.

* The frame api has a init_from_environment function added to it with a stub to use the init implementation. This disables any cursor theaming.

* The window api changes slightly, which IMO isn't a big deal, the andrew and winit crates should be impacted minimally, but it avoids maintaining a bunch of code we don't need.