### PR TITLE
keyboard: use SmallVec for the Enter event's currently pressed keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ wayland-protocols = { version = "0.28" , features = ["client", "unstable_protoco
 wayland-cursor = "0.28"
 calloop = { version = "0.6.1", optional = true }
 byteorder = "1.0"
+smallvec = "1"
 
 [features]
 default = ["frames", "calloop"]


### PR DESCRIPTION
The Event enum used string slices referencing stack-allocated Vecs (that were not reused anywhere else).
The lifetime makes it awkward for consumers (no way to e.g. store the Event somewhere) but I doubt
that it was a useful optimization (even if the optimizer can't allocate the Vec directly in the resulting enum,
creating a slice of it is hardly better than moving it: you still write the address and size, just not the capacity).

However, we can use SmallVec (already a dependency of wayland-rs) for an actual optimization:
this will avoid allocating Vec contents if 1-2 keys are held when the surface gets keyboard focus.

---

Unfortunately this does change the public API (e.g. `winit` would need to drop a `<'_>`) — it's possible to add a `PhantomData` for the lifetime though, but accumulating backwards compat junk on 0.x versions is ehh :/