### PR TITLE
surface: implementation should be threadsafe

### DIFF
--- a/src/surface.rs
+++ b/src/surface.rs
@@ -67,7 +67,7 @@ where
     environment
         .compositor
         .create_surface(move |surface| {
-            surface.implement_closure(
+            surface.implement_closure_threadsafe(
                 move |event, surface| {
                     let mut user_data = surface
                         .as_ref()


### PR DESCRIPTION
This implementation was erroneously not threadsafe, making it impossible to access the surface dpi from an other thread.

Will fix https://github.com/rust-windowing/winit/issues/1441