### PR TITLE
only compute the dpi factor on surfaces known to the OutputMgr in `co…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Surface: fix panic in `compute_dpi_factor()` by only computing the dpi factor on surfaces known to the OutputMgr
 - Window: `set_title()` now requires a manual `refresh()` for the change to take effect
 
 ## 0.4.4 -- 2018-12-27

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -47,11 +47,12 @@ impl SurfaceUserData {
     fn compute_dpi_factor(&mut self, surface: Proxy<wl_surface::WlSurface>) {
         let mut scale_factor = 1;
         for output in &self.outputs {
-            let scale_factor2 = self
+            if let Some(scale_factor2) = self
                 .output_manager
                 .with_info(&output, |_id, info| info.scale_factor)
-                .unwrap();
-            scale_factor = ::std::cmp::max(scale_factor, scale_factor2);
+            {
+                scale_factor = ::std::cmp::max(scale_factor, scale_factor2);
+            }
         }
         if self.dpi_factor != scale_factor {
             self.dpi_factor = scale_factor;


### PR DESCRIPTION
A panic is caused by computing the dpi factor on surfaces not known to SCTK.