### PR TITLE
Add max_version parameter to SimpleGlobal

### DIFF
--- a/examples/layer_shell.rs
+++ b/examples/layer_shell.rs
@@ -134,7 +134,7 @@ impl Drop for Surface {
 
 fn main() {
     let (env, display, queue) =
-        new_default_environment!(Env, fields = [layer_shell: SimpleGlobal::new(),])
+        new_default_environment!(Env, fields = [layer_shell: SimpleGlobal::new(4),])
             .expect("Initial roundtrip failed!");
 
     let surfaces = Rc::new(RefCell::new(Vec::new()));

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -32,6 +32,7 @@
 //! [`default_environment!`](../macro.default_environment.html) macro to quickly setup things and bring
 //! in all SCTK modules.
 
+use std::cmp::min;
 use std::io::Result;
 use std::rc::Rc;
 use std::{cell::RefCell, fmt};
@@ -266,12 +267,13 @@ pub trait InnerEnv {
 #[derive(Debug)]
 pub struct SimpleGlobal<I: Interface> {
     global: Option<Attached<I>>,
+    max_version: u32,
 }
 
 impl<I: Interface> SimpleGlobal<I> {
     /// Create a new handler
-    pub fn new() -> SimpleGlobal<I> {
-        SimpleGlobal { global: None }
+    pub fn new(max_version: u32) -> SimpleGlobal<I> {
+        SimpleGlobal { global: None, max_version }
     }
 }
 
@@ -283,6 +285,7 @@ impl<I: Interface + Clone + From<Proxy<I>> + AsRef<Proxy<I>>> GlobalHandler<I> f
         version: u32,
         _: DispatchData,
     ) {
+        let version = min(version, min(I::VERSION, self.max_version));
         self.global = Some((*registry.bind::<I>(version, id)).clone())
     }
     fn get(&self) -> Option<Attached<I>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@ macro_rules! new_default_environment {
             $(with=($display, $queue),)?
             fields = [
                 sctk_shell: $crate::shell::ShellHandler::new(),
-                sctk_decoration_mgr: $crate::environment::SimpleGlobal::new(),
+                sctk_decoration_mgr: $crate::environment::SimpleGlobal::new(1),
                 $($(
                     $fname: $fval,
                 )*)?
@@ -350,8 +350,8 @@ macro_rules! new_default_environment {
 
             let display = $crate::reexports::client::Proxy::clone(&$display);
             let env = $crate::environment::Environment::new(&display.attach($queue.token()), &mut $queue,$env_name {
-                sctk_compositor: $crate::environment::SimpleGlobal::new(),
-                sctk_subcompositor: $crate::environment::SimpleGlobal::new(),
+                sctk_compositor: $crate::environment::SimpleGlobal::new(5),
+                sctk_subcompositor: $crate::environment::SimpleGlobal::new(5),
                 sctk_shm: $crate::shm::ShmHandler::new(),
                 sctk_outputs: $crate::output::OutputHandler::new(),
                 sctk_seats,

--- a/src/output.rs
+++ b/src/output.rs
@@ -566,7 +566,7 @@ impl<E: crate::environment::MultiGlobalHandler<WlOutput>> crate::environment::En
 ///  let (sctk_outputs, sctk_xdg_out) = smithay_client_toolkit::output::XdgOutputHandler::new_output_handlers();
 ///
 ///  let env = smithay_client_toolkit::environment::Environment::new(&wl_display, &mut wl_queue, Globals {
-///      sctk_compositor: SimpleGlobal::new(),
+///      sctk_compositor: SimpleGlobal::new(5),
 ///      sctk_shm: smithay_client_toolkit::shm::ShmHandler::new(),
 ///      sctk_seats : smithay_client_toolkit::seat::SeatHandler::new(),
 ///      sctk_shell : smithay_client_toolkit::shell::ShellHandler::new(),


### PR DESCRIPTION
This is needed because new versions of protocols can change in a
backwards-incompatible manner, and clients unaware of the changes can
crash or behave incorrectly.

Note that Interface::VERSION on its own is not enough for this purpose,
because a protocol can make a backwards-incompatible change affecting
only the specified behaviour of the client without changing the interface
description.

Fixes https://github.com/Smithay/client-toolkit/issues/186