### PR TITLE
Add an alternate AutoMemPool for allocating buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   `FallbackFrame`. Dependency on `andrew` and `fontconfig` is dropped in the process. If fancier
   decorations are needed, they should be implemented using the `Frame` trait.
 
+#### Additions
+
+- `AutoMemPool` added as an alternative to the existing SHM pools
+
 ## 0.13.0 - 2021-03-04
 
 #### Breaking Changes

--- a/src/shm/mempool.rs
+++ b/src/shm/mempool.rs
@@ -109,13 +109,13 @@ impl Inner {
     fn new(shm: Attached<wl_shm::WlShm>) -> io::Result<Self> {
         let mem_fd = create_shm_fd()?;
         let mem_file = unsafe { File::from_raw_fd(mem_fd) };
-        mem_file.set_len(128)?;
+        mem_file.set_len(4096)?;
 
-        let pool = shm.create_pool(mem_fd, 128);
+        let pool = shm.create_pool(mem_fd, 4096);
 
         let mmap = unsafe { MmapMut::map_mut(&mem_file).unwrap() };
 
-        Ok(Inner { file: mem_file, len: 128, pool, mmap })
+        Ok(Inner { file: mem_file, len: 4096, pool, mmap })
     }
 
     fn resize(&mut self, newsize: usize) -> io::Result<()> {

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -9,7 +9,7 @@ use wayland_client::{
 
 mod mempool;
 
-pub use self::mempool::{DoubleMemPool, MemPool};
+pub use self::mempool::{AutoMemPool, DoubleMemPool, MemPool};
 pub use wl_shm::Format;
 
 /// A handler for the `wl_shm` global


### PR DESCRIPTION
This tracks the allocation of regions in a MemPool along with the
Wayland server's release operations instead of requiring a callback to
notify the client that reuse is possible.

Note that even with the normal MemPool, clients should prefer using
wl_surface::frame to delay draw operations instead of using the SHM
release callback.