### PR TITLE
Add optional xdg_output support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Batch output information updates instead of potentially making multiple
+  callbacks for one logical change
+
 #### Additions
 
 - `Window::start_interactive_move` to enable dragging the window with a user action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Batch output information updates instead of potentially making multiple
   callbacks for one logical change
 
+#### Breaking Changes
+
+- Mark OutputInfo as `#[non_exhaustive]` to allow future expansion without
+  breaking API.
+
 #### Additions
 
 - `Window::start_interactive_move` to enable dragging the window with a user action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Batch output information updates instead of potentially making multiple
   callbacks for one logical change
+- Add name and description fields to OutputInfo.
 
 #### Breaking Changes
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -41,6 +41,7 @@ pub struct Mode {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 /// Compiled information about an output
 pub struct OutputInfo {
     /// The ID of this output as a global


### PR DESCRIPTION
This adds name and description fields to OutputInfo and populates them if a properly initialized XdgOutputHandler is present.  If the global is not present or not offered by the server, output handling is unchanged and the new fields will be blank.