### PR TITLE
Request window menu when right clicking on CSD decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@
 #### Additions
 
 - `WaylandSource::queue` to access the `EventQueue` unserlying a `WaylandSource`
+- A window menu could be shown on right click on decorations for `ConceptFrame`
 
 #### Changes
 
 - `Window::set_title` now truncates the provided string to 1024 bytes, to avoid blowing up
   the Wayland connection
+
+#### Breaking Changes
+
+- Added `show_window_menu` on a `Frame` trait to request a window menu for a window.
+- `ShowMenu` enum variant to `FrameRequest`
 
 ## 0.10.0 -- 2020-07-10
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -129,6 +129,8 @@ pub trait ShellSurface: Send + Sync {
     fn set_min_size(&self, size: Option<(i32, i32)>);
     /// Set maximum surface size
     fn set_max_size(&self, size: Option<(i32, i32)>);
+    /// Show window menu.
+    fn show_window_menu(&self, seat: &wl_seat::WlSeat, serial: u32, x: i32, y: i32);
     /// Retrive the `XdgToplevel` proxy if the underlying shell surface
     /// uses the `xdg_shell` protocol.
     ///

--- a/src/shell/wl.rs
+++ b/src/shell/wl.rs
@@ -89,6 +89,10 @@ impl ShellSurface for Wl {
         self.shell_surface.set_toplevel();
     }
 
+    fn show_window_menu(&self, _: &wl_seat::WlSeat, _: u32, _: i32, _: i32) {
+        /* not available */
+    }
+
     fn set_minimized(&self) {
         /* not available */
     }

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -110,6 +110,10 @@ impl ShellSurface for Xdg {
         self.toplevel.set_minimized();
     }
 
+    fn show_window_menu(&self, seat: &wl_seat::WlSeat, serial: u32, x: i32, y: i32) {
+        self.toplevel.show_window_menu(seat, serial, x, y);
+    }
+
     fn set_geometry(&self, x: i32, y: i32, width: i32, height: i32) {
         self.surface.set_window_geometry(x, y, width, height);
     }

--- a/src/shell/zxdg.rs
+++ b/src/shell/zxdg.rs
@@ -113,6 +113,10 @@ impl ShellSurface for Zxdg {
         self.toplevel.set_minimized();
     }
 
+    fn show_window_menu(&self, seat: &wl_seat::WlSeat, serial: u32, x: i32, y: i32) {
+        self.toplevel.show_window_menu(seat, serial, x, y);
+    }
+
     fn set_geometry(&self, x: i32, y: i32, width: i32, height: i32) {
         self.surface.set_window_geometry(x, y, width, height);
     }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -205,6 +205,9 @@ impl<F: Frame + 'static> Window<F> {
                         FrameRequest::Resize(seat, edges) => {
                             inner.shell_surface.resize(&seat, serial, edges)
                         }
+                        FrameRequest::ShowMenu(seat, x, y) => {
+                            inner.shell_surface.show_window_menu(&seat, serial, x, y)
+                        }
                         FrameRequest::Close => (inner.user_impl)(Event::Close, ddata),
                         FrameRequest::Refresh => (inner.user_impl)(Event::Refresh, ddata),
                     }
@@ -630,6 +633,8 @@ pub enum FrameRequest {
     Move(wl_seat::WlSeat),
     /// An interactive resize should be started
     Resize(wl_seat::WlSeat, ResizeEdge),
+    /// Show window menu.
+    ShowMenu(wl_seat::WlSeat, i32, i32),
     /// The frame requests to be refreshed
     Refresh,
 }


### PR DESCRIPTION
Some compositors like mutter can show window menu
when performing xdg_toplevel.show_mindow_menu.

That's how it looks on GNOME. (cursor is there, just wasn't captured by `grim`).

![picture](https://user-images.githubusercontent.com/27620401/90984934-0ecbca80-e581-11ea-8383-347098613464.png)
