### PR TITLE
Replace memmap with memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = "1.0"
 nix = "0.18"
 dlib = "0.4"
 lazy_static = "1.0"
-memmap = "0.7"
+mapr = "0.8.0"
 andrew = { version = "0.3.0", optional = true }
 log = "0.4"
 wayland-client = "0.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = "1.0"
 nix = "0.18"
 dlib = "0.4"
 lazy_static = "1.0"
-mapr = "0.8.0"
+memmap2 = "0.1.0"
 andrew = { version = "0.3.0", optional = true }
 log = "0.4"
 wayland-client = "0.28"

--- a/src/seat/keyboard/state.rs
+++ b/src/seat/keyboard/state.rs
@@ -1,4 +1,4 @@
-use memmap::MmapOptions;
+use mapr::MmapOptions;
 use std::{env, ffi::CString, fs::File, os::raw::c_char, os::unix::ffi::OsStringExt, ptr};
 
 use super::ffi::{self, xkb_state_component, XKBCOMMON_HANDLE as XKBH};

--- a/src/seat/keyboard/state.rs
+++ b/src/seat/keyboard/state.rs
@@ -1,4 +1,4 @@
-use mapr::MmapOptions;
+use memmap2::MmapOptions;
 use std::{env, ffi::CString, fs::File, os::raw::c_char, os::unix::ffi::OsStringExt, ptr};
 
 use super::ffi::{self, xkb_state_component, XKBCOMMON_HANDLE as XKBH};

--- a/src/shm/mempool.rs
+++ b/src/shm/mempool.rs
@@ -18,7 +18,7 @@ use nix::{
     unistd,
 };
 
-use mapr::MmapMut;
+use memmap2::MmapMut;
 
 use wayland_client::{
     protocol::{wl_buffer, wl_shm, wl_shm_pool},
@@ -212,7 +212,7 @@ impl MemPool {
         (*buffer).clone().detach()
     }
 
-    /// Uses the mapr crate to map the underlying shared memory file
+    /// Uses the memmap2 crate to map the underlying shared memory file
     pub fn mmap(&mut self) -> &mut MmapMut {
         &mut self.mmap
     }

--- a/src/shm/mempool.rs
+++ b/src/shm/mempool.rs
@@ -18,7 +18,7 @@ use nix::{
     unistd,
 };
 
-use memmap::MmapMut;
+use mapr::MmapMut;
 
 use wayland_client::{
     protocol::{wl_buffer, wl_shm, wl_shm_pool},
@@ -212,7 +212,7 @@ impl MemPool {
         (*buffer).clone().detach()
     }
 
-    /// Uses the memmap crate to map the underlying shared memory file
+    /// Uses the mapr crate to map the underlying shared memory file
     pub fn mmap(&mut self) -> &mut MmapMut {
         &mut self.mmap
     }


### PR DESCRIPTION
This pull request replaces the memmap dependency with the mapr crate in accordance with [this Rust security advisory](https://rustsec.org/advisories/RUSTSEC-2020-0077). I had at first proposed the memmap2 crate, but after seeing that the last release was from a year ago, switched to mapr. Closes #165.

This is my first time contributing to smithay-client-toolkit. Let me know if I need to do anything else.

Edit: Now replacing with memmap2 because of FreeBSD issues.