### PR TITLE
Upgrade wayland-cursors to 0.26.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ andrew = { version = "0.3.0", optional = true }
 log = "0.4"
 wayland-client = "0.26"
 wayland-protocols = { version = "0.26" , features = ["client", "unstable_protocols"] }
-wayland-cursor = "0.26.3"
+wayland-cursor = "0.26.6"
 calloop = { version = "0.6.1", optional = true }
 byteorder = "1.0"
 


### PR DESCRIPTION
Seems to fix a panic on cursor loading on my system.
PRing this trivial change into master after hitting this for a second time ><
