### PR TITLE
use pkg-config to properly link to xkbcommon library when build without dlopen feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Bugfixes
+
+- when not using `dlopen` feature, `xkbdcommon` library is linked using `pkg-config`
+
 ## 0.15.0 - 2021-08-10
 
 #### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,8 @@ calloop = { version = "0.9.1", optional = true }
 default = ["calloop", "dlopen"]
 dlopen = ["wayland-client/dlopen"]
 
+[build-dependencies]
+pkg-config = "0.3"
+
 [dev-dependencies]
 image = "0.23"

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,5 @@ extern crate pkg_config;
 
 fn main() {
     #[cfg(not(feature = "dlopen"))]
-    if pkg_config::Config::new().find("xkbcommon").is_ok() {
-        return;
-    }
+    pkg_config::Config::new().find("xkbcommon").unwrap();
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+extern crate pkg_config;
+
+fn main() {
+    #[cfg(not(feature = "dlopen"))]
+    if pkg_config::Config::new().find("xkbcommon").is_ok() {
+        return;
+    }
+}


### PR DESCRIPTION
some OS (like OpenBSD or NetBSD) places third-parties libraries in no default paths, and requires explicit configuration to link to them. It makes smithay-client-toolkit difficult to build on such systems, as when not using `dlopen` feature, the build will fail.

For example, with alacritty build:
```
Building [=======================> ] 188/189: alacritty(bin)

error: linking with `cc` failed: exit status: 1
  |
  = note: [annoying stuff]
  = note: ld: error: unable to find library -lxkbcommon
          cc: error: linker command failed with exit code 1 (use -v to see invocation)

error: aborting due to previous error

error: could not compile `alacritty`

To learn more, run the command again with --verbose.
```

Currently, there is no way to specify a directory in smithay-client-toolkit to found the library and properly link to it.

This PR uses `pkg-config` crate to configure build script to properly locate the library based on pkg-config configuration file.