### PR TITLE
Add `seat_data()` method as a shorthand to get `SeatData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Additions
+
+- Add `clone_seat_data()` method as a shorthand to get `SeatData`
+
 ## 0.8.1 -- 2020-04-09
 
 #### Additions

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -172,6 +172,22 @@ fn process_seat_event(
     }
 }
 
+/// Get the copy of the data associated with this seat
+///
+/// If the provided `WlSeat` has not yet been initialized or is not managed by SCTK, `None` is returned.
+///
+/// If the seat has been removed by the compositor, the `defunct` field of the `SeatData`
+/// will be set to `true`. This handler will not automatically detroy the output by calling its
+/// `release` method, to avoid interfering with your logic.
+pub fn clone_seat_data(seat: &wl_seat::WlSeat) -> Option<SeatData> {
+    if let Some(ref udata_mutex) = seat.as_ref().user_data().get::<Mutex<SeatData>>() {
+        let udata = udata_mutex.lock().unwrap();
+        Some(udata.clone())
+    } else {
+        None
+    }
+}
+
 /// Access the data associated with this seat
 ///
 /// The provided closure is given the [`SeatData`](struct.SeatData.html) as argument,


### PR DESCRIPTION
It's a bit nicer way than doing something like.

```rust
if let Some(seat_data) = seat::with_seat_data(&seat, |seat_data| seat_data.clone()) {

}
```

So it should be just
```rust
if let Some(seat_data) = seat::seat_data(&seat) {

}
```