### PR TITLE
0.30 xdg: idea to make configures better

### DIFF
--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -1,45 +1,131 @@
 //! ## Cross desktop group (XDG) shell
 // TODO: Examples
 
-use wayland_client::{ConnectionHandle, QueueHandle};
+use std::marker::PhantomData;
+
+use wayland_backend::client::InvalidId;
+use wayland_client::{protocol::wl_surface, ConnectionHandle, Dispatch, QueueHandle};
 use wayland_protocols::xdg_shell::client::{xdg_surface, xdg_wm_base};
 
 mod inner;
 pub mod popup;
 pub mod window;
 
-#[derive(Debug)]
-pub struct XdgShellState {
-    // (name, global)
-    xdg_wm_base: Option<(u32, xdg_wm_base::XdgWmBase)>,
+#[derive(Debug, thiserror::Error)]
+pub enum XdgSurfaceError {
+    /// The xdg_wm_base global is not available.
+    #[error("the xdg_wm_base global is not available")]
+    MissingRequiredGlobals,
+
+    /// Protocol error.
+    #[error(transparent)]
+    Protocol(#[from] InvalidId),
 }
 
-impl XdgShellState {
-    pub fn new() -> XdgShellState {
-        XdgShellState { xdg_wm_base: None }
+#[derive(Debug)]
+pub struct XdgShellState<D> {
+    // (name, global)
+    xdg_wm_base: Option<(u32, xdg_wm_base::XdgWmBase)>,
+    _marker: PhantomData<D>,
+}
+
+impl<D> XdgShellState<D> {
+    pub fn new() -> Self {
+        Self { xdg_wm_base: None, _marker: PhantomData }
     }
 
     pub fn xdg_wm_base(&self) -> Option<&xdg_wm_base::XdgWmBase> {
         self.xdg_wm_base.as_ref().map(|(_, global)| global)
     }
+
+    /// Creates an [`XdgShellSurface`].
+    ///
+    /// This function is generally intended to be called in a higher level abstraction, such as
+    /// [`XdgWindowState::create_window`](self::window::XdgWindowState::create_window).
+    ///
+    /// The created [`XdgShellSurface`] does not destroy the underlying [`XdgSurface`] or [`WlSurface`] when
+    /// dropped. Higher level abstractions are responsible for ensuring the destruction order of protocol
+    /// objects is correct. Since this function consumes the [`WlSurface`], it may be accessed using
+    /// [`XdgShellSurface::wl_surface`].
+    ///
+    /// # Protocol errors
+    ///
+    /// If the surface already has a role object, the compositor will raise a protocol error.
+    ///
+    /// A surface is considered to have a role object if some other type of surface was created using the
+    /// surface. For example, creating a window, popup, layer, subsurface or some other type of surface object
+    /// all assign a role object to a surface.
+    ///
+    /// [`XdgSurface`]: xdg_surface::XdgSurface
+    /// [`WlSurface`]: wl_surface::WlSurface
+    pub fn create_xdg_surface(
+        &self,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<D>,
+        surface: wl_surface::WlSurface,
+        configure_handler: impl ConfigureHandler<D> + Send + Sync + 'static,
+    ) -> Result<XdgShellSurface, XdgSurfaceError>
+    where
+        D: Dispatch<xdg_surface::XdgSurface, UserData = XdgSurfaceData<D>> + 'static,
+    {
+        let wm_base = self.xdg_wm_base().ok_or(XdgSurfaceError::MissingRequiredGlobals)?;
+        let xdg_surface = wm_base.get_xdg_surface(
+            conn,
+            &surface,
+            qh,
+            XdgSurfaceData { configure_handler: Box::new(configure_handler) },
+        )?;
+
+        Ok(XdgShellSurface { xdg_surface, surface })
+    }
+}
+
+#[derive(Debug)]
+pub struct XdgShellSurface {
+    xdg_surface: xdg_surface::XdgSurface,
+    surface: wl_surface::WlSurface,
+}
+
+impl XdgShellSurface {
+    pub fn xdg_surface(&self) -> &xdg_surface::XdgSurface {
+        &self.xdg_surface
+    }
+
+    pub fn wl_surface(&self) -> &wl_surface::WlSurface {
+        &self.surface
+    }
 }
 
 pub trait XdgShellHandler: Sized {
-    fn xdg_shell_state(&mut self) -> &mut XdgShellState;
+    fn xdg_shell_state(&mut self) -> &mut XdgShellState<Self>;
+}
 
-    /// Called when the compositor has sent a configure event to an XdgSurface
+/// Trait that should be implemented by data used to create [`XdgSurfaceData`].
+///
+/// This trait exists to allow specialized configure functions to be implemented in a specific handler trait
+/// of any XDG shell managed surfaces such as [`WindowHandler::configure`](self::window::WindowHandler::configure).
+pub trait ConfigureHandler<D> {
+    /// The surface has received a configure.
     ///
     /// A configure atomically indicates that a sequence of events describing how a surface has changed have
     /// all been sent.
     ///
-    /// When this event is received, you can get information about the configure off the extending type of
-    /// the XdgSurface. For example, the window's configure is available by calling [`Window::configure`].
+    /// Implementations of this function should invoke a `configure` function on the specific handler trait
+    /// such as [`WindowHandler`](self::window::WindowHandler).
     fn configure(
-        &mut self,
+        &self,
+        data: &mut D,
         conn: &mut ConnectionHandle,
-        qh: &QueueHandle<Self>,
-        surface: &xdg_surface::XdgSurface,
+        qh: &QueueHandle<D>,
+        xdg_surface: &xdg_surface::XdgSurface,
+        serial: u32,
     );
+}
+
+/// Data associated with an [`XdgSurface`](xdg_surface::XdgSurface) protocol object.
+#[allow(missing_debug_implementations)]
+pub struct XdgSurfaceData<D> {
+    configure_handler: Box<(dyn ConfigureHandler<D> + Send + Sync + 'static)>,
 }
 
 #[macro_export]
@@ -48,11 +134,9 @@ macro_rules! delegate_xdg_shell {
         type __XdgWmBase = $crate::reexports::protocols::xdg_shell::client::xdg_wm_base::XdgWmBase;
         type __XdgSurface = $crate::reexports::protocols::xdg_shell::client::xdg_surface::XdgSurface;
 
-        // TODO: Popups
-
         $crate::reexports::client::delegate_dispatch!($ty: [
             __XdgWmBase,
             __XdgSurface
-        ] => $crate::shell::xdg::XdgShellState);
+        ] => $crate::shell::xdg::XdgShellState<$ty>);
     };
 }

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -1,40 +1,36 @@
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
-use wayland_backend::client::InvalidId;
 use wayland_client::{
-    protocol::{wl_output, wl_surface},
+    protocol::{wl_output, wl_seat, wl_surface},
     ConnectionHandle, Dispatch, QueueHandle,
 };
 use wayland_protocols::{
     unstable::xdg_decoration::v1::client::{
-        zxdg_decoration_manager_v1, zxdg_toplevel_decoration_v1,
+        zxdg_decoration_manager_v1,
+        zxdg_toplevel_decoration_v1::{self, Mode},
     },
     xdg_shell::client::{
         xdg_surface,
         xdg_toplevel::{self, State},
-        xdg_wm_base,
     },
 };
 
-use crate::compositor::SurfaceData;
-
 use self::inner::{WindowDataInner, WindowInner};
 
-use super::XdgShellHandler;
+use super::{ConfigureHandler, XdgShellHandler, XdgShellState, XdgSurfaceData, XdgSurfaceError};
 
 pub(super) mod inner;
 
 #[derive(Debug)]
 pub struct XdgWindowState {
     // (name, global)
-    xdg_wm_base: Option<(u32, xdg_wm_base::XdgWmBase)>,
-    zxdg_decoration_manager_v1: Option<(u32, zxdg_decoration_manager_v1::ZxdgDecorationManagerV1)>,
+    xdg_decoration_manager: Option<(u32, zxdg_decoration_manager_v1::ZxdgDecorationManagerV1)>,
     windows: Vec<Window>,
 }
 
 impl XdgWindowState {
     pub fn new() -> XdgWindowState {
-        XdgWindowState { xdg_wm_base: None, zxdg_decoration_manager_v1: None, windows: vec![] }
+        XdgWindowState { xdg_decoration_manager: None, windows: vec![] }
     }
 
     pub fn window_by_wl(&self, surface: &wl_surface::WlSurface) -> Option<&Window> {
@@ -48,71 +44,6 @@ impl XdgWindowState {
     pub fn window_by_toplevel(&self, toplevel: &xdg_toplevel::XdgToplevel) -> Option<&Window> {
         self.windows.iter().find(|window| window.xdg_toplevel() == toplevel)
     }
-
-    /// Create a window.
-    ///
-    /// This function will create a window from a [`WlSurface`]. Note the window will consume the
-    /// [`WlSurface`] when the window is dropped.
-    ///
-    /// ## Default settings
-    ///
-    /// ### Window decorations
-    ///
-    /// The window will use the decoration mode dictated by the compositor. If you do not want this, set the
-    /// preferred decoration mode before [`map()`](Window::map)ing the window.
-    ///
-    /// ### Initial window size
-    ///
-    /// This will vary depending on the compositor. Some compositors may allow the you to make the window
-    /// any desired size while others may give the you a desired size during the initial commit.
-    ///
-    /// You ultimately have control over what size buffer is committed, meaning you could ignore the
-    /// compositor. However, not respecting the compositor will likely result in aggravated users and a subpar
-    /// experience.
-    ///
-    /// Some compositors may take the minimum and maximum window size in consideration when determining how
-    /// large of a window that will be requested during the initial commit.
-    ///
-    /// # Protocol errors
-    ///
-    /// If the surface already has a role object, the compositor will raise a protocol error.
-    ///
-    /// A surface is considered to have a role object if some other type of surface was created using the
-    /// surface. For example, creating a window, popup, layer or subsurface all assign a role object to a
-    /// surface.
-    ///
-    /// The function here takes an owned reference to the surface to hint the surface will be owned by the
-    /// returned window.
-    ///
-    /// [`WlSurface`]: wl_surface::WlSurface
-    #[must_use = "dropping the window will consume the wl_surface and destroy the window"]
-    pub fn create_window<D>(
-        &mut self,
-        conn: &mut ConnectionHandle,
-        qh: &QueueHandle<D>,
-        wl_surface: wl_surface::WlSurface,
-    ) -> Result<Window, CreateWindowError>
-    where
-        D: Dispatch<wl_surface::WlSurface, UserData = SurfaceData>
-            + Dispatch<xdg_surface::XdgSurface, UserData = ()>
-            + Dispatch<xdg_toplevel::XdgToplevel, UserData = WindowData>
-            + 'static,
-    {
-        let (_, xdg_wm_base) =
-            self.xdg_wm_base.as_ref().ok_or(CreateWindowError::MissingRequiredGlobals)?;
-        let zxdg_decoration_manager =
-            self.zxdg_decoration_manager_v1.clone().map(|(_, global)| global);
-
-        let xdg_surface = xdg_wm_base.get_xdg_surface(conn, &wl_surface, qh, ())?;
-        let inner = WindowInner::new(conn, qh, &wl_surface, &xdg_surface, zxdg_decoration_manager)?;
-
-        let window =
-            Window { inner, primary: true, death_signal: Arc::new(AtomicBool::new(false)) };
-
-        self.windows.push(window.impl_clone());
-
-        Ok(window)
-    }
 }
 
 pub trait WindowHandler: XdgShellHandler + Sized {
@@ -123,14 +54,41 @@ pub trait WindowHandler: XdgShellHandler + Sized {
     /// This request does not destroy the window. You must drop the [`Window`] for the window to be destroyed.
     ///
     /// This may be sent at any time, whether it is the client side window decorations or the compositor.
-    fn request_close_window(
+    fn request_close(
         &mut self,
         conn: &mut ConnectionHandle,
         qh: &QueueHandle<Self>,
         window: &Window,
     );
+
+    /// Called when the compositor has sent a configure event to an XdgSurface
+    ///
+    /// A configure atomically indicates that a sequence of events describing how a surface has changed have
+    /// all been sent.
+    fn configure(
+        &mut self,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<Self>,
+        window: &Window,
+        configure: WindowConfigure,
+        serial: u32,
+    );
 }
 
+/// Decoration mode of a window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecorationMode {
+    /// The window should draw client side decorations.
+    Client,
+
+    /// The server will draw window decorations.
+    Server,
+}
+
+/// The configure state of a window
+///
+/// This type indicates compositor changes to the window, such as a new size and if the state of the window
+/// has changed.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct WindowConfigure {
@@ -138,6 +96,17 @@ pub struct WindowConfigure {
     ///
     /// If this value is [`None`], you may set the size of the window as you wish.
     pub new_size: Option<(u32, u32)>,
+
+    /// Compositor suggested maximum bounds for a window.
+    ///
+    /// This may be used to ensure a window is not created in a way where it will not fit.
+    pub suggested_bounds: Option<(u32, u32)>,
+
+    /// The compositor set decoration mode of the window.
+    ///
+    /// This will always be [`DecorationMode::Client`] if server side decorations are not enabled or
+    /// supported.
+    pub decoration_mode: DecorationMode,
 
     /// States indicating how the window should be resized.
     ///
@@ -149,8 +118,8 @@ pub struct WindowConfigure {
     /// | State(s) | Any size | Notes |
     /// |-------|----------|-------|
     /// | No states | yes ||
-    /// | [`Maximized`](State::Maximized) | no | the window geometry must be obeyed |
-    /// | [`Fullscreen`](State::Fullscreen) | no | the window geometry is a maximum. Not obeying the size may result in letterboxes. |
+    /// | [`Maximized`](State::Maximized) | no | the window geometry must be obeyed. Drop shadows should also been hidden. |
+    /// | [`Fullscreen`](State::Fullscreen) | no | the window geometry is a maximum. A smaller size may be used but letterboxes will appear. |
     /// | [`Resizing`](State::Resizing) | no | the window geometry is a maximum. If you have cell sizing or a fixed aspect ratio, a smaller size may be used. |
     /// | [`Activated`](State::Activated) | yes? | if the client provides window decorations, the decorations should be drawn as if the window is active. |
     ///
@@ -164,30 +133,227 @@ pub struct WindowConfigure {
     pub states: Vec<State>,
 }
 
+/// Decorations a window is created with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DecorationMode {
-    PreferServer,
+pub enum WindowDecorations {
+    /// The window should use the decoration mode the server asks for.
+    ///
+    /// The server may ask the client to render with or without client side decorations. If server side
+    /// decorations are not available, client side decorations are drawn instead.
+    ServerDefault,
 
-    ServerOnly,
+    /// The window should request server side decorations.
+    ///
+    /// The server may ignore this request and ask the client to render with client side decorations. If
+    /// server side decorations are not available, client side decorations are drawn instead.
+    RequestServer,
 
+    /// The window should request client side decorations.
+    ///
+    /// The server may ignore this request and render server side decorations. If server side decorations are
+    /// not available, client side decorations are drawn.
+    RequestClient,
+
+    /// The window should always draw it's own client side decorations.
     ClientOnly,
 
+    /// The window should use server side decorations or draw any client side decorations.
     None,
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum CreateWindowError {
-    /// Surface already has a role object.
-    #[error("surface already has a role object")]
-    HasRole,
+#[derive(Debug)]
+pub struct WindowBuilder {
+    title: Option<String>,
+    app_id: Option<String>,
+    min_size: Option<(u32, u32)>,
+    max_size: Option<(u32, u32)>,
+    parent: Option<xdg_toplevel::XdgToplevel>,
+    fullscreen: Option<wl_output::WlOutput>,
+    maximized: bool,
+    decorations: WindowDecorations,
+}
 
-    /// The xdg_wm_base global is not available.
-    #[error("the xdg_wm_base global is not available")]
-    MissingRequiredGlobals,
+impl WindowBuilder {
+    /// Set the title of the window being built.
+    pub fn title(self, title: impl Into<String>) -> Self {
+        Self { title: Some(title.into()), ..self }
+    }
 
-    /// Protocol error.
-    #[error(transparent)]
-    Protocol(#[from] InvalidId),
+    /// Set the app id of the window being built.
+    ///
+    /// This may be used as a compositor hint to influence how the window is initially configured.
+    pub fn app_id(self, app_id: impl Into<String>) -> Self {
+        Self { app_id: Some(app_id.into()), ..self }
+    }
+
+    /// Suggested the minimum size of the window being built.
+    ///
+    /// This may be used as a compositor hint to send an initial configure with the specified minimum size.
+    pub fn min_size(self, min_size: (u32, u32)) -> Self {
+        Self { min_size: Some(min_size), ..self }
+    }
+
+    /// Suggest the maximum size of the window being built.
+    ///
+    /// This may be used as a compositor hint to send an initial configure with the specified maximum size.
+    pub fn max_size(self, max_size: (u32, u32)) -> Self {
+        Self { max_size: Some(max_size), ..self }
+    }
+
+    /// Set the parent window of the window being built.
+    pub fn parent(self, parent: &Window) -> Self {
+        Self { parent: Some(parent.xdg_toplevel().clone()), ..self }
+    }
+
+    /// Suggest the window should be created full screened.
+    ///
+    /// This may be used as a compositor hint to send an initial configure with the window in a full screen
+    /// state.
+    pub fn fullscreen(self, output: &wl_output::WlOutput) -> Self {
+        Self { fullscreen: Some(output.clone()), ..self }
+    }
+
+    /// Suggest the window should be created maximized.
+    ///
+    /// This may be used as a compositor hint to send an initial configure with the window maximized.
+    pub fn maximized(self) -> Self {
+        Self { maximized: true, ..self }
+    }
+
+    /// Sets the decoration mode the window should be created with.
+    ///
+    /// By default the decoration mode is set to [`DecorationMode::RequestServer`] to use server provided
+    /// decorations where possible.
+    pub fn decorations(self, decorations: WindowDecorations) -> Self {
+        Self { decorations, ..self }
+    }
+
+    /// Build and map the window
+    ///
+    /// This function will create the window and send the initial commit.
+    ///
+    /// # Protocol errors
+    ///
+    /// If the surface already has a role object, the compositor will raise a protocol error.
+    ///
+    /// A surface is considered to have a role object if some other type of surface was created using the
+    /// surface. For example, creating a window, popup, layer or subsurface all assign a role object to a
+    /// surface.
+    ///
+    /// The function here takes an owned reference to the surface to hint the surface will be consumed by the
+    /// window.
+    ///
+    /// [`WlSurface`]: wl_surface::WlSurface
+    #[must_use = "The window is destroyed if dropped"]
+    pub fn map<D>(
+        self,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<D>,
+        shell_state: &XdgShellState<D>,
+        window_state: &mut XdgWindowState,
+        surface: wl_surface::WlSurface,
+    ) -> Result<Window, XdgSurfaceError>
+    where
+        D: Dispatch<xdg_surface::XdgSurface, UserData = XdgSurfaceData<D>>
+            + Dispatch<xdg_toplevel::XdgToplevel, UserData = WindowData>
+            + Dispatch<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1, UserData = WindowData>
+            + WindowHandler
+            + 'static,
+    {
+        let decoration_manager =
+            window_state.xdg_decoration_manager.as_ref().map(|(_, global)| global);
+
+        let data = Arc::new(WindowDataInner {
+            pending_configure: Mutex::new(WindowConfigure {
+                new_size: None,
+                suggested_bounds: None,
+                // Initial configure will indicate whether there are server side decorations.
+                decoration_mode: DecorationMode::Client,
+                states: Vec::new(),
+            }),
+        });
+
+        let xdg_surface = shell_state.create_xdg_surface(
+            conn,
+            qh,
+            surface,
+            WindowConfigureHandler { data: data.clone() },
+        )?;
+
+        let window_data = WindowData(data);
+        let xdg_toplevel = xdg_surface.xdg_surface().get_toplevel(conn, qh, window_data.clone())?;
+
+        // If server side decorations are available, create the toplevel decoration.
+        let toplevel_decoration = if let Some(decoration_manager) = decoration_manager {
+            match self.decorations {
+                // Window does not want any server side decorations.
+                WindowDecorations::ClientOnly | WindowDecorations::None => None,
+
+                _ => {
+                    // Create the toplevel decoration.
+                    let toplevel_decoration = decoration_manager
+                        .get_toplevel_decoration(conn, &xdg_toplevel, qh, window_data)
+                        .expect("failed to create toplevel decoration");
+
+                    // Tell the compositor we would like a specific mode.
+                    let mode = match self.decorations {
+                        WindowDecorations::RequestServer => Some(Mode::ServerSide),
+                        WindowDecorations::RequestClient => Some(Mode::ClientSide),
+                        _ => None,
+                    };
+
+                    if let Some(mode) = mode {
+                        toplevel_decoration.set_mode(conn, mode);
+                    }
+
+                    Some(toplevel_decoration)
+                }
+            }
+        } else {
+            None
+        };
+
+        let inner = Arc::new(WindowInner { xdg_surface, xdg_toplevel, toplevel_decoration });
+
+        let window =
+            Window { inner, primary: true, death_signal: Arc::new(AtomicBool::new(false)) };
+
+        window_state.windows.push(window.impl_clone());
+
+        // Apply state from builder
+        if let Some(title) = self.title {
+            window.set_title(conn, title);
+        }
+
+        if let Some(app_id) = self.app_id {
+            window.set_app_id(conn, app_id);
+        }
+
+        if let Some(min_size) = self.min_size {
+            window.set_min_size(conn, Some(min_size));
+        }
+
+        if let Some(max_size) = self.max_size {
+            window.set_max_size(conn, Some(max_size));
+        }
+
+        if let Some(parent) = self.parent {
+            window.xdg_toplevel().set_parent(conn, Some(&parent));
+        }
+
+        if let Some(output) = self.fullscreen {
+            window.set_fullscreen(conn, Some(&output));
+        }
+
+        if self.maximized {
+            window.set_maximized(conn);
+        }
+
+        // Initial commit
+        window.wl_surface().commit(conn);
+
+        Ok(window)
+    }
 }
 
 #[derive(Debug)]
@@ -210,28 +376,27 @@ pub struct Window {
 }
 
 impl Window {
-    /// Map the window.
-    ///
-    /// This function will commit the initial window state and will result in the initial configure at some
-    /// point.
-    ///
-    /// # Protocol errors
-    ///
-    /// The [`WlSurface`] may not have any buffers attached. If a buffer is attached, a protocol error will
-    /// occur.
-    ///
-    /// [`WlSurface`]: wl_surface::WlSurface
-    pub fn map<D>(&self, conn: &mut ConnectionHandle, qh: &QueueHandle<D>)
-    where
-        D: Dispatch<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1, UserData = WindowData>
-            + 'static,
-    {
-        self.inner.map(conn, qh)
+    pub fn builder() -> WindowBuilder {
+        WindowBuilder {
+            title: None,
+            app_id: None,
+            min_size: None,
+            max_size: None,
+            parent: None,
+            fullscreen: None,
+            maximized: false,
+            decorations: WindowDecorations::RequestServer,
+        }
     }
 
-    #[must_use]
-    pub fn configure(&self) -> Option<WindowConfigure> {
-        self.inner.configure()
+    pub fn show_window_menu(
+        &self,
+        conn: &mut ConnectionHandle,
+        seat: &wl_seat::WlSeat,
+        serial: u32,
+        position: (u32, u32),
+    ) {
+        self.inner.show_window_menu(conn, seat, serial, position.0, position.1)
     }
 
     pub fn set_title(&self, conn: &mut ConnectionHandle, title: impl Into<String>) {
@@ -242,28 +407,9 @@ impl Window {
         self.inner.set_app_id(conn, app_id.into())
     }
 
-    pub fn set_min_size(&self, conn: &mut ConnectionHandle, min_size: Option<(u32, u32)>) {
-        self.inner.set_min_size(conn, min_size)
-    }
-
-    /// # Protocol errors
-    ///
-    /// The maximum size of the window may not be smaller than the minimum size.
-    pub fn set_max_size(&self, conn: &mut ConnectionHandle, max_size: Option<(u32, u32)>) {
-        self.inner.set_max_size(conn, max_size)
-    }
-
-    // TODO: Change decoration mode
-
     pub fn set_parent(&self, conn: &mut ConnectionHandle, parent: Option<&Window>) {
         self.inner.set_parent(conn, parent)
     }
-
-    // TODO: Show window menu
-
-    // TODO: Move
-
-    // TODO: Resize
 
     pub fn set_maximized(&self, conn: &mut ConnectionHandle) {
         self.inner.set_maximized(conn)
@@ -289,17 +435,58 @@ impl Window {
         self.inner.unset_fullscreen(conn)
     }
 
-    /// Returns the surface wrapped in this window.
+    /// Requests the window should use the specified decoration mode.
+    ///
+    /// A mode of [`None`] indicates that the window does not care what type of decorations are used.
+    ///
+    /// The compositor will respond with a [`configure`](WindowHandler::configure). The configure will
+    /// indicate whether the window's decoration mode has changed.
+    ///
+    /// # Configure loops
+    ///
+    /// You should avoid sending multiple decoration mode requests to ensure you do not enter a configure loop.
+    pub fn request_decoration_mode(
+        &self,
+        conn: &mut ConnectionHandle,
+        mode: Option<DecorationMode>,
+    ) {
+        self.inner.request_decoration_mode(conn, mode)
+    }
+
+    // TODO: Move
+
+    // TODO: Resize
+
+    // Double buffered window state
+
+    pub fn set_min_size(&self, conn: &mut ConnectionHandle, min_size: Option<(u32, u32)>) {
+        self.inner.set_min_size(conn, min_size)
+    }
+
+    /// # Protocol errors
+    ///
+    /// The maximum size of the window may not be smaller than the minimum size.
+    pub fn set_max_size(&self, conn: &mut ConnectionHandle, max_size: Option<(u32, u32)>) {
+        self.inner.set_max_size(conn, max_size)
+    }
+
+    // TODO: Window geometry
+
+    // TODO: WlSurface stuff
+
+    // Other
+
+    /// Returns the underlying surface wrapped by this window.
     pub fn wl_surface(&self) -> &wl_surface::WlSurface {
-        &self.inner.wl_surface
+        self.inner.xdg_surface.wl_surface()
     }
 
-    /// Returns the xdg surface wrapped in this window.
+    /// Returns the underlying xdg surface wrapped by this window.
     pub fn xdg_surface(&self) -> &xdg_surface::XdgSurface {
-        &self.inner.xdg_surface
+        self.inner.xdg_surface.xdg_surface()
     }
 
-    /// Returns the xdg toplevel wrapped in this window.
+    /// Returns the underlying xdg toplevel wrapped by this window.
     pub fn xdg_toplevel(&self) -> &xdg_toplevel::XdgToplevel {
         &self.inner.xdg_toplevel
     }
@@ -324,4 +511,29 @@ macro_rules! delegate_xdg_window {
             __ZxdgToplevelDecorationV1
         ] => $crate::shell::xdg::window::XdgWindowState);
     };
+}
+
+struct WindowConfigureHandler {
+    data: Arc<WindowDataInner>,
+}
+
+impl<D> ConfigureHandler<D> for WindowConfigureHandler
+where
+    D: WindowHandler,
+{
+    fn configure(
+        &self,
+        data: &mut D,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<D>,
+        xdg_surface: &xdg_surface::XdgSurface,
+        serial: u32,
+    ) {
+        if let Some(window) = data.xdg_window_state().window_by_xdg(xdg_surface) {
+            let window = window.impl_clone();
+            let configure = { self.data.pending_configure.lock().unwrap().clone() };
+
+            WindowHandler::configure(data, conn, qh, &window, configure, serial);
+        }
+    }
 }


### PR DESCRIPTION
Vast improvements to `Window` abstraction in xdg shell handling for SCTK.

Changes include:
- Moving configure to `WindowHandler`, each derivation of `XdgSurface` is expected to provide it's own handler method for configures.
- Window creation uses a builder
- Creating an XdgSurface, returned as a `XdgShellSurface` is now possible to allow external implementations of protocols which extend `XdgSurface`.
- Better server side decoration handling
- General cleanup of window data