### PR TITLE
surface: Return `Attached<WlSurface>` instead of WlSurface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Breaking Changes
+
+- `create_surface` and `create_surface_with_scale_callback` now return `Attached<WlSurface>`
+
 #### Changes
 
 - `andrew` is updated to `0.3`.

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -42,9 +42,11 @@ fn main() {
         .expect("Unable to connect to a Wayland compositor");
 
     // Use the compositor global to create a new surface
-    let surface = env.create_surface_with_scale_callback(|dpi, _surface, _dispatch_data| {
-        println!("dpi changed to {}", dpi);
-    });
+    let surface = env
+        .create_surface_with_scale_callback(|dpi, _surface, _dispatch_data| {
+            println!("dpi changed to {}", dpi);
+        })
+        .detach();
 
     /*
      * Init the window

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -38,7 +38,7 @@ fn main() {
      * Init wayland objects
      */
 
-    let surface = env.create_surface();
+    let surface = env.create_surface().detach();
 
     let mut window = env
         .create_window::<ConceptFrame, _>(surface, dimensions, move |evt, mut dispatch_data| {

--- a/examples/layer_shell.rs
+++ b/examples/layer_shell.rs
@@ -160,7 +160,7 @@ fn main() {
             output.release();
         } else {
             // an output has been created, construct a surface for it
-            let surface = env_handle.create_surface();
+            let surface = env_handle.create_surface().detach();
             let pools =
                 env_handle.create_double_pool(|_| {}).expect("Failed to create a memory pool!");
             (*surfaces_handle.borrow_mut())

--- a/examples/pointer_input.rs
+++ b/examples/pointer_input.rs
@@ -68,12 +68,14 @@ fn main() {
 
     let mut window_config = WindowConfig::new();
 
-    let surface = env.create_surface_with_scale_callback(move |dpi, surface, mut dispatch_data| {
-        let config = dispatch_data.get::<WindowConfig>().unwrap();
-        surface.set_buffer_scale(dpi);
-        config.dpi_scale = dpi;
-        config.handle_action(NextAction::Redraw);
-    });
+    let surface = env
+        .create_surface_with_scale_callback(move |dpi, surface, mut dispatch_data| {
+            let config = dispatch_data.get::<WindowConfig>().unwrap();
+            surface.set_buffer_scale(dpi);
+            config.dpi_scale = dpi;
+            config.handle_action(NextAction::Redraw);
+        })
+        .detach();
 
     let mut window = env
         .create_window::<ConceptFrame, _>(

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -42,7 +42,7 @@ fn main() {
 
     // we need a window to receive things actually
     let mut dimensions = (320u32, 240u32);
-    let surface = env.create_surface();
+    let surface = env.create_surface().detach();
 
     let mut window = env
         .create_window::<ConceptFrame, _>(surface, dimensions, move |evt, mut dispatch_data| {

--- a/examples/themed_frame.rs
+++ b/examples/themed_frame.rs
@@ -84,7 +84,7 @@ fn main() {
      * Init wayland objects
      */
 
-    let surface = env.create_surface();
+    let surface = env.create_surface().detach();
 
     let mut window = env
         .create_window::<ConceptFrame, _>(surface, dimensions, move |evt, mut dispatch_data| {

--- a/src/window/concept_frame.rs
+++ b/src/window/concept_frame.rs
@@ -178,6 +178,8 @@ impl Part {
             )
         };
 
+        let surface = surface.detach();
+
         let subsurface = subcompositor.get_subsurface(&surface, parent);
 
         Part { surface, subsurface: subsurface.detach() }


### PR DESCRIPTION
We should return `Attached<WlSurface>` from `create_surface`
and `create_surface_with_scale_callback` to simplify handling
of frame callbacks and object creation, since queue could be
unavailable in a place of surface creation.

Fixes #132.