### PR TITLE
Advertise seats with an empty name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 #### BugFixes
 
 - keyboard: Remove the unnecessary type parameter of `map_keyboard`
-- seat: seat not being advertise with an empty name
+- seat: Seats with an empty name are no longer filtered out
 
 ## 0.9.0 -- 2020-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 #### BugFixes
 
 - keyboard: Remove the unnecessary type parameter of `map_keyboard`
+- seat: seat not being advertise with an empty name
 
 ## 0.9.0 -- 2020-04-22
 


### PR DESCRIPTION
Some compositors(plasma) do use empty name for a seat name, filtering
out by empty seat name, was leading to not working clipboard on such
compositors.