### PR TITLE
event_loop: add WaylandSource::queue_mut()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Additions
 
-- `Waylandsource::queue` to access the `EventQueue` unserlying a `WaylandSource`
+- `WaylandSource::queue` to access the `EventQueue` unserlying a `WaylandSource`
 
 ## 0.10.0 -- 2020-07-10
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -54,8 +54,8 @@ impl WaylandSource {
     /// Note that you should be careful when interacting with it if you invoke methods that
     /// interact with the wayland socket (such as `dispatch()` or `prepare_read()`). These may
     /// interefere with the proper waking up of this event source in the event loop.
-    pub fn queue(&self) -> &EventQueue {
-        &self.queue
+    pub fn queue(&mut self) -> &mut EventQueue {
+        &mut self.queue
     }
 }
 


### PR DESCRIPTION
I actually need `queue_mut`, since I should do `sync_roundtrip` after creating a window in winit and dispatching also requires a mut EventQueue.