### PR TITLE
Implement `start_interactive_move`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Additions
+
+- `Window::start_interactive_move` to enable dragging the window with a user action
+
 ## 0.12.2 -- 2020-12-30
 
 #### Changes

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -669,6 +669,26 @@ impl<F: Frame + 'static> Window<F> {
     pub fn set_frame_config(&mut self, config: F::Config) {
         self.frame.borrow_mut().set_config(config)
     }
+
+    /// Start an interactive, user-driven move of the surface
+    ///
+    /// This request must be used in response to some sort of user action
+    /// like a button press, key press, or touch down event. The passed
+    /// serial is used to determine the type of interactive move (touch,
+    /// pointer, etc).
+    ///
+    /// The server may ignore move requests depending on the state of
+    /// the surface (e.g. fullscreen or maximized), or if the passed serial
+    /// is no longer valid.
+    ///
+    /// If triggered, the surface will lose the focus of the device
+    /// (wl_pointer, wl_touch, etc) used for the move. It is up to the
+    /// compositor to visually indicate that the move is taking place, such as
+    /// updating a pointer cursor, during the move. There is no guarantee
+    /// that the device focus will return when the move is completed.
+    pub fn start_interactive_move(&self, seat: &wl_seat::WlSeat, serial: u32) {
+        self.shell_surface.move_(seat, serial);
+    }
 }
 
 impl<F: Frame> Drop for Window<F> {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -680,12 +680,6 @@ impl<F: Frame + 'static> Window<F> {
     /// The server may ignore move requests depending on the state of
     /// the surface (e.g. fullscreen or maximized), or if the passed serial
     /// is no longer valid.
-    ///
-    /// If triggered, the surface will lose the focus of the device
-    /// (wl_pointer, wl_touch, etc) used for the move. It is up to the
-    /// compositor to visually indicate that the move is taking place, such as
-    /// updating a pointer cursor, during the move. There is no guarantee
-    /// that the device focus will return when the move is completed.
     pub fn start_interactive_move(&self, seat: &wl_seat::WlSeat, serial: u32) {
         self.shell_surface.move_(seat, serial);
     }


### PR DESCRIPTION
As discussed in chat.

I have copied the documentation from the wayland-protocols specification, as I have basically very little clue about Wayland I'm open to suggestions, thank you.

~~I will leave it as a draft until I try it out, which I'm in the process of doing at the moment.~~
Tested with https://github.com/rust-windowing/winit/pull/1840, works like a charm.