### PR TITLE
do not crash when fonts don't have extensions

### DIFF
--- a/src/window/concept_frame.rs
+++ b/src/window/concept_frame.rs
@@ -484,12 +484,9 @@ impl Frame for ConceptFrame {
                                 .get_regular_family_fonts("sans")
                                 .unwrap()
                                 .iter()
-                                .filter_map(|p| {
-                                    if p.extension().unwrap() == "ttf" {
-                                        Some(p)
-                                    } else {
-                                        None
-                                    }
+                                .filter_map(|p| match p.extension() {
+                                    Some(e) if e == "ttf" => Some(p),
+                                    _ => None,
                                 })
                                 .nth(0)
                             {


### PR DESCRIPTION
This happened (for me) when using alacritty on a wayland desktop. Seems
that there is some messed up font in the fontconfig list. Let's just
ignore these broken fonts.