### PR TITLE
Require a `refresh()` after `set_title()` for changes to take effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Window: `set_title()` now requires a manual `refresh()` for the change to take effect
+
 ## 0.4.4 -- 2018-12-27
 
 - Shell: expose shell interface and add `create_shell_surface` to `Environment`.

--- a/src/window/basic_frame.rs
+++ b/src/window/basic_frame.rs
@@ -790,7 +790,6 @@ impl Frame for BasicFrame {
 
     fn set_title(&mut self, title: String) {
         self.title = Some(title);
-        (&mut *self.inner.implem.lock().unwrap())(FrameRequest::Refresh, 0);
     }
 }
 

--- a/src/window/concept_frame.rs
+++ b/src/window/concept_frame.rs
@@ -771,7 +771,6 @@ impl Frame for ConceptFrame {
 
     fn set_title(&mut self, title: String) {
         self.title = Some(title);
-        (&mut *self.inner.implem.lock().unwrap())(FrameRequest::Refresh, 0);
     }
 }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -388,6 +388,9 @@ impl<F: Frame + 'static> Window<F> {
     ///
     /// This string may be used to identify the surface in a task bar, window list, or other
     /// user interface elements provided by the compositor.
+    ///
+    /// You need to call `refresh()` afterwards for this to properly
+    /// take effect.
     pub fn set_title(&self, title: String) {
         self.frame.lock().unwrap().set_title(title.clone());
         self.shell_surface.set_title(title);


### PR DESCRIPTION
The automatic triggering of a refresh after calling `set_title()` when also handling a window event causes a mutex deadlock. 

Requiring the user to manually refresh the window after setting the title fixes this issue.

I cannot find any other instances where this sort of deadlock would occur but would be happy to include them in this PR if there are.

Fixes https://github.com/Smithay/client-toolkit/issues/56