### PR TITLE
Use `subsec_nanos()` of time since UNIX_EPOCH for random shm file han…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ nix = "0.13"
 dlib = "0.4"
 lazy_static = "1"
 memmap = "0.7"
-rand = "0.6"
 andrew = "0.1.2"
 wayland-commons = { version = "0.21" }
 wayland-client = { version = "0.21", features = ["cursor"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ extern crate lazy_static;
 extern crate andrew;
 extern crate memmap;
 extern crate nix;
-extern crate rand;
 #[doc(hidden)]
 pub extern crate wayland_client;
 #[doc(hidden)]

--- a/src/utils/mempool.rs
+++ b/src/utils/mempool.rs
@@ -12,9 +12,10 @@ use std::io;
 use std::os::unix::io::FromRawFd;
 use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use memmap::MmapMut;
-use rand::prelude::*;
 
 use wayland_client::protocol::{wl_buffer, wl_shm, wl_shm_pool};
 use wayland_client::Proxy;
@@ -248,10 +249,10 @@ fn create_shm_fd() -> io::Result<RawFd> {
     }
 
     // Fallback to using shm_open
-    let mut rng = thread_rng();
+    let sys_time = SystemTime::now();
     let mut mem_file_handle = format!(
         "/smithay-client-toolkit-{}",
-        rng.gen_range(0, ::std::u32::MAX)
+        sys_time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
     );
     loop {
         match mman::shm_open(
@@ -275,7 +276,7 @@ fn create_shm_fd() -> io::Result<RawFd> {
                 // If a file with that handle exists then change the handle
                 mem_file_handle = format!(
                     "/smithay-client-toolkit-{}",
-                    rng.gen_range(0, ::std::u32::MAX)
+                    sys_time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
                 );
                 continue;
             }


### PR DESCRIPTION
Removes the rand crate by instead using the time since UNIX_EPOCH's subsecond nanoseconds. Its good because its a fairly random number that changes every nanosecond and if we somehow get two of the same handles then we can just try again a nanosecond later.