### PR TITLE
Create subsurfaces in 'ConceptFrame' only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Requesting `None` decorations if `ServerSide` are presented will result in setting
   `ClientSide` decorations with hidden frame
 - `ConceptFrame` will use `Disabled` style for maximized button for non-resizeable frame
+- `ConceptFrame` will create subsurfaces for client side decorations only if a frame is visible
 
 #### Bugfixes
 

--- a/src/window/concept_frame.rs
+++ b/src/window/concept_frame.rs
@@ -204,7 +204,7 @@ struct PointerUserData {
  */
 
 struct Inner {
-    parts: Vec<Part>,
+    parts: Option<Vec<Part>>,
     size: (u32, u32),
     resizable: bool,
     theme_over_surface: bool,
@@ -216,15 +216,19 @@ struct Inner {
 
 impl Inner {
     fn find_surface(&self, surface: &wl_surface::WlSurface) -> Location {
-        if surface.as_ref().equals(&self.parts[HEAD].surface.as_ref()) {
+        let parts = match self.parts.as_ref() {
+            Some(parts) => parts,
+            None => return Location::None,
+        };
+        if surface.as_ref().equals(&parts[HEAD].surface.as_ref()) {
             Location::Head
-        } else if surface.as_ref().equals(&self.parts[TOP].surface.as_ref()) {
+        } else if surface.as_ref().equals(&parts[TOP].surface.as_ref()) {
             Location::Top
-        } else if surface.as_ref().equals(&self.parts[BOTTOM].surface.as_ref()) {
+        } else if surface.as_ref().equals(&parts[BOTTOM].surface.as_ref()) {
             Location::Bottom
-        } else if surface.as_ref().equals(&self.parts[LEFT].surface.as_ref()) {
+        } else if surface.as_ref().equals(&parts[LEFT].surface.as_ref()) {
             Location::Left
-        } else if surface.as_ref().equals(&self.parts[RIGHT].surface.as_ref()) {
+        } else if surface.as_ref().equals(&parts[RIGHT].surface.as_ref()) {
             Location::Right
         } else {
             Location::None
@@ -318,6 +322,9 @@ fn find_button(x: f64, y: f64, w: u32, buttons: (bool, bool, bool)) -> Location 
 /// in a `Fullscreen` state and brings them back if those are
 /// visible when unsetting `Fullscreen` state.
 pub struct ConceptFrame {
+    base_surface: wl_surface::WlSurface,
+    compositor: Attached<wl_compositor::WlCompositor>,
+    subcompositor: Attached<wl_subcompositor::WlSubcompositor>,
     inner: Rc<RefCell<Inner>>,
     pools: DoubleMemPool,
     active: WindowState,
@@ -348,7 +355,7 @@ impl Frame for ConceptFrame {
         };
 
         let inner = Rc::new(RefCell::new(Inner {
-            parts: vec![],
+            parts: None,
             size: (1, 1),
             resizable: true,
             implem: implementation,
@@ -358,14 +365,6 @@ impl Frame for ConceptFrame {
             buttons: (true, true, true),
         }));
 
-        inner.borrow_mut().parts = vec![
-            Part::new(base_surface, compositor, subcompositor, Some(Rc::clone(&inner))),
-            Part::new(base_surface, compositor, subcompositor, None),
-            Part::new(base_surface, compositor, subcompositor, None),
-            Part::new(base_surface, compositor, subcompositor, None),
-            Part::new(base_surface, compositor, subcompositor, None),
-        ];
-
         let my_inner = inner.clone();
         // Send a Refresh request on callback from DoubleMemPool as it will be fired when
         // None was previously returned from `pool()` and the draw was postponed
@@ -374,10 +373,13 @@ impl Frame for ConceptFrame {
         })?;
 
         Ok(ConceptFrame {
+            base_surface: base_surface.clone(),
+            compositor: compositor.clone(),
+            subcompositor: subcompositor.clone(),
             inner,
             pools,
             active: WindowState::Inactive,
-            hidden: false,
+            hidden: true,
             pointers: Vec::new(),
             themer,
             surface_version: compositor.as_ref().version(),
@@ -510,6 +512,25 @@ impl Frame for ConceptFrame {
 
     fn set_hidden(&mut self, hidden: bool) {
         self.hidden = hidden;
+        let mut inner = self.inner.borrow_mut();
+        if !self.hidden {
+            if inner.parts.is_none() {
+                inner.parts = Some(vec![
+                    Part::new(
+                        &self.base_surface,
+                        &self.compositor,
+                        &self.subcompositor,
+                        Some(Rc::clone(&self.inner)),
+                    ),
+                    Part::new(&self.base_surface, &self.compositor, &self.subcompositor, None),
+                    Part::new(&self.base_surface, &self.compositor, &self.subcompositor, None),
+                    Part::new(&self.base_surface, &self.compositor, &self.subcompositor, None),
+                    Part::new(&self.base_surface, &self.compositor, &self.subcompositor, None),
+                ]);
+            }
+        } else {
+            inner.parts = None;
+        }
     }
 
     fn set_resizable(&mut self, resizable: bool) {
@@ -525,16 +546,21 @@ impl Frame for ConceptFrame {
 
         // Don't draw borders if the frame explicitly hidden or fullscreened.
         if self.hidden || inner.fullscreened {
-            // don't draw the borders
-            for p in &inner.parts {
-                p.surface.attach(None, 0, 0);
-                p.surface.commit();
+            // Don't draw the borders.
+            if let Some(parts) = inner.parts.as_ref() {
+                for p in parts {
+                    p.surface.attach(None, 0, 0);
+                    p.surface.commit();
+                }
             }
             return;
         }
 
-        let scales: Vec<u32> = inner
-            .parts
+        // `parts` can't be `None` here, since the initial state for `self.hidden` is true, and
+        // they will be created once `self.hidden` will become `false`.
+        let parts = inner.parts.as_ref().unwrap();
+
+        let scales: Vec<u32> = parts
             .iter()
             .map(|part| crate::surface::get_surface_scale_factor(&part.surface) as u32)
             .collect();
@@ -703,10 +729,10 @@ impl Frame for ConceptFrame {
                 4 * scaled_header_width as i32,
                 wl_shm::Format::Argb8888,
             );
-            inner.parts[HEAD].subsurface.set_position(0, -(HEADER_SIZE as i32));
-            inner.parts[HEAD].surface.attach(Some(&buffer), 0, 0);
+            parts[HEAD].subsurface.set_position(0, -(HEADER_SIZE as i32));
+            parts[HEAD].surface.attach(Some(&buffer), 0, 0);
             if self.surface_version >= 4 {
-                inner.parts[HEAD].surface.damage_buffer(
+                parts[HEAD].surface.damage_buffer(
                     0,
                     0,
                     scaled_header_width as i32,
@@ -715,9 +741,9 @@ impl Frame for ConceptFrame {
             } else {
                 // surface is old and does not support damage_buffer, so we damage
                 // in surface coordinates and hope it is not rescaled
-                inner.parts[HEAD].surface.damage(0, 0, width as i32, HEADER_SIZE as i32);
+                parts[HEAD].surface.damage(0, 0, width as i32, HEADER_SIZE as i32);
             }
-            inner.parts[HEAD].surface.commit();
+            parts[HEAD].surface.commit();
 
             // -> top-subsurface
             let buffer = pool.buffer(
@@ -727,12 +753,12 @@ impl Frame for ConceptFrame {
                 (4 * scales[TOP] * (width + 2 * BORDER_SIZE)) as i32,
                 wl_shm::Format::Argb8888,
             );
-            inner.parts[TOP]
+            parts[TOP]
                 .subsurface
                 .set_position(-(BORDER_SIZE as i32), -(HEADER_SIZE as i32 + BORDER_SIZE as i32));
-            inner.parts[TOP].surface.attach(Some(&buffer), 0, 0);
+            parts[TOP].surface.attach(Some(&buffer), 0, 0);
             if self.surface_version >= 4 {
-                inner.parts[TOP].surface.damage_buffer(
+                parts[TOP].surface.damage_buffer(
                     0,
                     0,
                     ((width + 2 * BORDER_SIZE) * scales[TOP]) as i32,
@@ -741,14 +767,14 @@ impl Frame for ConceptFrame {
             } else {
                 // surface is old and does not support damage_buffer, so we damage
                 // in surface coordinates and hope it is not rescaled
-                inner.parts[TOP].surface.damage(
+                parts[TOP].surface.damage(
                     0,
                     0,
                     (width + 2 * BORDER_SIZE) as i32,
                     BORDER_SIZE as i32,
                 );
             }
-            inner.parts[TOP].surface.commit();
+            parts[TOP].surface.commit();
 
             // -> bottom-subsurface
             let buffer = pool.buffer(
@@ -758,10 +784,10 @@ impl Frame for ConceptFrame {
                 (4 * scales[BOTTOM] * (width + 2 * BORDER_SIZE)) as i32,
                 wl_shm::Format::Argb8888,
             );
-            inner.parts[BOTTOM].subsurface.set_position(-(BORDER_SIZE as i32), height as i32);
-            inner.parts[BOTTOM].surface.attach(Some(&buffer), 0, 0);
+            parts[BOTTOM].subsurface.set_position(-(BORDER_SIZE as i32), height as i32);
+            parts[BOTTOM].surface.attach(Some(&buffer), 0, 0);
             if self.surface_version >= 4 {
-                inner.parts[BOTTOM].surface.damage_buffer(
+                parts[BOTTOM].surface.damage_buffer(
                     0,
                     0,
                     ((width + 2 * BORDER_SIZE) * scales[BOTTOM]) as i32,
@@ -770,14 +796,14 @@ impl Frame for ConceptFrame {
             } else {
                 // surface is old and does not support damage_buffer, so we damage
                 // in surface coordinates and hope it is not rescaled
-                inner.parts[BOTTOM].surface.damage(
+                parts[BOTTOM].surface.damage(
                     0,
                     0,
                     (width + 2 * BORDER_SIZE) as i32,
                     BORDER_SIZE as i32,
                 );
             }
-            inner.parts[BOTTOM].surface.commit();
+            parts[BOTTOM].surface.commit();
 
             // -> left-subsurface
             let buffer = pool.buffer(
@@ -787,10 +813,10 @@ impl Frame for ConceptFrame {
                 4 * (BORDER_SIZE * scales[LEFT]) as i32,
                 wl_shm::Format::Argb8888,
             );
-            inner.parts[LEFT].subsurface.set_position(-(BORDER_SIZE as i32), -(HEADER_SIZE as i32));
-            inner.parts[LEFT].surface.attach(Some(&buffer), 0, 0);
+            parts[LEFT].subsurface.set_position(-(BORDER_SIZE as i32), -(HEADER_SIZE as i32));
+            parts[LEFT].surface.attach(Some(&buffer), 0, 0);
             if self.surface_version >= 4 {
-                inner.parts[LEFT].surface.damage_buffer(
+                parts[LEFT].surface.damage_buffer(
                     0,
                     0,
                     (BORDER_SIZE * scales[LEFT]) as i32,
@@ -799,14 +825,9 @@ impl Frame for ConceptFrame {
             } else {
                 // surface is old and does not support damage_buffer, so we damage
                 // in surface coordinates and hope it is not rescaled
-                inner.parts[LEFT].surface.damage(
-                    0,
-                    0,
-                    BORDER_SIZE as i32,
-                    (height + HEADER_SIZE) as i32,
-                );
+                parts[LEFT].surface.damage(0, 0, BORDER_SIZE as i32, (height + HEADER_SIZE) as i32);
             }
-            inner.parts[LEFT].surface.commit();
+            parts[LEFT].surface.commit();
 
             // -> right-subsurface
             let buffer = pool.buffer(
@@ -816,10 +837,10 @@ impl Frame for ConceptFrame {
                 4 * (BORDER_SIZE * scales[RIGHT]) as i32,
                 wl_shm::Format::Argb8888,
             );
-            inner.parts[RIGHT].subsurface.set_position(width as i32, -(HEADER_SIZE as i32));
-            inner.parts[RIGHT].surface.attach(Some(&buffer), 0, 0);
+            parts[RIGHT].subsurface.set_position(width as i32, -(HEADER_SIZE as i32));
+            parts[RIGHT].surface.attach(Some(&buffer), 0, 0);
             if self.surface_version >= 4 {
-                inner.parts[RIGHT].surface.damage_buffer(
+                parts[RIGHT].surface.damage_buffer(
                     0,
                     0,
                     (BORDER_SIZE * scales[RIGHT]) as i32,
@@ -828,14 +849,14 @@ impl Frame for ConceptFrame {
             } else {
                 // surface is old and does not support damage_buffer, so we damage
                 // in surface coordinates and hope it is not rescaled
-                inner.parts[RIGHT].surface.damage(
+                parts[RIGHT].surface.damage(
                     0,
                     0,
                     BORDER_SIZE as i32,
                     (height + HEADER_SIZE) as i32,
                 );
             }
-            inner.parts[RIGHT].surface.commit();
+            parts[RIGHT].surface.commit();
         }
     }
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -221,6 +221,14 @@ impl<F: Frame + 'static> Window<F> {
                 }
             }) as Box<_>,
         )?;
+
+        let decoration_mgr = env.get_global::<ZxdgDecorationManagerV1>();
+        if decoration_mgr.is_none() {
+            // We don't have ServerSide decorations, so we'll be using CSD, and so should
+            // mark frame as not hidden.
+            frame.set_hidden(false);
+        }
+
         frame.resize(initial_dims);
         let frame = Rc::new(RefCell::new(frame));
         let shell_surface = Arc::new(shell::create_shell_surface(
@@ -338,7 +346,6 @@ impl<F: Frame + 'static> Window<F> {
         });
 
         // Setup window decorations if applicable.
-        let decoration_mgr = env.get_global::<ZxdgDecorationManagerV1>();
         let decoration = Self::setup_decorations_handler(
             &decoration_mgr,
             &shell_surface,


### PR DESCRIPTION
Previously 'ConceptFrame' was always creating subsurfaces, which
was consuming unnecessary resources when ServerSide decorations were
used. Now it'll create those only when frame is in fact visible.


Tested on kwin(wayland) where it fixes https://bugs.kde.org/show_bug.cgi?id=419235 , however it's still a kwin bug.
gnome(wayland)
weston
sway.