### PR TITLE
Fix precision in keyboard repeated keys events rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - `Window::set_title` now truncates the provided string to 1024 bytes, to avoid blowing up
   the Wayland connection
 
+#### Bugfixes
+
+- Precision in a rate of key repeat events
+
 ## 0.10.0 -- 2020-07-10
 
 #### Breaking Changes

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -33,6 +33,8 @@ pub mod keysyms;
 use self::state::KbState;
 pub use self::state::{ModifiersState, RMLVO};
 
+const MICROS_IN_SECOND: u32 = 1000000;
+
 /// Possible kinds of key repetition
 pub enum RepeatKind {
     /// keys will be repeated at a set rate and delay
@@ -197,7 +199,7 @@ where
     let repeat = match repeatkind {
         RepeatKind::System => RepeatDetails { locked: false, gap: 100, delay: 300 },
         RepeatKind::Fixed { rate, delay } => {
-            RepeatDetails { locked: true, gap: 1000 / rate, delay }
+            RepeatDetails { locked: true, gap: MICROS_IN_SECOND / rate, delay }
         }
     };
 
@@ -247,7 +249,9 @@ type KbdCallback = dyn FnMut(Event<'_>, wl_keyboard::WlKeyboard, wayland_client:
 #[cfg(feature = "calloop")]
 struct RepeatDetails {
     locked: bool,
+    /// Gap between key presses in microseconds.
     gap: u32,
+    /// Delay before starting key repeat in milliseconds.
     delay: u32,
 }
 
@@ -268,15 +272,15 @@ struct KbdRepeat {
 #[cfg(feature = "calloop")]
 impl KbdRepeat {
     fn start_repeat(&self, key: u32, keyboard: wl_keyboard::WlKeyboard, time: u32) {
-        // start a new repetition, overwriting the previous ones
+        // Start a new repetition, overwriting the previous ones
         self.timer_handle.cancel_all_timeouts();
         *self.current_repeat.borrow_mut() = Some(RepeatData {
             keyboard,
             keycode: key,
-            gap: self.details.gap,
-            time: time + self.details.delay,
+            gap: self.details.gap as u64,
+            time: (time + self.details.delay) as u64 * 1000,
         });
-        self.timer_handle.add_timeout(Duration::from_millis(self.details.delay as u64), ());
+        self.timer_handle.add_timeout(Duration::from_micros(self.details.delay as u64 * 1000), ());
     }
 
     fn stop_repeat(&self, key: u32) {
@@ -477,7 +481,7 @@ impl KbdHandler {
         {
             if let Some(ref mut repeat_handle) = self.repeat {
                 if !repeat_handle.details.locked {
-                    repeat_handle.details.gap = 1000 / (rate as u32);
+                    repeat_handle.details.gap = MICROS_IN_SECOND / (rate as u32);
                     repeat_handle.details.delay = delay as u32;
                 }
             }
@@ -493,10 +497,10 @@ impl KbdHandler {
 struct RepeatData {
     keyboard: wl_keyboard::WlKeyboard,
     keycode: u32,
-    // repeat gap, in ms
-    gap: u32,
-    // time of the last event, in ms
-    time: u32,
+    /// Gap between key presses in microseconds.
+    gap: u64,
+    /// Time of the last event in microseconds.
+    time: u64,
 }
 
 /// An event source managing the key repetition of a keyboard
@@ -540,15 +544,20 @@ impl calloop::EventSource for RepeatSource {
                 let keysym = state.get_one_sym_raw(data.keycode);
                 let utf8 = state.get_utf8_raw(data.keycode);
                 let new_time = data.gap + data.time;
-                // notify the callback
+                // Notify the callback.
                 callback(
-                    Event::Repeat { time: new_time, rawkey: data.keycode, keysym, utf8 },
+                    Event::Repeat {
+                        time: (new_time / 1000) as u32,
+                        rawkey: data.keycode,
+                        keysym,
+                        utf8,
+                    },
                     &mut data.keyboard,
                 );
-                // update the time of last event
+                // Update the time of last event.
                 data.time = new_time;
-                // schedule the next timeout
-                timer_handle.add_timeout(Duration::from_millis(data.gap as u64), ());
+                // Schedule the next timeout.
+                timer_handle.add_timeout(Duration::from_micros(data.gap), ());
             }
         })
     }

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -33,6 +33,7 @@ pub mod keysyms;
 use self::state::KbState;
 pub use self::state::{ModifiersState, RMLVO};
 
+#[cfg(feature = "calloop")]
 const MICROS_IN_SECOND: u32 = 1000000;
 
 /// Possible kinds of key repetition


### PR DESCRIPTION
Milliseconds are not accurate enough resulting in lower
repeat gap than it should be, however using microseconds seems enough
to solve that.

Fixes #141.