### PR TITLE
Bump memmap2 to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = "1.0"
 nix = "0.20"
 dlib = "0.5"
 lazy_static = "1.0"
-memmap2 = "0.2.0"
+memmap2 = "0.3.0"
 log = "0.4"
 wayland-client = "0.28"
 wayland-protocols = { version = "0.28" , features = ["client", "unstable_protocols"] }


### PR DESCRIPTION
This PR updates the memmap2 dependency to the latest version.
The change does not seem to require any actual code changes. Builds fine and all tests pass.