### PR TITLE
Allow linking to libxkbcommon at compile time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
 
+      - name: Install libxkbcommon
+        run: sudo apt-get install libxkbcommon-dev
+
       - name: Test lib no features
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 bitflags = "1.0"
 nix = "0.19"
-dlib = "0.4"
+dlib = "0.5"
 lazy_static = "1.0"
 memmap2 = "0.2.0"
 andrew = { version = "0.3.0", optional = true }
@@ -25,7 +25,8 @@ wayland-cursor = "0.28"
 calloop = { version = "0.6.1", optional = true }
 
 [features]
-default = ["frames", "calloop"]
+default = ["frames", "calloop", "dlopen"]
+dlopen = ["wayland-client/dlopen"]
 frames = ["andrew"]
 
 [dev-dependencies]

--- a/src/seat/keyboard/ffi.rs
+++ b/src/seat/keyboard/ffi.rs
@@ -174,7 +174,7 @@ bitflags::bitflags!(
     }
 );
 
-dlopen_external_library!(XkbCommon,
+external_library!(XkbCommon, "xkbcommon",
 functions:
     fn xkb_keysym_get_name(xkb_keysym_t, *mut c_char, usize) -> c_int,
     fn xkb_keysym_from_name(*const c_char, xkb_keysym_flags) -> xkb_keysym_t,
@@ -253,8 +253,9 @@ functions:
     fn xkb_compose_state_get_one_sym(*mut xkb_compose_state) -> xkb_keysym_t,
 );
 
+#[cfg(feature = "dlopen")]
 lazy_static::lazy_static!(
-    pub static ref XKBCOMMON_OPTION: Option<XkbCommon> = {
+    pub static ref XKBCOMMON_OPTION: Option<XkbCommon> = unsafe {
         XkbCommon::open("libxkbcommon.so.0")
             .or_else(|_| XkbCommon::open("libxkbcommon.so"))
             .ok()


### PR DESCRIPTION
I am packaging a version of [alacritty](https://github.com/alacritty/alacritty) that runs on Wayland (without Xwayland) for [Guix](https://guix.gnu.org/), a distro which, like NixOS, stores all shared libraries in a [weird place](https://guix.gnu.org/manual/en/html_node/The-Store.html). The dynamic linker doesn't check this path by default, so sometimes packagers are forced to modify the library search path after building, but a better way is to link to the library at compile time.

This commit introduces a "dlopen" feature that is enabled by default that preserves the existing behavior of not linking to libxkbcommon except for trying to dlopen it at runtime. If the feature is disabled, cargo will link to the system's libxkbcommon.so at compile time.

To do this, I used the [generic macros in dlib](https://github.com/vberger/dlib/blob/7352a7731b687dcba6446c8c8362a7c13f409fcb/README.md#remaining-generic-in-your-crate) which either dlopen the library in a lazy_static struct like the current behavior, or invoke the "statically dynamically-linked" functions if the dlopen feature is turned off.