### PR TITLE
window: fire user cb on xdg_surface.configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@
 - Additional theming capability on `ConceptFrame` via the `Theme` trait:
  optional methods `get_<button-name>_button_icon_color` allows the stroke
  color on the buttons to be customized beyond what the secondary color allows.
-
-#### Breaking changes
-- Button color methods now affect the `ConceptFrame`'s fill behind the
-buttons.
+ Button color methods now affect the `ConceptFrame`'s fill behind the buttons.
+- Fix the firing of `Configure` events in window abstraction.
 
 ## 0.6.0 -- 2019-02-18
 


### PR DESCRIPTION
Firing on xdg_toplevel_surface.configure is wrong: if the client
attaches as a response to the cb, the attach will reach the server
before the ack_configure, which is a protocol error.