### PR TITLE
Remove byteorder dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Changes
+
+- Dependency on `byteorder` was replaced with `u32::from_ne_bytes()`
+
 ## 0.12.1 -- 2020-12-08
 
 #### Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ wayland-client = "0.28"
 wayland-protocols = { version = "0.28" , features = ["client", "unstable_protocols"] }
 wayland-cursor = "0.28"
 calloop = { version = "0.6.1", optional = true }
-byteorder = "1.0"
 
 [features]
 default = ["frames", "calloop"]

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -1,11 +1,8 @@
-extern crate byteorder;
 extern crate image;
 extern crate smithay_client_toolkit as sctk;
 
 use std::env;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
-
-use byteorder::{NativeEndian, WriteBytesExt};
 
 use sctk::reexports::client::protocol::{wl_shm, wl_surface};
 use sctk::shm::MemPool;
@@ -288,14 +285,15 @@ fn redraw(
                 let g = ::std::cmp::min(0xFF, (0xFF * (0xFF - a) + a * g) / 0xFF);
                 let b = ::std::cmp::min(0xFF, (0xFF * (0xFF - a) + a * b) / 0xFF);
                 // write the pixel
-                // We use byteorder, as the wayland protocol explicitly specifies
+                // The wayland protocol explicitly specifies
                 // that the pixels must be written in native endianness
-                writer.write_u32::<NativeEndian>((0xFF << 24) + (r << 16) + (g << 8) + b)?;
+                let pixel: u32 = (0xFF << 24) + (r << 16) + (g << 8) + b;
+                writer.write_all(&pixel.to_ne_bytes())?;
             }
         } else {
             // We do not have any image to draw, so we draw black contents
             for _ in 0..(buf_x * buf_y) {
-                writer.write_u32::<NativeEndian>(0xFF000000)?;
+                writer.write_all(&0xFF000000u32.to_ne_bytes())?;
             }
         }
         // Don't forget to flush the writer, to make sure all the contents are

--- a/examples/kbd_input.rs
+++ b/examples/kbd_input.rs
@@ -1,10 +1,7 @@
-extern crate byteorder;
 extern crate smithay_client_toolkit as sctk;
 
 use std::cmp::min;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
-
-use byteorder::{NativeEndian, WriteBytesExt};
 
 use sctk::reexports::calloop;
 use sctk::reexports::client::protocol::{wl_keyboard, wl_shm, wl_surface};
