### PR TITLE
fix extra key repeat when also releasing a modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Keyboard: fix extra key repeat when using also releasing a modifier
+
 ## 0.6.2 -- 2019-06-13
 
 - Update `Nix` to 0.14

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -755,16 +755,19 @@ where
 
             loop {
                 // Drain channel
+                let mut need_update = false;
                 loop {
                     match receiver.try_recv() {
-                        Ok(()) => {
-                            let mut state = thread_state.lock().unwrap();
-                            sym = state.get_one_sym_raw(key);
-                            utf8 = state.get_utf8_raw(key);
-                        }
+                        Ok(()) => need_update = true,
                         Err(mpsc::TryRecvError::Empty) => break,
                         Err(mpsc::TryRecvError::Disconnected) => return,
                     }
+                }
+                if need_update {
+                    // Update state
+                    let mut state = thread_state.lock().unwrap();
+                    sym = state.get_one_sym_raw(key);
+                    utf8 = state.get_utf8_raw(key);
                 }
 
                 let elapsed_time = time_tracker.elapsed();

--- a/src/keyboard/mod.rs
+++ b/src/keyboard/mod.rs
@@ -763,6 +763,10 @@ where
                     Err(mpsc::TryRecvError::Empty) => (),
                     Err(mpsc::TryRecvError::Disconnected) => return,
                 }
+                // Check if the sender has been dropped after sending message
+                if let Err(mpsc::TryRecvError::Disconnected) = receiver.try_recv() {
+                    return
+                }
                 let elapsed_time = time_tracker.elapsed();
                 (&mut *thread_impl.lock().unwrap())(
                     KeyRepeatEvent {


### PR DESCRIPTION
Fixes when a modifier release event occurs so a state change message is sent to the key repeat thread, thus making it so that the thread doesn't receive a disconnect message on `try_recv()`.

Fixes https://github.com/Smithay/client-toolkit/issues/73