### PR TITLE
Fix fd leak in keymap updates

### DIFF
--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -14,7 +14,12 @@
 
 #[cfg(feature = "calloop")]
 use std::time::Duration;
-use std::{cell::RefCell, os::unix::io::RawFd, rc::Rc};
+use std::{
+    cell::RefCell,
+    fs::File,
+    os::unix::io::{FromRawFd, RawFd},
+    rc::Rc,
+};
 
 use byteorder::{ByteOrder, NativeEndian};
 
@@ -328,6 +333,7 @@ impl KbdHandler {
         fd: RawFd,
         size: u32,
     ) {
+        let fd = unsafe { File::from_raw_fd(fd) };
         let mut state = self.state.borrow_mut();
         if state.locked() {
             // state is locked, ignore keymap updates

--- a/src/seat/keyboard/state.rs
+++ b/src/seat/keyboard/state.rs
@@ -1,16 +1,5 @@
-use std::{
-    env,
-    ffi::CString,
-    fs::File,
-    os::raw::c_char,
-    os::unix::{
-        ffi::OsStringExt,
-        io::{FromRawFd, RawFd},
-    },
-    ptr,
-};
-
 use memmap::MmapOptions;
+use std::{env, ffi::CString, fs::File, os::raw::c_char, os::unix::ffi::OsStringExt, ptr};
 
 use super::ffi::{self, xkb_state_component, XKBCOMMON_HANDLE as XKBH};
 use super::Error;
@@ -327,8 +316,8 @@ impl KbState {
         self.xkb_keymap = ptr::null_mut();
     }
 
-    pub(crate) unsafe fn init_with_fd(&mut self, fd: RawFd, size: usize) {
-        let map = MmapOptions::new().len(size).map(&File::from_raw_fd(fd)).unwrap();
+    pub(crate) unsafe fn init_with_fd(&mut self, fd: File, size: usize) {
+        let map = MmapOptions::new().len(size).map(&fd).unwrap();
 
         let xkb_keymap = (XKBH.xkb_keymap_new_from_string)(
             self.xkb_context,


### PR DESCRIPTION
If the keymap is not passed to init_with_fd, the file descriptor is leaked.
Wrap the fd in a File earlier on so normal drop code takes care of this.

The virtual-kbd program at https://github.com/danieldg/wlroots/blob/master/examples/virtual-kbd.c triggers this leak, if you want to test.