@@ -223,7 +220,8 @@ fn redraw(
             let r: u32 = min(((buf_x - x) * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
             let g: u32 = min((x * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
             let b: u32 = min(((buf_x - x) * 0xFF) / buf_x, (y * 0xFF) / buf_y);
-            writer.write_u32::<NativeEndian>((0xFF << 24) + (r << 16) + (g << 8) + b)?;
+            let pixel: u32 = (0xFF << 24) + (r << 16) + (g << 8) + b;
+            writer.write_all(&pixel.to_ne_bytes())?;
         }
         writer.flush()?;
     }

--- a/examples/layer_shell.rs
+++ b/examples/layer_shell.rs
@@ -15,8 +15,6 @@ use smithay_client_toolkit::{
     WaylandSource,
 };
 
-use byteorder::{NativeEndian, WriteBytesExt};
-
 use std::cell::{Cell, RefCell};
 use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::rc::Rc;
@@ -121,7 +119,7 @@ impl Surface {
         {
             let mut writer = BufWriter::new(&mut *pool);
             for _ in 0..(width * height) {
-                writer.write_u32::<NativeEndian>(0xff00ff00).unwrap();
+                writer.write_all(&0xff00ff00u32.to_ne_bytes()).unwrap();
             }
             writer.flush().unwrap();
         }

--- a/examples/pointer_input.rs
+++ b/examples/pointer_input.rs
@@ -1,10 +1,7 @@
-extern crate byteorder;
 extern crate smithay_client_toolkit as sctk;
 
 use std::cmp::min;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
-
-use byteorder::{NativeEndian, WriteBytesExt};
 
 use sctk::reexports::client::protocol::{wl_pointer, wl_shm, wl_surface};
 use sctk::shm::MemPool;
@@ -211,7 +208,8 @@ fn redraw(
             let r: u32 = min(((buf_x - x) * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
             let g: u32 = min((x * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
             let b: u32 = min(((buf_x - x) * 0xFF) / buf_x, (y * 0xFF) / buf_y);
-            writer.write_u32::<NativeEndian>((0xFF << 24) + (r << 16) + (g << 8) + b)?;
+            let pixel = (0xFF << 24) + (r << 16) + (g << 8) + b;
+            writer.write_all(&pixel.to_ne_bytes())?;
         }
         writer.flush()?;
     }

--- a/examples/selection.rs
+++ b/examples/selection.rs
@@ -1,9 +1,6 @@
-extern crate byteorder;
 extern crate smithay_client_toolkit as sctk;
 
 use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
-
-use byteorder::{NativeEndian, WriteBytesExt};
 
 use sctk::{
     data_device::{DataSourceEvent, ReadPipe},
@@ -344,7 +341,7 @@ fn redraw(
     {
         let mut writer = BufWriter::new(&mut *pool);
         for _ in 0..(buf_x * buf_y) {
-            writer.write_u32::<NativeEndian>(0xFF000000)?;
+            writer.write(&0xFF000000u32.to_ne_bytes())?;
         }
         writer.flush()?;
     }

--- a/examples/themed_frame.rs
+++ b/examples/themed_frame.rs
@@ -1,10 +1,7 @@
-extern crate byteorder;
 extern crate smithay_client_toolkit as sctk;
 
 use std::cmp::min;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
-
-use byteorder::{NativeEndian, WriteBytesExt};
 
 use sctk::reexports::client::protocol::{wl_shm, wl_surface};
 use sctk::shm::MemPool;
@@ -169,7 +166,8 @@ fn redraw(
             let r: u32 = min(((buf_x - x) * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
             let g: u32 = min((x * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
             let b: u32 = min(((buf_x - x) * 0xFF) / buf_x, (y * 0xFF) / buf_y);
-            writer.write_u32::<NativeEndian>((0xFF << 24) + (r << 16) + (g << 8) + b)?;
+            let pixel: u32 = (0xFF << 24) + (r << 16) + (g << 8) + b;
+            writer.write_all(&pixel.to_ne_bytes())?;
         }
         writer.flush()?;
     }

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -18,12 +18,11 @@ use std::num::NonZeroU32;
 use std::time::Duration;
 use std::{
     cell::RefCell,
+    convert::TryInto,
     fs::File,
     os::unix::io::{FromRawFd, RawFd},
     rc::Rc,
 };
-
-use byteorder::{ByteOrder, NativeEndian};
 
 pub use wayland_client::protocol::wl_keyboard::KeyState;
 use wayland_client::{
@@ -393,7 +392,7 @@ impl KbdHandler {
         dispatch_data: wayland_client::DispatchData,
     ) {
         let mut state = self.state.borrow_mut();
-        let rawkeys = keys.chunks_exact(4).map(NativeEndian::read_u32).collect::<Vec<_>>();
+        let rawkeys = keys.chunks_exact(4).map(|c| u32::from_ne_bytes(c.try_into().unwrap())).collect::<Vec<_>>();
         let keys: Vec<u32> = rawkeys.iter().map(|k| state.get_one_sym_raw(*k)).collect();
         (&mut *self.callback.borrow_mut())(
             Event::Enter { serial, surface, rawkeys: &rawkeys, keysyms: &keys },

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -392,7 +392,10 @@ impl KbdHandler {
         dispatch_data: wayland_client::DispatchData,
     ) {
         let mut state = self.state.borrow_mut();
-        let rawkeys = keys.chunks_exact(4).map(|c| u32::from_ne_bytes(c.try_into().unwrap())).collect::<Vec<_>>();
+        let rawkeys = keys
+            .chunks_exact(4)
+            .map(|c| u32::from_ne_bytes(c.try_into().unwrap()))
+            .collect::<Vec<_>>();
         let keys: Vec<u32> = rawkeys.iter().map(|k| state.get_one_sym_raw(*k)).collect();
         (&mut *self.callback.borrow_mut())(
             Event::Enter { serial, surface, rawkeys: &rawkeys, keysyms: &keys },

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -1,6 +1,4 @@
-use std::{cell::RefCell, rc::Rc};
-
-use byteorder::{ByteOrder, NativeEndian};
+use std::{cell::RefCell, convert::TryInto, rc::Rc};
 
 use wayland_client::{
     protocol::{wl_output, wl_seat, wl_surface},
@@ -59,7 +57,7 @@ impl Xdg {
                     };
                     let translated_states = states
                         .chunks_exact(4)
-                        .map(NativeEndian::read_u32)
+                        .map(|c| u32::from_ne_bytes(c.try_into().unwrap()))
                         .flat_map(xdg_toplevel::State::from_raw)
                         .collect::<Vec<_>>();
 

--- a/src/shell/zxdg.rs
+++ b/src/shell/zxdg.rs
@@ -1,6 +1,4 @@
-use std::{cell::RefCell, rc::Rc};
-
-use byteorder::{ByteOrder, NativeEndian};
+use std::{cell::RefCell, convert::TryInto, rc::Rc};
 
 use wayland_client::{
     protocol::{wl_output, wl_seat, wl_surface},
@@ -62,7 +60,7 @@ impl Zxdg {
                     };
                     let translated_states = states
                         .chunks_exact(4)
-                        .map(NativeEndian::read_u32)
+                        .map(|c| u32::from_ne_bytes(c.try_into().unwrap()))
                         .flat_map(xdg_toplevel::State::from_raw)
                         .collect::<Vec<_>>();
 


### PR DESCRIPTION
This PR removes the dependency on the byteorder crate.

My motivation is a bad one: Less dependencies! (and byteorder is not really necessary for the things that are done here)
My testing is weak: `cargo build --all-targets && cargo test` succeeds. I did not even run any of the examples since I do not have a wayland compositor at hand.

I did this in separate commits so that in case something is wrong, `git bisect` is more helpful. However, I am not sure if that is really necessary. If wanted, I can squash this.