### PR TITLE
Update to nix 0.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "smithay/client-toolkit" }
 
 [dependencies]
 bitflags = "1.0"
-nix = "0.13"
+nix = "0.14.1"
 dlib = "0.4"
 lazy_static = "1"
 memmap = "0.7"


### PR DESCRIPTION
This should probably be handled as a follow-up to https://github.com/Smithay/wayland-rs/pull/265

Once that is merged, I can update this to completely get rid of nix 0.13.