### PR TITLE
Add 'Option<ThemeManager>' argument to 'create_window'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@
 - `window.set_decorate` is now taking mutable reference
 - Added `show_window_menu` on a `Frame` trait to request a window menu for a window.
 - `ShowMenu` enum variant to `FrameRequest`
+- `create_window` now also takes `Option<ThemeManager>`
+- `Frame::init` now also takes `Option<ThemeManager>` to reuse users' `ThemeManager`
 
 #### Additions
 
 - `WaylandSource::queue` to access the `EventQueue` unserlying a `WaylandSource`
 - A window menu could be shown on right click on decorations for `ConceptFrame`
+- `ConceptFrame` will no longer change cursor over base surface if `ThemeManager` was provided
 
 #### Changes
 
@@ -29,6 +32,7 @@
 
 - Toggling between `ServerSide` and `None` decorations raising protocol error
 - Precision in a rate of key repeat events
+- `ThemeManager` not being clone-able even if it was stated in docs
 
 ## 0.10.0 -- 2020-07-10
 

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -67,6 +67,7 @@ fn main() {
     let mut window = env
         .create_window::<ConceptFrame, _>(
             surface,            // the wl_surface that serves as the basis of this window
+            None,               // None for theme_manager, since we don't theme pointer outself
             image.dimensions(), // the initial internal dimensions of the window
             move |evt, mut dispatch_data| {
                 // This is the closure that process the Window events.

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -41,20 +41,25 @@ fn main() {
     let surface = env.create_surface().detach();
 
     let mut window = env
-        .create_window::<ConceptFrame, _>(surface, dimensions, move |evt, mut dispatch_data| {
-            let next_action = dispatch_data.get::<Option<WEvent>>().unwrap();
-            // Keep last event in priority order : Close > Configure > Refresh
-            let replace = match (&evt, &*next_action) {
-                (_, &None)
-                | (_, &Some(WEvent::Refresh))
-                | (&WEvent::Configure { .. }, &Some(WEvent::Configure { .. }))
-                | (&WEvent::Close, _) => true,
-                _ => false,
-            };
-            if replace {
-                *next_action = Some(evt);
-            }
-        })
+        .create_window::<ConceptFrame, _>(
+            surface,
+            None,
+            dimensions,
+            move |evt, mut dispatch_data| {
+                let next_action = dispatch_data.get::<Option<WEvent>>().unwrap();
+                // Keep last event in priority order : Close > Configure > Refresh
+                let replace = match (&evt, &*next_action) {
+                    (_, &None)
+                    | (_, &Some(WEvent::Refresh))
+                    | (&WEvent::Configure { .. }, &Some(WEvent::Configure { .. }))
+                    | (&WEvent::Close, _) => true,
+                    _ => false,
+                };
+                if replace {
+                    *next_action = Some(evt);
+                }
+            },
+        )
         .expect("Failed to create a window !");
 
     window.set_title("Kbd Input".to_string());

--- a/examples/pointer_input.rs
+++ b/examples/pointer_input.rs
@@ -80,6 +80,7 @@ fn main() {
     let mut window = env
         .create_window::<ConceptFrame, _>(
             surface,
+            None,
             window_config.dimensions(),
             move |event, mut dispatch_data| {
                 let mut config = dispatch_data.get::<WindowConfig>().unwrap();

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -45,20 +45,25 @@ fn main() {
     let surface = env.create_surface().detach();
 
     let mut window = env
-        .create_window::<ConceptFrame, _>(surface, dimensions, move |evt, mut dispatch_data| {
-            let (_, next_action, _) = dispatch_data.get::<DData>().unwrap();
-            // Keep last event in priority order : Close > Configure > Refresh
-            let replace = match (&evt, &*next_action) {
-                (_, &None)
-                | (_, &Some(WEvent::Refresh))
-                | (&WEvent::Configure { .. }, &Some(WEvent::Configure { .. }))
-                | (&WEvent::Close, _) => true,
-                _ => false,
-            };
-            if replace {
-                *next_action = Some(evt);
-            }
-        })
+        .create_window::<ConceptFrame, _>(
+            surface,
+            None,
+            dimensions,
+            move |evt, mut dispatch_data| {
+                let (_, next_action, _) = dispatch_data.get::<DData>().unwrap();
+                // Keep last event in priority order : Close > Configure > Refresh
+                let replace = match (&evt, &*next_action) {
+                    (_, &None)
+                    | (_, &Some(WEvent::Refresh))
+                    | (&WEvent::Configure { .. }, &Some(WEvent::Configure { .. }))
+                    | (&WEvent::Close, _) => true,
+                    _ => false,
+                };
+                if replace {
+                    *next_action = Some(evt);
+                }
+            },
+        )
         .expect("Failed to create a window !");
     window.set_title("Selection example".to_string());
 

--- a/examples/themed_frame.rs
+++ b/examples/themed_frame.rs
@@ -87,20 +87,25 @@ fn main() {
     let surface = env.create_surface().detach();
 
     let mut window = env
-        .create_window::<ConceptFrame, _>(surface, dimensions, move |evt, mut dispatch_data| {
-            let next_action = dispatch_data.get::<Option<WEvent>>().unwrap();
-            // Keep last event in priority order : Close > Configure > Refresh
-            let replace = match (&evt, &*next_action) {
-                (_, &None)
-                | (_, &Some(WEvent::Refresh))
-                | (&WEvent::Configure { .. }, &Some(WEvent::Configure { .. }))
-                | (&WEvent::Close, _) => true,
-                _ => false,
-            };
-            if replace {
-                *next_action = Some(evt);
-            }
-        })
+        .create_window::<ConceptFrame, _>(
+            surface,
+            None,
+            dimensions,
+            move |evt, mut dispatch_data| {
+                let next_action = dispatch_data.get::<Option<WEvent>>().unwrap();
+                // Keep last event in priority order : Close > Configure > Refresh
+                let replace = match (&evt, &*next_action) {
+                    (_, &None)
+                    | (_, &Some(WEvent::Refresh))
+                    | (&WEvent::Configure { .. }, &Some(WEvent::Configure { .. }))
+                    | (&WEvent::Close, _) => true,
+                    _ => false,
+                };
+                if replace {
+                    *next_action = Some(evt);
+                }
+            },
+        )
         .expect("Failed to create a window !");
 
     window.set_title("Themed frame".to_string());

--- a/src/seat/pointer/theme.rs
+++ b/src/seat/pointer/theme.rs
@@ -38,7 +38,8 @@ pub enum ThemeSpec<'a> {
 /// Is is also clone-able in case you need to handle several
 /// pointer theming from different places.
 ///
-/// Note that it is however not `Send` nor `Sync`
+/// Note that it is however neither `Send` nor `Sync`
+#[derive(Clone)]
 pub struct ThemeManager {
     themes: Rc<RefCell<ScaledThemeList>>,
     compositor: Attached<wl_compositor::WlCompositor>,
@@ -48,8 +49,6 @@ impl ThemeManager {
     /// Load a system pointer theme
     ///
     /// Will use the default theme of the system if name is `None`.
-    ///
-    /// Fails if `libwayland-cursor` is not available.
     pub fn init(
         theme: ThemeSpec,
         compositor: Attached<wl_compositor::WlCompositor>,
@@ -211,12 +210,11 @@ impl PointerInner {
 ///
 /// Just like `Proxy`, this is a `Rc`-like wrapper. You can clone it
 /// to have several handles to the same theming machinery of a pointer.
+#[derive(Clone)]
 pub struct ThemedPointer {
     pointer: wl_pointer::WlPointer,
     inner: Rc<RefCell<PointerInner>>,
 }
-
-// load_theme(name, 16, &shm)
 
 impl ThemedPointer {
     /// Change the cursor to the given cursor name
@@ -233,12 +231,6 @@ impl ThemedPointer {
         }
         inner.current_cursor = name.into();
         inner.update_cursor(&self.pointer)
-    }
-}
-
-impl Clone for ThemedPointer {
-    fn clone(&self) -> ThemedPointer {
-        ThemedPointer { pointer: self.pointer.clone(), inner: self.inner.clone() }
     }
 }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -16,6 +16,7 @@ use wayland_protocols::unstable::xdg_decoration::v1::client::{
 
 use crate::{
     environment::{Environment, GlobalHandler, MultiGlobalHandler},
+    seat::pointer::ThemeManager,
     shell,
 };
 
@@ -163,9 +164,13 @@ impl<F: Frame + 'static> Window<F> {
     ///
     /// It can fail if the initialization of the frame fails (for example if the
     /// frame class fails to initialize its SHM).
+    ///
+    /// Providing non `None` value for `theme_manager` should prevent theming pointer
+    /// over the `surface`.
     fn init_with_decorations<Impl, E>(
         env: &crate::environment::Environment<E>,
         surface: wl_surface::WlSurface,
+        theme_manager: Option<ThemeManager>,
         initial_dims: (u32, u32),
         implementation: Impl,
     ) -> Result<Window<F>, F::Error>
@@ -194,6 +199,7 @@ impl<F: Frame + 'static> Window<F> {
             &compositor,
             &subcompositor,
             &shm,
+            theme_manager,
             Box::new(move |req, serial, ddata: DispatchData| {
                 if let Some(ref mut inner) = *shell_inner.lock().unwrap() {
                     match req {
@@ -689,12 +695,16 @@ pub trait Frame: Sized {
     type Error;
     /// Configuration for this frame
     type Config;
-    /// Initialize the Frame
+    /// Initialize the Frame.
+    ///
+    /// Providing non `None` to `theme_manager` should prevent `Frame` to theme pointer
+    /// over `base_surface` surface.
     fn init(
         base_surface: &wl_surface::WlSurface,
         compositor: &Attached<wl_compositor::WlCompositor>,
         subcompositor: &Attached<wl_subcompositor::WlSubcompositor>,
         shm: &Attached<wl_shm::WlShm>,
+        theme_manager: Option<ThemeManager>,
         callback: Box<dyn FnMut(FrameRequest, u32, DispatchData)>,
     ) -> Result<Self, Self::Error>;
     /// Set the Window XDG states for the frame
@@ -764,13 +774,14 @@ where
     pub fn create_window<F: Frame + 'static, CB>(
         &self,
         surface: wl_surface::WlSurface,
+        theme_manager: Option<ThemeManager>,
         initial_dims: (u32, u32),
         callback: CB,
     ) -> Result<Window<F>, F::Error>
     where
         CB: FnMut(Event, DispatchData) + 'static,
     {
-        Window::<F>::init_with_decorations(self, surface, initial_dims, callback)
+        Window::<F>::init_with_decorations(self, surface, theme_manager, initial_dims, callback)
     }
 }
 


### PR DESCRIPTION
Allow users to pass `ThemeManager` to reduce the usage of resources
and extra loads of users' themes.

Frames could use that to detect whether they should theme cursor
over the base surface.