### PR TITLE
Add 'must_use' annotations for listeners

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -424,6 +424,7 @@ impl<E: OutputHandling> crate::environment::Environment<E> {
     ///
     /// The returned [`OutputStatusListener`](../output/struct.OutputStatusListener.hmtl) keeps your
     /// callback alive, dropping it will disable it.
+    #[must_use = "the returned OutputStatusListener keeps your callback alive, dropping it will disable it"]
     pub fn listen_for_outputs<F: FnMut(WlOutput, &OutputInfo, DispatchData) + 'static>(
         &self,
         f: F,

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -272,6 +272,7 @@ impl<E: SeatHandling> crate::environment::Environment<E> {
     ///
     /// The returned [`SeatListener`](../seat/struct.SeatListener.hmtl) keeps your callback alive,
     /// dropping it will disable it.
+    #[must_use = "the returned SeatListener keeps your callback alive, dropping it will disable it"]
     pub fn listen_for_seats<
         F: FnMut(Attached<wl_seat::WlSeat>, &SeatData, DispatchData) + 'static,
     >(


### PR DESCRIPTION
It makes more clear that the result from calling 'listen_for_seats'
and 'listen_for_outputs' must be kept around to keep the user's callback
alive.

Example of how it looks.
```
warning: unused return value of `sctk::seat::<impl sctk::environment::Environment<E>>::listen_for_seats` that must be used
   --> examples/kbd_input.rs:105:5
    |
105 | /     env.listen_for_seats(move |seat, seat_data, _| {
106 | |         // find the seat in the vec of seats, or insert it if it is unknown
107 | |         let idx = seats.iter().position(|(name, _)| name == &seat_data.name);
108 | |         let idx = idx.unwrap_or_else(|| {
...   |
140 | |         }
141 | |     });
    | |_______^
    |
    = note: `#[warn(unused_must_use)]` on by default
    = note: the returned SeatListener keeps your callback alive, dropping it will disawarning: unused return value of `sctk::seat::<impl sctk::environment::Environment<E>>::listen_for_seats` that must be used
ble it

warning: 1 warning emitte   --> examples/kbd_input.rs:105:5
d
    |
105 | /     env.listen_for_seats(move |seat, seat_data, _| {
106 | |         // find the seat in the vec of seats, or insert it if it is unknown
107 | |         let idx = seats.iter().position(|(name, _)| name == &seat_data.name);
108 | |         let idx = idx.unwrap_or_else(|| {
...   |
140 | |         }
141 | |     });
    | |_______^
    |
    = note: `#[warn(unused_must_use)]` on by default
    = note: the returned SeatListener keeps your callback alive, dropping it will disable it

warning: 1 warning emitted

```