### PR TITLE
Maintenance/update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Changes
+
+- `andrew` is updated to `0.3`.
+
 ## 0.9.1 -- 2020-05-03
 
 #### Additions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ nix = "0.17"
 dlib = "0.4"
 lazy_static = "1.0"
 memmap = "0.7"
-andrew = { version = "0.2.0", optional = true }
+andrew = { version = "0.3.0", optional = true }
 log = "0.4"
 wayland-client = "0.26"
 wayland-protocols = { version = "0.26" , features = ["client", "unstable_protocols"] }


### PR DESCRIPTION
Updates dependency versions.

The main change here is `andrew` from `0.2.0` to `0.3.0`, which has a number of dependency upgrades (see [andrew#2/files](https://github.com/trimental/andrew/pull/2/files)), and raises the minimum supported Rust version to 1.41.0.
