### PR TITLE
surface: don't count being hidden as a DPI change

### DIFF
--- a/src/surface.rs
+++ b/src/surface.rs
@@ -85,6 +85,10 @@ impl SurfaceUserData {
                 false
             }
         });
+        if self.outputs.is_empty() {
+            // don't update the scale factor if we are not displayed on any output
+            return self.scale_factor;
+        }
         self.scale_factor = new_scale_factor;
         new_scale_factor
     }


### PR DESCRIPTION
Don't consider the output list becoming empty as a scale factor change,
to avoid unneeded transient changes between scale 1 and the real scale
factor when surface is hidden / shown.

This notably affects cursor surfaces, whose output list becomes empty as
soon as they leave the app surface on some compositors.