### PR TITLE
Fix system repeat rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keyboard: fix system repeat rate as repeats per second rather then millisecond delay between repeats
 - Surface: fix panic in `compute_dpi_factor()` by only computing the dpi factor on surfaces known to the OutputMgr
 - Window: `set_title()` now requires a manual `refresh()` for the change to take effect
 

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -729,7 +729,9 @@ where
                                                 proxy.clone(),
                                             );
                                             // Rate
-                                            thread::sleep(Duration::from_millis(repeat_timing.0));
+                                            thread::sleep(
+                                                Duration::from_secs(1) / repeat_timing.0 as u32,
+                                            );
                                             match thread_kill_chan.lock().unwrap().1.try_recv() {
                                                 Ok(_) | Err(mpsc::TryRecvError::Disconnected) => {
                                                     break

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -361,7 +361,7 @@ impl Drop for KbState {
 pub enum KeyRepeatKind {
     /// keys will be repeated at a set rate and delay
     Fixed {
-        /// rate (in milliseconds) at which the repetition should occur
+        /// the number of repetitions per second that should occur
         rate: u64,
         /// delay (in milliseconds) between a key press and the start of repetition
         delay: u64,


### PR DESCRIPTION
This was a mistake I made when implementing the key repetition. The delay should be milliseconds but the repeat rate is repeats per second.

```
from wayland docs:
rate | the rate of repeating keys in characters per second
delay | delay in milliseconds since key down until repeating starts
```

Thanks to @e00E for catching this bug