### PR TITLE
xdg-shell (0.30): split windowing out of XdgShellState

### DIFF
--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -12,7 +12,7 @@ use smithay_client_toolkit::{
         Capability, SeatHandler, SeatState,
     },
     shell::xdg::{
-        window::{Window, WindowHandler},
+        window::{Window, WindowHandler, XdgWindowState},
         XdgShellHandler, XdgShellState,
     },
     shm::{pool::raw::RawPool, ShmHandler, ShmState},
@@ -42,6 +42,7 @@ fn main() {
         compositor_state: CompositorState::new(),
         shm_state: ShmState::new(),
         xdg_shell_state: XdgShellState::new(),
+        xdg_window_state: XdgWindowState::new(),
 
         exit: false,
         first_configure: true,
@@ -73,7 +74,7 @@ fn main() {
     let surface = simple_window.compositor_state.create_surface(&mut conn.handle(), &qh).unwrap();
 
     let window = simple_window
-        .xdg_shell_state
+        .xdg_window_state
         .create_window(&mut conn.handle(), &qh, surface)
         .expect("window");
 
@@ -106,6 +107,7 @@ struct SimpleWindow {
     compositor_state: CompositorState,
     shm_state: ShmState,
     xdg_shell_state: XdgShellState,
+    xdg_window_state: XdgWindowState,
 
     exit: bool,
     first_configure: bool,
@@ -213,6 +215,10 @@ impl XdgShellHandler for SimpleWindow {
 }
 
 impl WindowHandler for SimpleWindow {
+    fn xdg_window_state(&mut self) -> &mut XdgWindowState {
+        &mut self.xdg_window_state
+    }
+
     fn request_close_window(
         &mut self,
         _: &mut ConnectionHandle,
@@ -528,6 +534,7 @@ delegate_registry!(SimpleWindow: [
     ShmState,
     SeatState,
     XdgShellState,
+    XdgWindowState,
 ]);
 
 impl ProvidesRegistryState for SimpleWindow {

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1,5 +1,5 @@
 use std::sync::{
-    atomic::{AtomicBool, AtomicI32, Ordering},
+    atomic::{AtomicI32, Ordering},
     Mutex,
 };
 
@@ -75,11 +75,7 @@ impl CompositorState {
         let surface = compositor.create_surface(
             conn,
             qh,
-            SurfaceData {
-                scale_factor: AtomicI32::new(1),
-                outputs: Mutex::new(vec![]),
-                has_role: AtomicBool::new(false),
-            },
+            SurfaceData { scale_factor: AtomicI32::new(1), outputs: Mutex::new(vec![]) },
         )?;
 
         Ok(surface)
@@ -94,9 +90,6 @@ pub struct SurfaceData {
 
     /// The outputs the surface is currently inside.
     pub(crate) outputs: Mutex<Vec<wl_output::WlOutput>>,
-
-    /// Whether the surface has a role object.
-    pub(crate) has_role: AtomicBool,
 }
 
 #[macro_export]

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,7 +1,7 @@
 //! # Shell abstractions
 //!
-//! A shell describes a set of wayland protocol extensions which define the capabilities of a surface and how the
-//! surface is displayed.
+//! A shell describes a set of wayland protocol extensions which define the capabilities of a surface and how
+//! the surface is displayed.
 //!
 //! ## Cross desktop group (XDG) shell
 //!
@@ -25,3 +25,4 @@
 //! [`Window`]: self::xdg::window::Window
 
 pub mod xdg;
+// TODO: Would be nice to support the layer shell.

--- a/src/shell/xdg/inner.rs
+++ b/src/shell/xdg/inner.rs
@@ -1,109 +1,43 @@
-use std::sync::atomic::Ordering;
-
 use wayland_client::{
     ConnectionHandle, DelegateDispatch, DelegateDispatchBase, Dispatch, QueueHandle,
 };
-use wayland_protocols::{
-    unstable::xdg_decoration::v1::client::{
-        zxdg_decoration_manager_v1, zxdg_toplevel_decoration_v1,
-    },
-    xdg_shell::client::{xdg_surface, xdg_wm_base},
-};
+use wayland_protocols::xdg_shell::client::{xdg_surface, xdg_wm_base};
 
 use crate::registry::{ProvidesRegistryState, RegistryHandler};
 
-use super::{window::WindowData, XdgShellHandler, XdgShellState};
+use super::{XdgShellHandler, XdgShellState};
 
-const MAX_XDG_WM_BASE: u32 = 3;
-const MAX_ZXDG_DECORATION_MANAGER: u32 = 1;
-
-impl XdgShellState {
-    pub(crate) fn cleanup(&mut self, conn: &mut ConnectionHandle) {
-        self.windows.retain(|window| {
-            let alive = !window.death_signal.load(Ordering::SeqCst);
-
-            if !alive {
-                // XDG decoration says we must destroy the decoration object before the toplevel
-                if let Some(decoration) = &*window.inner.zxdg_toplevel_decoration.lock().unwrap() {
-                    decoration.destroy(conn);
-                }
-
-                // XDG Shell protocol dictates we must destroy the role object before the xdg surface.
-                window.xdg_toplevel().destroy(conn);
-                window.xdg_surface().destroy(conn);
-            }
-
-            alive
-        })
-    }
-}
+pub(crate) const MAX_XDG_WM_BASE: u32 = 3;
 
 impl<D> RegistryHandler<D> for XdgShellState
 where
     D: Dispatch<xdg_wm_base::XdgWmBase, UserData = ()>
-        + Dispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, UserData = ()>
-        // Decoration late-init
-        + Dispatch<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1, UserData = WindowData>
         + XdgShellHandler
         + ProvidesRegistryState
         + 'static,
 {
     fn new_global(
-        state: &mut D,
+        data: &mut D,
         conn: &mut ConnectionHandle,
         qh: &QueueHandle<D>,
         name: u32,
         interface: &str,
         version: u32,
     ) {
-        match interface {
-            "xdg_wm_base" => {
-                if state.xdg_shell_state().xdg_wm_base.is_some() {
-                    log::warn!(target: "sctk", "compositor advertises xdg_wm_base but one is already bound");
-                    return;
-                }
-
-                let xdg_wm_base = state
-                    .registry()
-                    .bind_once::<xdg_wm_base::XdgWmBase, _, _>(
-                        conn,
-                        qh,
-                        name,
-                        u32::min(version, MAX_XDG_WM_BASE),
-                        (),
-                    )
-                    .expect("failed to bind global");
-
-                state.xdg_shell_state().xdg_wm_base = Some((name, xdg_wm_base));
+        if interface == "xdg_wm_base" {
+            if data.xdg_shell_state().xdg_wm_base.is_some() {
+                log::warn!(target: "sctk", "compositor advertises xdg_wm_base but one is already bound");
+                return;
             }
 
-            "zxdg_decoration_manager_v1" => {
-                if state.xdg_shell_state().zxdg_decoration_manager_v1.is_some() {
-                    log::warn!(target: "sctk", "compositor advertises zxdg_decoration_manager_v1 but one is already bound");
-                    return;
-                }
+            let xdg_wm_base = data
+                .registry()
+                .bind_cached::<xdg_wm_base::XdgWmBase, _, _, _>(conn, qh, name, || {
+                    (u32::min(version, MAX_XDG_WM_BASE), ())
+                })
+                .expect("failed to bind global");
 
-                let zxdg_decoration_manager_v1 = state
-                    .registry()
-                    .bind_once::<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, _, _>(
-                        conn,
-                        qh,
-                        name,
-                        MAX_ZXDG_DECORATION_MANAGER,
-                        (),
-                    )
-                    .expect("failed to bind global");
-
-                state.xdg_shell_state().zxdg_decoration_manager_v1 =
-                    Some((name, zxdg_decoration_manager_v1));
-
-                // Since the order in which globals are advertised is undefined, we need to ensure we enable
-                // server side decorations if the decoration manager is advertised after any surfaces are
-                // created.
-                state.xdg_shell_state().init_decorations(conn, qh);
-            }
-
-            _ => (),
+            data.xdg_shell_state().xdg_wm_base = Some((name, xdg_wm_base));
         }
     }
 
@@ -116,16 +50,6 @@ where
             .is_some()
         {
             todo!("XDG shell global destruction")
-        }
-
-        if state
-            .xdg_shell_state()
-            .zxdg_decoration_manager_v1
-            .as_ref()
-            .filter(|(global_name, _)| global_name == &name)
-            .is_some()
-        {
-            todo!("ZXDG decoration global destruction")
         }
     }
 }
@@ -141,7 +65,7 @@ where
     D: Dispatch<xdg_wm_base::XdgWmBase, UserData = Self::UserData> + XdgShellHandler,
 {
     fn event(
-        data: &mut D,
+        _: &mut D,
         xdg_wm_base: &xdg_wm_base::XdgWmBase,
         event: xdg_wm_base::Event,
         _: &(),
@@ -155,9 +79,6 @@ where
 
             _ => unreachable!(),
         }
-
-        // Perform cleanup as necessary
-        data.xdg_shell_state().cleanup(conn);
     }
 }
 
@@ -186,8 +107,5 @@ where
 
             _ => unreachable!(),
         }
-
-        // Perform cleanup as necessary
-        data.xdg_shell_state().cleanup(conn);
     }
 }

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -2,12 +2,7 @@
 // TODO: Examples
 
 use wayland_client::{ConnectionHandle, QueueHandle};
-use wayland_protocols::{
-    unstable::xdg_decoration::v1::client::zxdg_decoration_manager_v1,
-    xdg_shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base},
-};
-
-use self::window::Window;
+use wayland_protocols::xdg_shell::client::{xdg_surface, xdg_wm_base};
 
 mod inner;
 pub mod popup;
@@ -17,23 +12,15 @@ pub mod window;
 pub struct XdgShellState {
     // (name, global)
     xdg_wm_base: Option<(u32, xdg_wm_base::XdgWmBase)>,
-    zxdg_decoration_manager_v1: Option<(u32, zxdg_decoration_manager_v1::ZxdgDecorationManagerV1)>,
-
-    /// We hold strong references to the window
-    windows: Vec<Window>,
 }
 
 impl XdgShellState {
     pub fn new() -> XdgShellState {
-        XdgShellState { xdg_wm_base: None, zxdg_decoration_manager_v1: None, windows: vec![] }
+        XdgShellState { xdg_wm_base: None }
     }
 
-    pub fn window_by_surface(&self, surface: &xdg_surface::XdgSurface) -> Option<&Window> {
-        self.windows.iter().find(|window| window.xdg_surface() == surface)
-    }
-
-    pub fn window_by_toplevel(&self, toplevel: &xdg_toplevel::XdgToplevel) -> Option<&Window> {
-        self.windows.iter().find(|window| window.xdg_toplevel() == toplevel)
+    pub fn xdg_wm_base(&self) -> Option<&xdg_wm_base::XdgWmBase> {
+        self.xdg_wm_base.as_ref().map(|(_, global)| global)
     }
 }
 
@@ -66,24 +53,6 @@ macro_rules! delegate_xdg_shell {
         $crate::reexports::client::delegate_dispatch!($ty: [
             __XdgWmBase,
             __XdgSurface
-        ] => $crate::shell::xdg::XdgShellState);
-    };
-}
-
-#[macro_export]
-macro_rules! delegate_xdg_window {
-    ($ty: ty) => {
-        // Toplevel
-        type __XdgToplevel = $crate::reexports::protocols::xdg_shell::client::xdg_toplevel::XdgToplevel;
-        type __ZxdgDecorationManagerV1 =
-            $crate::reexports::protocols::unstable::xdg_decoration::v1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1;
-        type __ZxdgToplevelDecorationV1 =
-            $crate::reexports::protocols::unstable::xdg_decoration::v1::client::zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1;
-
-        $crate::reexports::client::delegate_dispatch!($ty: [
-            __XdgToplevel,
-            __ZxdgDecorationManagerV1,
-            __ZxdgToplevelDecorationV1
         ] => $crate::shell::xdg::XdgShellState);
     };
 }

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -1,18 +1,18 @@
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::{atomic::AtomicBool, Arc};
 
 use wayland_backend::client::InvalidId;
 use wayland_client::{
     protocol::{wl_output, wl_surface},
-    ConnectionHandle, Dispatch, Proxy, QueueHandle,
+    ConnectionHandle, Dispatch, QueueHandle,
 };
 use wayland_protocols::{
-    unstable::xdg_decoration::v1::client::zxdg_toplevel_decoration_v1,
+    unstable::xdg_decoration::v1::client::{
+        zxdg_decoration_manager_v1, zxdg_toplevel_decoration_v1,
+    },
     xdg_shell::client::{
         xdg_surface,
         xdg_toplevel::{self, State},
+        xdg_wm_base,
     },
 };
 
@@ -20,23 +20,148 @@ use crate::compositor::SurfaceData;
 
 use self::inner::{WindowDataInner, WindowInner};
 
-use super::{XdgShellHandler, XdgShellState};
+use super::XdgShellHandler;
 
 pub(super) mod inner;
 
-#[derive(Debug, Clone)]
-pub struct WindowConfigure {
-    pub new_size: Option<(u32, u32)>,
-    pub states: Vec<State>,
+#[derive(Debug)]
+pub struct XdgWindowState {
+    // (name, global)
+    xdg_wm_base: Option<(u32, xdg_wm_base::XdgWmBase)>,
+    zxdg_decoration_manager_v1: Option<(u32, zxdg_decoration_manager_v1::ZxdgDecorationManagerV1)>,
+    windows: Vec<Window>,
+}
+
+impl XdgWindowState {
+    pub fn new() -> XdgWindowState {
+        XdgWindowState { xdg_wm_base: None, zxdg_decoration_manager_v1: None, windows: vec![] }
+    }
+
+    pub fn window_by_wl(&self, surface: &wl_surface::WlSurface) -> Option<&Window> {
+        self.windows.iter().find(|window| window.wl_surface() == surface)
+    }
+
+    pub fn window_by_xdg(&self, surface: &xdg_surface::XdgSurface) -> Option<&Window> {
+        self.windows.iter().find(|window| window.xdg_surface() == surface)
+    }
+
+    pub fn window_by_toplevel(&self, toplevel: &xdg_toplevel::XdgToplevel) -> Option<&Window> {
+        self.windows.iter().find(|window| window.xdg_toplevel() == toplevel)
+    }
+
+    /// Create a window.
+    ///
+    /// This function will create a window from a [`WlSurface`]. Note the window will consume the
+    /// [`WlSurface`] when the window is dropped.
+    ///
+    /// ## Default settings
+    ///
+    /// ### Window decorations
+    ///
+    /// The window will use the decoration mode dictated by the compositor. If you do not want this, set the
+    /// preferred decoration mode before [`map()`](Window::map)ing the window.
+    ///
+    /// ### Initial window size
+    ///
+    /// This will vary depending on the compositor. Some compositors may allow the you to make the window
+    /// any desired size while others may give the you a desired size during the initial commit.
+    ///
+    /// You ultimately have control over what size buffer is committed, meaning you could ignore the
+    /// compositor. However, not respecting the compositor will likely result in aggravated users and a subpar
+    /// experience.
+    ///
+    /// Some compositors may take the minimum and maximum window size in consideration when determining how
+    /// large of a window that will be requested during the initial commit.
+    ///
+    /// # Protocol errors
+    ///
+    /// If the surface already has a role object, the compositor will raise a protocol error.
+    ///
+    /// A surface is considered to have a role object if some other type of surface was created using the
+    /// surface. For example, creating a window, popup, layer or subsurface all assign a role object to a
+    /// surface.
+    ///
+    /// The function here takes an owned reference to the surface to hint the surface will be owned by the
+    /// returned window.
+    ///
+    /// [`WlSurface`]: wl_surface::WlSurface
+    #[must_use = "dropping the window will consume the wl_surface and destroy the window"]
+    pub fn create_window<D>(
+        &mut self,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<D>,
+        wl_surface: wl_surface::WlSurface,
+    ) -> Result<Window, CreateWindowError>
+    where
+        D: Dispatch<wl_surface::WlSurface, UserData = SurfaceData>
+            + Dispatch<xdg_surface::XdgSurface, UserData = ()>
+            + Dispatch<xdg_toplevel::XdgToplevel, UserData = WindowData>
+            + 'static,
+    {
+        let (_, xdg_wm_base) =
+            self.xdg_wm_base.as_ref().ok_or(CreateWindowError::MissingRequiredGlobals)?;
+        let zxdg_decoration_manager =
+            self.zxdg_decoration_manager_v1.clone().map(|(_, global)| global);
+
+        let xdg_surface = xdg_wm_base.get_xdg_surface(conn, &wl_surface, qh, ())?;
+        let inner = WindowInner::new(conn, qh, &wl_surface, &xdg_surface, zxdg_decoration_manager)?;
+
+        let window =
+            Window { inner, primary: true, death_signal: Arc::new(AtomicBool::new(false)) };
+
+        self.windows.push(window.impl_clone());
+
+        Ok(window)
+    }
 }
 
 pub trait WindowHandler: XdgShellHandler + Sized {
+    fn xdg_window_state(&mut self) -> &mut XdgWindowState;
+
+    /// Called when a window has been requested to close.
+    ///
+    /// This request does not destroy the window. You must drop the [`Window`] for the window to be destroyed.
+    ///
+    /// This may be sent at any time, whether it is the client side window decorations or the compositor.
     fn request_close_window(
         &mut self,
         conn: &mut ConnectionHandle,
         qh: &QueueHandle<Self>,
         window: &Window,
     );
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct WindowConfigure {
+    /// The compositor suggested new size of the window.
+    ///
+    /// If this value is [`None`], you may set the size of the window as you wish.
+    pub new_size: Option<(u32, u32)>,
+
+    /// States indicating how the window should be resized.
+    ///
+    /// Some states require the new size of the window to be obeyed. States may also be combined. For example,
+    /// a window could be activated and maximized at the same time.
+    ///
+    /// Below is a table explains the constraints a window needs to obey depending on the set states:
+    ///
+    /// | State(s) | Any size | Notes |
+    /// |-------|----------|-------|
+    /// | No states | yes ||
+    /// | [`Maximized`](State::Maximized) | no | the window geometry must be obeyed |
+    /// | [`Fullscreen`](State::Fullscreen) | no | the window geometry is a maximum. Not obeying the size may result in letterboxes. |
+    /// | [`Resizing`](State::Resizing) | no | the window geometry is a maximum. If you have cell sizing or a fixed aspect ratio, a smaller size may be used. |
+    /// | [`Activated`](State::Activated) | yes? | if the client provides window decorations, the decorations should be drawn as if the window is active. |
+    ///
+    /// There are also states that indicate the sides of a window which are tiled. Tiling is a hint which
+    /// specifies which sides of a window should probably not be resized and may be used to hide shadows.
+    /// Tiling values include:
+    /// - [`Left`](State::TiledLeft)
+    /// - [`Right`](State::TiledRight)
+    /// - [`Top`](State::TiledTop)
+    /// - [`Bottom`](State::TiledBottom)
+    pub states: Vec<State>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,7 +215,7 @@ impl Window {
     /// This function will commit the initial window state and will result in the initial configure at some
     /// point.
     ///
-    /// ## Protocol errors
+    /// # Protocol errors
     ///
     /// The [`WlSurface`] may not have any buffers attached. If a buffer is attached, a protocol error will
     /// occur.
@@ -121,7 +246,7 @@ impl Window {
         self.inner.set_min_size(conn, min_size)
     }
 
-    /// ## Protocol errors
+    /// # Protocol errors
     ///
     /// The maximum size of the window may not be smaller than the minimum size.
     pub fn set_max_size(&self, conn: &mut ConnectionHandle, max_size: Option<(u32, u32)>) {
@@ -180,72 +305,23 @@ impl Window {
     }
 }
 
-impl XdgShellState {
-    /// Create a window.
-    ///
-    /// This function will create a window from a [`WlSurface`].
-    ///
-    /// ## Default settings
-    ///
-    /// ### Window decorations
-    ///
-    /// The window will use the decoration mode dictated by the compositor. If you do not want this, set the
-    /// preferred decoration mode before [`map()`](Window::map)ing the window.
-    ///
-    /// ### Initial window size
-    ///
-    /// This will vary depending on the compositor. Some compositors may allow the you to make the window
-    /// any desired size while others may give the you a desired size during the initial commit.
-    ///
-    /// You ultimately have control over what size buffer is committed, meaning you could ignore the
-    /// compositor. However, not respecting the compositor will likely result in aggravated users and a subpar
-    /// experience.
-    ///
-    /// Some compositors may take the minimum and maximum window size in consideration when determining how
-    /// large of a window that will be requested during the initial commit.
-    ///
-    /// [`WlSurface`]: wl_surface::WlSurface
-    #[must_use = "You must map() the window before presenting to it"]
-    pub fn create_window<D>(
-        &mut self,
-        conn: &mut ConnectionHandle,
-        qh: &QueueHandle<D>,
-        wl_surface: wl_surface::WlSurface,
-    ) -> Result<Window, CreateWindowError>
-    where
-        D: Dispatch<wl_surface::WlSurface, UserData = SurfaceData>
-            + Dispatch<xdg_surface::XdgSurface, UserData = ()>
-            + Dispatch<xdg_toplevel::XdgToplevel, UserData = WindowData>
-            + 'static,
-    {
-        // We don't know if an un-managed surface has a role object.
-        let surface_data = wl_surface.data::<SurfaceData>().ok_or(CreateWindowError::HasRole)?;
-
-        // XDG Shell protocol forbids creating an window from a surface that already has a role object.
-        if surface_data.has_role.load(Ordering::SeqCst) {
-            return Err(CreateWindowError::HasRole);
-        }
-
-        let (_, xdg_wm_base) =
-            self.xdg_wm_base.as_ref().ok_or(CreateWindowError::MissingRequiredGlobals)?;
-        let zxdg_decoration_manager =
-            self.zxdg_decoration_manager_v1.clone().map(|(_, global)| global);
-
-        let xdg_surface = xdg_wm_base.get_xdg_surface(conn, &wl_surface, qh, ())?;
-        let inner = WindowInner::new(conn, qh, &wl_surface, &xdg_surface, zxdg_decoration_manager)?;
-
-        // Mark the surface has having a role object.
-        let surface_data = wl_surface.data::<SurfaceData>().unwrap();
-        surface_data.has_role.store(true, Ordering::SeqCst);
-
-        let window =
-            Window { inner, primary: true, death_signal: Arc::new(AtomicBool::new(false)) };
-
-        self.windows.push(window.impl_clone());
-
-        Ok(window)
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct WindowData(pub(crate) Arc<WindowDataInner>);
+
+#[macro_export]
+macro_rules! delegate_xdg_window {
+    ($ty: ty) => {
+        // Toplevel
+        type __XdgToplevel = $crate::reexports::protocols::xdg_shell::client::xdg_toplevel::XdgToplevel;
+        type __ZxdgDecorationManagerV1 =
+            $crate::reexports::protocols::unstable::xdg_decoration::v1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1;
+        type __ZxdgToplevelDecorationV1 =
+            $crate::reexports::protocols::unstable::xdg_decoration::v1::client::zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1;
+
+        $crate::reexports::client::delegate_dispatch!($ty: [
+            __XdgToplevel,
+            __ZxdgDecorationManagerV1,
+            __ZxdgToplevelDecorationV1
+        ] => $crate::shell::xdg::window::XdgWindowState);
+    };
+}


### PR DESCRIPTION
This splits the windows out of `XdgShellState` and into a new `XdgWindowState`. This makes the xdg shell abstractions much more modular and removes the need to have `delgate_xdg_shell` require `delegate_xdg_window`.