### PR TITLE
chore: update rustfmt attributes

### DIFF
--- a/src/seat/keyboard/ffi.rs
+++ b/src/seat/keyboard/ffi.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, non_camel_case_types, clippy::identity_op)]
-#![cfg_attr(rustfmt, rustfmt_skip)]
 
 use std::os::raw::{c_char, c_int, c_void, c_uint};
 

--- a/src/seat/keyboard/keysyms.rs
+++ b/src/seat/keyboard/keysyms.rs
@@ -3,7 +3,6 @@
 //
 
 #![allow(missing_docs, non_upper_case_globals, unused_parens, clippy::all)]
-#![cfg_attr(rustfmt, rustfmt_skip)]
 
 /***********************************************************
 Copyright 1987, 1994, 1998  The Open Group

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -24,8 +24,10 @@ use wayland_client::{
     Attached,
 };
 
+#[rustfmt::skip]
 mod ffi;
 mod state;
+#[rustfmt::skip]
 pub mod keysyms;
 
 use self::state::KbState;


### PR DESCRIPTION
It's either rust 1.44.0 broke old things entirely or removed them. Anyway, the new way is to skip formatting like that IIRC.