### PR TITLE
Rework 'Environment' initialization methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 #### Breaking Changes
 
 - Update `wayland-client` to version 0.28
+- `Environment::init` was renamed to `Environment::new_pending`
+- `init_default_environment!` marco was renamed to `new_default_environment!`
+
+#### Additions
+
+- `Environment::new` method to properly bootstrap environment
 
 ## 0.11.0 -- 2020-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 - Update `wayland-client` to version 0.28
 - `Environment::init` was renamed to `Environment::new_pending`
-- `init_default_environment!` marco was renamed to `new_default_environment!`
+- `init_default_environment!` macro was renamed to `new_default_environment!`
 
 #### Additions
 
-- `Environment::new` method to properly bootstrap environment
+- `Environment::new` method to fully bootstrap environment
 
 ## 0.11.0 -- 2020-08-30
 

--- a/examples/compositor_info.rs
+++ b/examples/compositor_info.rs
@@ -8,7 +8,7 @@ use sctk::shell::Shell;
 sctk::default_environment!(CompInfo, desktop);
 
 fn main() -> Result<(), ()> {
-    let (env, _display, _queue) = sctk::init_default_environment!(CompInfo, desktop)
+    let (env, _display, _queue) = sctk::new_default_environment!(CompInfo, desktop)
         .expect("Unable to connect to a Wayland compositor");
 
     println!("== Smithay's compositor info tool ==\n");

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -38,7 +38,7 @@ fn main() {
     /*
      * Initalize the wayland connection
      */
-    let (env, _display, mut queue) = sctk::init_default_environment!(ImViewerExample, desktop)
+    let (env, _display, mut queue) = sctk::new_default_environment!(ImViewerExample, desktop)
         .expect("Unable to connect to a Wayland compositor");
 
     // Use the compositor global to create a new surface

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -18,7 +18,7 @@ fn main() {
     /*
      * Initial setup
      */
-    let (env, display, queue) = sctk::init_default_environment!(KbdInputExample, desktop)
+    let (env, display, queue) = sctk::new_default_environment!(KbdInputExample, desktop)
         .expect("Unable to connect to a Wayland compositor");
 
     /*

--- a/examples/layer_shell.rs
+++ b/examples/layer_shell.rs
@@ -1,7 +1,7 @@
 use smithay_client_toolkit::{
     default_environment,
     environment::SimpleGlobal,
-    init_default_environment,
+    new_default_environment,
     output::{with_output_info, OutputInfo},
     reexports::{
         calloop,
@@ -144,7 +144,7 @@ impl Drop for Surface {
 
 fn main() {
     let (env, display, queue) =
-        init_default_environment!(Env, fields = [layer_shell: SimpleGlobal::new(),])
+        new_default_environment!(Env, fields = [layer_shell: SimpleGlobal::new(),])
             .expect("Initial roundtrip failed!");
 
     let surfaces = Rc::new(RefCell::new(Vec::new()));

--- a/examples/pointer_input.rs
+++ b/examples/pointer_input.rs
@@ -59,7 +59,7 @@ fn main() {
     /*
      * Initial setup
      */
-    let (env, _display, mut queue) = sctk::init_default_environment!(PtrInputExample, desktop)
+    let (env, _display, mut queue) = sctk::new_default_environment!(PtrInputExample, desktop)
         .expect("Unable to connect to a Wayland compositor");
 
     /*

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -32,7 +32,7 @@ fn main() {
     /*
      * Initial setup
      */
-    let (env, display, queue) = sctk::init_default_environment!(SelectionExample, desktop)
+    let (env, display, queue) = sctk::new_default_environment!(SelectionExample, desktop)
         .expect("Unable to connect to a Wayland compositor");
 
     /*

--- a/examples/themed_frame.rs
+++ b/examples/themed_frame.rs
@@ -72,7 +72,7 @@ fn main() {
     /*
      * Initial setup
      */
-    let (env, _display, mut queue) = sctk::init_default_environment!(ThemedFrameExample, desktop)
+    let (env, _display, mut queue) = sctk::new_default_environment!(ThemedFrameExample, desktop)
         .expect("Unable to connect to a Wayland compositor");
     /*
      * Create a buffer with window contents

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -108,8 +108,9 @@ impl<E: InnerEnv + 'static> Environment<E> {
     /// [`new_default_environment!`](../macro.new_default_environment.html) macro.
     ///
     /// `std::io::Error` could be returned if initial roundtrips to the server failed.
-    /// This call may block when doing initial roundtrips, but those blocks could only be due to
-    /// server bugs.
+    ///
+    /// If this call indefinitely blocks when doing initial roundtrips this can only be
+    /// caused by server bugs.
     pub fn new(
         display: &Attached<wl_display::WlDisplay>,
         queue: &mut EventQueue,
@@ -135,7 +136,7 @@ impl<E: InnerEnv + 'static> Environment<E> {
     /// [`new_default_environment!`](../macro.new_default_environment.html) macro.
     ///
     /// You should prefer to use `Environment::new`, unless you want to control initialization
-    /// manually or you create additional environement meaning that the initialization may be fine
+    /// manually or you create additional environment meaning that the initialization may be fine
     /// with just `dispatch_pending` of the event queue, instead of two roundtrips to
     /// fully initialize environment. If you manually initialize your environment two sync
     /// roundtrips are required.

--- a/src/output.rs
+++ b/src/output.rs
@@ -4,7 +4,7 @@
 //! [`OutputHandler`](struct.OutputHandler.html) type, which is a
 //! [`MultiGlobalHandler`](../environment/trait.MultiGlobalHandler.html) for
 //! use with the [`init_environment!`](../macro.init_environment.html) macro. It is automatically
-//! included if you use the [`init_default_environment!`](../macro.init_default_environment.html).
+//! included if you use the [`new_default_environment!`](../macro.new_default_environment.html).
 //!
 //! The second is the [`with_output_info`](fn.with_output_info.html) with allows you to
 //! access the information associated to this output, as an [`OutputInfo`](struct.OutputInfo.html).
@@ -113,7 +113,7 @@ type OutputStatusCallback = dyn FnMut(WlOutput, &OutputInfo, DispatchData) + 'st
 ///
 /// This handler can be used for managing `wl_output` in the
 /// [`init_environment!`](../macro.init_environment.html) macro, and is automatically
-/// included in [`init_default_environment!`](../macro.init_default_environment.html).
+/// included in [`new_default_environment!`](../macro.new_default_environment.html).
 ///
 /// It aggregates the output information and makes it available via the
 /// [`with_output_info`](fn.with_output_info.html) function.

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -187,7 +187,7 @@ struct ShellInner {
 ///     }
 /// }
 ///
-/// let env = Environment::init(&attached_display, MyEnv {
+/// let env = Environment::new(&attached_display, &mut queue, MyEnv {
 ///     my_shell: ShellHandler::new()
 /// });
 /// ```


### PR DESCRIPTION
Previously 'Environment' was initialized via 'init' method,
and then it was requiring downstream to perform two sync roundtrips
to the server, which wasn't ergonomic for rust API, however the
initialization without two roundtrips could be preferred in some
scenarios.

This commit adds new method 'Environment::new', which will take
'EventQueue' and perform proper initialization for the users. The old
method is now named 'Environment::new_pending', and you'll still have
to perform two roundtrips.

In addition, this commit renames 'init_default_environment!' to
'new_default_environment!' to respect new naming scheme.