### PR TITLE
Update nix dependency to 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "smithay/client-toolkit" }
 
 [dependencies]
 bitflags = "1.0"
-nix = "0.12"
+nix = "0.13"
 dlib = "0.4"
 lazy_static = "1"
 memmap = "0.7"


### PR DESCRIPTION
While wayland itself is not supported on OpenBSD (and probably never will be) Smithay/client-toolkit is a dependency of jwilm/alacritty even when wayland is not in use.

There is a new nix release which fixes a build issue on OpenBSD, please see below.

Also, would it be possible to do a version bump for Smithay/client-toolkit to 0.4.5 ? I can add the relevant commit in this PR if it's ok. This is so I can update the downstream dependency in alacritty.

```bash
user1 ~/ALACRITTY/client-toolkit $ cargo build
    Updating crates.io index
 Downloading crates ...
  Downloaded wayland-client v0.21.4
  Downloaded wayland-protocols v0.21.4
  Downloaded wayland-commons v0.21.4
  Downloaded xdg v2.1.0
  Downloaded libc v0.2.47
  Downloaded wayland-sys v0.21.4
  Downloaded rusttype v0.7.2
  Downloaded approx v0.3.0
  Downloaded stb_truetype v0.2.4
  Downloaded wayland-scanner v0.21.4
  Downloaded arrayvec v0.4.7
   Compiling cc v1.0.25
   Compiling semver-parser v0.7.0
   Compiling libc v0.2.47
   Compiling xml-rs v0.8.0
   Compiling nix v0.11.0
   Compiling num-traits v0.2.6
   Compiling void v1.0.2
   Compiling lazy_static v1.2.0
   Compiling autocfg v0.1.1
   Compiling cfg-if v0.1.6
   Compiling bitflags v1.0.4
   Compiling nodrop v0.1.13
   Compiling byteorder v1.2.7
   Compiling downcast-rs v1.0.3
   Compiling nix v0.12.0
   Compiling same-file v1.0.4
   Compiling rand_core v0.3.0
   Compiling xdg v2.1.0
   Compiling arrayvec v0.4.7
   Compiling semver v0.9.0
   Compiling walkdir v2.2.7
   Compiling rand_chacha v0.1.1
   Compiling rand v0.6.4
   Compiling stb_truetype v0.2.4
   Compiling rand_hc v0.1.0
   Compiling rand_isaac v0.1.1
   Compiling rand_xorshift v0.1.1
   Compiling rustc_version v0.2.3
   Compiling libloading v0.5.0
   Compiling wayland-scanner v0.21.4
   Compiling rand_pcg v0.1.1
   Compiling rand_os v0.1.1
   Compiling memmap v0.7.0
   Compiling dlib v0.4.1
   Compiling wayland-sys v0.21.4
error[E0425]: cannot find function `lutimes` in module `libc`
   --> /home/user1/.cargo/registry/src/github.com-1ecc6299db9ec823/nix-0.12.0/src/sys/stat.rs:216:15
    |
216 |         libc::lutimes(cstr.as_ptr(), &times[0])
    |               ^^^^^^^ did you mean `futimes`?
help: possible candidate is found in another module, you can import it into scope
    |
1   | use sys::stat::lutimes;
    |

   Compiling ordered-float v1.0.1
   Compiling approx v0.3.0
   Compiling line_drawing v0.7.0
   Compiling rusttype v0.7.2
   Compiling wayland-client v0.21.4
   Compiling wayland-protocols v0.21.4
error: aborting due to previous error

For more information about this error, try `rustc --explain E0425`.
error: Could not compile `nix`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```

```diff
user1 ~/ALACRITTY/client-toolkit $ git diff
diff --git a/Cargo.toml b/Cargo.toml
index 12322a9..4973832 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "smithay/client-toolkit" }

 [dependencies]
 bitflags = "1.0"
-nix = "0.12"
+nix = "0.13"
 dlib = "0.4"
 lazy_static = "1"
 memmap = "0.7"
```

```bash
user1 ~/ALACRITTY/client-toolkit $ cargo build
    Updating crates.io index
 Downloading crates ...
  Downloaded nix v0.13.0
   Compiling nix v0.13.0
   Compiling wayland-client v0.21.4
   Compiling wayland-protocols v0.21.4
   Compiling andrew v0.1.4
   Compiling wayland-commons v0.21.4
   Compiling smithay-client-toolkit v0.4.4 (/home/user1/ALACRITTY/client-toolkit)
warning: unused import: `std::ffi::CStr`
 --> src/utils/mempool.rs:9:5
  |
9 | use std::ffi::CStr;
  |     ^^^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

    Finished dev [unoptimized + debuginfo] target(s) in 28.53s
```