### PR TITLE
Add minimum alignment guarantees to buffers from AutoMemPool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Additions
+
+- `AutoMemPool` now guarantees a minimum alignment of returned buffers
+
 ## 0.14.0 - 2021-05-07
 
 #### Breaking Changes


### PR DESCRIPTION
This mostly already happens, but it is useful to guarantee it, especially if rendering directly to the shm canvas.