### PR TITLE
0.30: layer shell

### DIFF
--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -1,0 +1,537 @@
+//! This example is horrible. Please make a better one soon.
+
+use std::convert::TryInto;
+
+use smithay_client_toolkit::{
+    compositor::{CompositorHandler, CompositorState},
+    delegate_compositor, delegate_keyboard, delegate_layer, delegate_output, delegate_pointer,
+    delegate_registry, delegate_seat, delegate_shm,
+    output::{OutputHandler, OutputState},
+    registry::{ProvidesRegistryState, RegistryState},
+    seat::{
+        keyboard::{KeyEvent, KeyboardHandler, Modifiers},
+        pointer::{PointerHandler, PointerScroll},
+        Capability, SeatHandler, SeatState,
+    },
+    shell::layer::{
+        Anchor, KeyboardInteractivity, Layer, LayerHandler, LayerState, LayerSurface,
+        LayerSurfaceConfigure,
+    },
+    shm::{pool::raw::RawPool, ShmHandler, ShmState},
+};
+use wayland_client::{
+    protocol::{wl_buffer, wl_keyboard, wl_output, wl_pointer, wl_seat, wl_shm, wl_surface},
+    Connection, ConnectionHandle, Dispatch, QueueHandle,
+};
+
+fn main() {
+    env_logger::init();
+
+    let conn = Connection::connect_to_env().unwrap();
+
+    let display = conn.handle().display();
+
+    let mut event_queue = conn.new_event_queue();
+    let qh = event_queue.handle();
+
+    let registry = display.get_registry(&mut conn.handle(), &qh, ()).unwrap();
+
+    let mut simple_layer = SimpleLayer {
+        registry_state: RegistryState::new(registry),
+        seat_state: SeatState::new(),
+        output_state: OutputState::new(),
+        compositor_state: CompositorState::new(),
+        shm_state: ShmState::new(),
+        layer_state: LayerState::new(),
+
+        exit: false,
+        first_configure: true,
+        pool: None,
+        width: 256,
+        height: 256,
+        buffer: None,
+        layer: None,
+        keyboard: None,
+        keyboard_focus: false,
+        pointer: None,
+        pointer_focus: false,
+    };
+
+    event_queue.blocking_dispatch(&mut simple_layer).unwrap();
+    // event_queue.blocking_dispatch(&mut simple_layer).unwrap();
+
+    let pool = simple_layer
+        .shm_state
+        .new_raw_pool(
+            simple_layer.width as usize * simple_layer.height as usize * 4,
+            &mut conn.handle(),
+            &qh,
+            (),
+        )
+        .expect("Failed to create pool");
+    simple_layer.pool = Some(pool);
+
+    let surface = simple_layer.compositor_state.create_surface(&mut conn.handle(), &qh).unwrap();
+
+    let layer = LayerSurface::builder()
+        .size((256, 256))
+        .anchor(Anchor::BOTTOM)
+        .keyboard_interactivity(KeyboardInteractivity::OnDemand)
+        .namespace("sample_layer")
+        .map(&mut conn.handle(), &qh, &mut simple_layer.layer_state, surface, Layer::Top)
+        .expect("layer surface creation");
+
+    simple_layer.layer = Some(layer);
+
+    // We don't draw immediately, the configure will notify us when to first draw.
+
+    loop {
+        event_queue.blocking_dispatch(&mut simple_layer).unwrap();
+
+        if simple_layer.exit {
+            println!("exiting example");
+            break;
+        }
+    }
+}
+
+struct SimpleLayer {
+    registry_state: RegistryState,
+    seat_state: SeatState,
+    output_state: OutputState,
+    compositor_state: CompositorState,
+    shm_state: ShmState,
+    layer_state: LayerState,
+
+    exit: bool,
+    first_configure: bool,
+    pool: Option<RawPool>,
+    width: u32,
+    height: u32,
+    buffer: Option<wl_buffer::WlBuffer>,
+    layer: Option<LayerSurface>,
+    keyboard: Option<wl_keyboard::WlKeyboard>,
+    keyboard_focus: bool,
+    pointer: Option<wl_pointer::WlPointer>,
+    pointer_focus: bool,
+}
+
+impl CompositorHandler for SimpleLayer {
+    fn compositor_state(&mut self) -> &mut CompositorState {
+        &mut self.compositor_state
+    }
+
+    fn scale_factor_changed(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _new_factor: i32,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn frame(
+        &mut self,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _time: u32,
+    ) {
+        self.draw(conn, qh);
+    }
+}
+
+impl OutputHandler for SimpleLayer {
+    fn output_state(&mut self) -> &mut OutputState {
+        &mut self.output_state
+    }
+
+    fn new_output(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+
+    fn update_output(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+
+    fn output_destroyed(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+}
+
+impl LayerHandler for SimpleLayer {
+    fn layer_state(&mut self) -> &mut LayerState {
+        &mut self.layer_state
+    }
+
+    fn closed(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _layer: &LayerSurface,
+    ) {
+        self.exit = true;
+    }
+
+    fn configure(
+        &mut self,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<Self>,
+        _layer: &LayerSurface,
+        configure: LayerSurfaceConfigure,
+        _serial: u32,
+    ) {
+        if configure.new_size.0 == 0 || configure.new_size.1 == 0 {
+            self.width = 256;
+            self.height = 256;
+        } else {
+            self.width = configure.new_size.0;
+            self.height = configure.new_size.1;
+        }
+
+        // Initiate the first draw.
+        if self.first_configure {
+            self.first_configure = false;
+            self.draw(conn, qh);
+        }
+    }
+}
+
+impl SeatHandler for SimpleLayer {
+    fn seat_state(&mut self) -> &mut SeatState {
+        &mut self.seat_state
+    }
+
+    fn new_seat(&mut self, _: &mut ConnectionHandle, _: &QueueHandle<Self>, _: wl_seat::WlSeat) {}
+
+    fn new_capability(
+        &mut self,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<Self>,
+        seat: wl_seat::WlSeat,
+        capability: Capability,
+    ) {
+        if capability == Capability::Keyboard && self.keyboard.is_none() {
+            println!("Set keyboard capability");
+            let keyboard = self
+                .seat_state
+                .get_keyboard(conn, qh, &seat, None)
+                .expect("Failed to create keyboard");
+            self.keyboard = Some(keyboard);
+        }
+
+        if capability == Capability::Pointer && self.pointer.is_none() {
+            println!("Set pointer capability");
+            let pointer =
+                self.seat_state.get_pointer(conn, qh, &seat).expect("Failed to create pointer");
+            self.pointer = Some(pointer);
+        }
+    }
+
+    fn remove_capability(
+        &mut self,
+        conn: &mut ConnectionHandle,
+        _: &QueueHandle<Self>,
+        _: wl_seat::WlSeat,
+        capability: Capability,
+    ) {
+        if capability == Capability::Keyboard && self.keyboard.is_some() {
+            println!("Unset keyboard capability");
+            self.keyboard.take().unwrap().release(conn);
+        }
+
+        if capability == Capability::Pointer && self.pointer.is_some() {
+            println!("Unset pointer capability");
+            self.pointer.take().unwrap().release(conn);
+        }
+    }
+
+    fn remove_seat(&mut self, _: &mut ConnectionHandle, _: &QueueHandle<Self>, _: wl_seat::WlSeat) {
+    }
+}
+
+impl KeyboardHandler for SimpleLayer {
+    fn enter(
+        &mut self,
+        _: &mut ConnectionHandle,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        surface: &wl_surface::WlSurface,
+        _: u32,
+        _: &[u32],
+        keysyms: &[u32],
+    ) {
+        if self.layer.as_ref().map(LayerSurface::wl_surface) == Some(surface) {
+            println!("Keyboard focus on window with pressed syms: {:?}", keysyms);
+            self.keyboard_focus = true;
+        }
+    }
+
+    fn leave(
+        &mut self,
+        _: &mut ConnectionHandle,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        surface: &wl_surface::WlSurface,
+        _: u32,
+    ) {
+        if self.layer.as_ref().map(LayerSurface::wl_surface) == Some(surface) {
+            println!("Release keyboard focus on window");
+            self.keyboard_focus = false;
+        }
+    }
+
+    fn press_key(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _: u32,
+        event: KeyEvent,
+    ) {
+        println!("Key press: {:?}", event);
+    }
+
+    fn release_key(
+        &mut self,
+        _: &mut ConnectionHandle,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _: u32,
+        event: KeyEvent,
+    ) {
+        println!("Key release: {:?}", event);
+    }
+
+    fn update_modifiers(
+        &mut self,
+        _: &mut ConnectionHandle,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _serial: u32,
+        modifiers: Modifiers,
+    ) {
+        println!("Update modifiers: {:?}", modifiers);
+    }
+}
+
+impl PointerHandler for SimpleLayer {
+    fn pointer_focus(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _pointer: &wl_pointer::WlPointer,
+        surface: &wl_surface::WlSurface,
+        entered: (f64, f64),
+    ) {
+        if self.layer.as_ref().map(LayerSurface::wl_surface) == Some(surface) {
+            println!("Pointer focus on layer, entering at {:?}", entered);
+            self.pointer_focus = true;
+        }
+    }
+
+    fn pointer_release_focus(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _pointer: &wl_pointer::WlPointer,
+        surface: &wl_surface::WlSurface,
+    ) {
+        if self.layer.as_ref().map(LayerSurface::wl_surface) == Some(surface) {
+            println!("Release pointer focus on layer");
+            self.pointer_focus = false;
+        }
+    }
+
+    fn pointer_motion(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _pointer: &wl_pointer::WlPointer,
+        time: u32,
+        position: (f64, f64),
+    ) {
+        if self.pointer_focus {
+            println!("Pointer motion: {:?} @ {}", position, time);
+        }
+    }
+
+    fn pointer_press_button(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _pointer: &wl_pointer::WlPointer,
+        time: u32,
+        button: u32,
+    ) {
+        if self.pointer_focus {
+            println!("Pointer press button: {:?} @ {}", button, time);
+        }
+    }
+
+    fn pointer_release_button(
+        &mut self,
+        _conn: &mut ConnectionHandle,
+        _qh: &QueueHandle<Self>,
+        _pointer: &wl_pointer::WlPointer,
+        time: u32,
+        button: u32,
+    ) {
+        if self.pointer_focus {
+            println!("Pointer release button: {:?} @ {}", button, time);
+        }
+    }
+
+    fn pointer_axis(
+        &mut self,
+        _: &mut ConnectionHandle,
+        _: &QueueHandle<Self>,
+        _: &wl_pointer::WlPointer,
+        time: u32,
+        scroll: PointerScroll,
+    ) {
+        if self.pointer_focus {
+            println!("Pointer scroll: @ {}", time);
+
+            if let Some(vertical) = scroll.axis(wl_pointer::Axis::VerticalScroll) {
+                println!("\nV: {:?}", vertical);
+            }
+
+            if let Some(horizontal) = scroll.axis(wl_pointer::Axis::HorizontalScroll) {
+                println!("\nH: {:?}", horizontal);
+            }
+        }
+    }
+}
+
+impl ShmHandler for SimpleLayer {
+    fn shm_state(&mut self) -> &mut ShmState {
+        &mut self.shm_state
+    }
+}
+
+impl SimpleLayer {
+    pub fn draw(&mut self, conn: &mut ConnectionHandle, qh: &QueueHandle<Self>) {
+        if let Some(window) = self.layer.as_ref() {
+            // Ensure the pool is big enough to hold the new buffer.
+            self.pool
+                .as_mut()
+                .unwrap()
+                .resize((self.width * self.height * 4) as usize, conn)
+                .expect("resize pool");
+
+            // Destroy the old buffer.
+            // FIXME: Integrate this into the pool logic.
+            if let Some(buffer) = self.buffer.take() {
+                buffer.destroy(conn);
+            }
+
+            let offset = 0;
+            let stride = self.width as i32 * 4;
+            let pool = self.pool.as_mut().unwrap();
+
+            let wl_buffer = pool
+                .create_buffer(
+                    offset,
+                    self.width as i32,
+                    self.height as i32,
+                    stride,
+                    wl_shm::Format::Argb8888,
+                    (),
+                    conn,
+                    qh,
+                )
+                .expect("create buffer");
+
+            // TODO: Upgrade to a better pool type
+            let len = self.height as usize * stride as usize; // length of a row
+            let buffer = &mut pool.mmap()[offset as usize..][..len];
+
+            // Draw to the window:
+            {
+                let width = self.width;
+                let height = self.height;
+
+                buffer.chunks_exact_mut(4).enumerate().for_each(|(index, chunk)| {
+                    let x = (index % width as usize) as u32;
+                    let y = (index / width as usize) as u32;
+
+                    let a = 0xFF;
+                    let r = u32::min(((width - x) * 0xFF) / width, ((height - y) * 0xFF) / height);
+                    let g = u32::min((x * 0xFF) / width, ((height - y) * 0xFF) / height);
+                    let b = u32::min(((width - x) * 0xFF) / width, (y * 0xFF) / height);
+                    let color = (a << 24) + (r << 16) + (g << 8) + b;
+
+                    let array: &mut [u8; 4] = chunk.try_into().unwrap();
+                    *array = color.to_le_bytes();
+                });
+            }
+
+            self.buffer = Some(wl_buffer);
+
+            // Request our next frame
+            window
+                .wl_surface()
+                .frame(conn, qh, window.wl_surface().clone())
+                .expect("create callback");
+
+            assert!(self.buffer.is_some(), "No buffer?");
+            // Attach and commit to present.
+            window.wl_surface().attach(conn, self.buffer.as_ref(), 0, 0);
+            window.wl_surface().commit(conn);
+        }
+    }
+}
+
+delegate_compositor!(SimpleLayer);
+delegate_output!(SimpleLayer);
+delegate_shm!(SimpleLayer);
+
+delegate_seat!(SimpleLayer);
+delegate_keyboard!(SimpleLayer);
+delegate_pointer!(SimpleLayer);
+
+delegate_layer!(SimpleLayer);
+
+delegate_registry!(SimpleLayer: [
+    CompositorState,
+    OutputState,
+    ShmState,
+    SeatState,
+    LayerState,
+]);
+
+impl ProvidesRegistryState for SimpleLayer {
+    fn registry(&mut self) -> &mut RegistryState {
+        &mut self.registry_state
+    }
+}
+
+// TODO
+impl Dispatch<wl_buffer::WlBuffer> for SimpleLayer {
+    type UserData = ();
+
+    fn event(
+        &mut self,
+        _: &wl_buffer::WlBuffer,
+        _: wl_buffer::Event,
+        _: &Self::UserData,
+        _: &mut wayland_client::ConnectionHandle,
+        _: &wayland_client::QueueHandle<Self>,
+    ) {
+        // todo
+    }
+}

--- a/src/shell/layer/dispatch.rs
+++ b/src/shell/layer/dispatch.rs
@@ -1,0 +1,130 @@
+use wayland_client::{
+    ConnectionHandle, DelegateDispatch, DelegateDispatchBase, Dispatch, QueueHandle,
+};
+use wayland_protocols::wlr::unstable::layer_shell::v1::client::{
+    zwlr_layer_shell_v1, zwlr_layer_surface_v1,
+};
+
+use crate::registry::{ProvidesRegistryState, RegistryHandler};
+
+use super::{
+    LayerHandler, LayerState, LayerSurface, LayerSurfaceConfigure, LayerSurfaceData, SurfaceKind,
+};
+
+impl<D> RegistryHandler<D> for LayerState
+where
+    D: Dispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, UserData = ()>
+        + LayerHandler
+        + ProvidesRegistryState
+        + 'static,
+{
+    fn new_global(
+        data: &mut D,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<D>,
+        name: u32,
+        interface: &str,
+        version: u32,
+    ) {
+        if interface == "zwlr_layer_shell_v1" {
+            if data.layer_state().wlr_layer_shell.is_some() {
+                return;
+            }
+
+            data.layer_state().wlr_layer_shell = Some(
+                data.registry()
+                    .bind_once::<zwlr_layer_shell_v1::ZwlrLayerShellV1, _, _>(
+                        conn,
+                        qh,
+                        name,
+                        u32::min(version, 4),
+                        (),
+                    )
+                    .expect("failed to bind wlr layer shell"),
+            );
+        }
+    }
+
+    fn remove_global(_: &mut D, _: &mut ConnectionHandle, _: &QueueHandle<D>, _: u32) {
+        // Unlikely to ever occur and the surfaces become inert if this happens.
+    }
+}
+
+impl DelegateDispatchBase<zwlr_layer_shell_v1::ZwlrLayerShellV1> for LayerState {
+    type UserData = ();
+}
+
+impl<D> DelegateDispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, D> for LayerState
+where
+    D: Dispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, UserData = ()> + LayerHandler + 'static,
+{
+    fn event(
+        _: &mut D,
+        _: &zwlr_layer_shell_v1::ZwlrLayerShellV1,
+        _: zwlr_layer_shell_v1::Event,
+        _: &Self::UserData,
+        _: &mut ConnectionHandle,
+        _: &QueueHandle<D>,
+    ) {
+        unreachable!("zwlr_layer_shell_v1 has no events")
+    }
+}
+
+impl DelegateDispatchBase<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1> for LayerState {
+    type UserData = LayerSurfaceData;
+}
+
+impl<D> DelegateDispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, D> for LayerState
+where
+    D: Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, UserData = Self::UserData>
+        + LayerHandler
+        + 'static,
+{
+    fn event(
+        data: &mut D,
+        surface: &zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
+        event: zwlr_layer_surface_v1::Event,
+        _udata: &Self::UserData,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<D>,
+    ) {
+        match event {
+            zwlr_layer_surface_v1::Event::Configure { serial, width, height } => {
+                if let Some(layer) = data
+                    .layer_state()
+                    .surfaces
+                    .iter()
+                    .find(|layer| match layer.kind() {
+                        SurfaceKind::Wlr(wlr) => wlr == surface,
+                    })
+                    .map(LayerSurface::impl_clone)
+                {
+                    surface.ack_configure(conn, serial);
+
+                    let configure = LayerSurfaceConfigure { new_size: (width, height) };
+
+                    data.configure(conn, qh, &layer, configure, serial);
+                }
+            }
+
+            zwlr_layer_surface_v1::Event::Closed => {
+                if let Some(layer) = data
+                    .layer_state()
+                    .surfaces
+                    .iter()
+                    .find(|layer| match layer.kind() {
+                        SurfaceKind::Wlr(wlr) => wlr == surface,
+                    })
+                    .map(LayerSurface::impl_clone)
+                {
+                    data.closed(conn, qh, &layer);
+                }
+            }
+
+            _ => unreachable!(),
+        }
+
+        // Perform cleanup of any dropped layers
+        data.layer_state().cleanup(conn);
+    }
+}

--- a/src/shell/layer/mod.rs
+++ b/src/shell/layer/mod.rs
@@ -1,0 +1,496 @@
+mod dispatch;
+
+use std::{
+    convert::TryFrom,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+use bitflags::bitflags;
+use wayland_backend::client::InvalidId;
+use wayland_client::{
+    protocol::{wl_output, wl_surface},
+    ConnectionHandle, Dispatch, QueueHandle,
+};
+use wayland_protocols::wlr::unstable::layer_shell::v1::client::{
+    zwlr_layer_shell_v1, zwlr_layer_surface_v1,
+};
+
+#[derive(Debug)]
+pub struct LayerState {
+    wlr_layer_shell: Option<zwlr_layer_shell_v1::ZwlrLayerShellV1>,
+    surfaces: Vec<LayerSurface>,
+}
+
+impl LayerState {
+    pub fn new() -> LayerState {
+        LayerState { wlr_layer_shell: None, surfaces: Vec::new() }
+    }
+
+    /// Returns whether the layer shell is available.
+    ///
+    /// The layer shell is not supported by all compositors and this function may be used to determine if
+    /// compositor support is available.
+    pub fn is_available(&self) -> bool {
+        self.wlr_layer_shell.is_some()
+    }
+
+    pub fn wlr_layer_shell(&self) -> Option<&zwlr_layer_shell_v1::ZwlrLayerShellV1> {
+        self.wlr_layer_shell.as_ref()
+    }
+}
+
+pub trait LayerHandler: Sized {
+    fn layer_state(&mut self) -> &mut LayerState;
+
+    /// Called when the surface will no longer be shown.
+    ///
+    /// This may occur as a result of the output the layer is placed on being destroyed or the user has caused
+    /// the layer to be removed.
+    ///
+    /// You should drop the layer you have when this event is received.
+    fn closed(&mut self, conn: &mut ConnectionHandle, qh: &QueueHandle<Self>, layer: &LayerSurface);
+
+    /// Called when the compositor has sent a configure event to an layer
+    ///
+    /// A configure atomically indicates that a sequence of events describing how a surface has changed have
+    /// all been sent.
+    fn configure(
+        &mut self,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<Self>,
+        layer: &LayerSurface,
+        configure: LayerSurfaceConfigure,
+        serial: u32,
+    );
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LayerSurfaceError {
+    /// The layer shell global is not available.
+    #[error("the layer shell global is not available")]
+    MissingRequiredGlobals,
+
+    /// Protocol error.
+    #[error(transparent)]
+    Protocol(#[from] InvalidId),
+}
+
+#[derive(Debug)]
+pub struct LayerSurfaceBuilder {
+    output: Option<wl_output::WlOutput>,
+    namespace: Option<String>,
+    size: Option<(u32, u32)>,
+    anchor: Option<Anchor>,
+    zone: Option<i32>,
+    // top, right, bottom, left
+    margin: Option<(i32, i32, i32, i32)>,
+    interactivity: Option<KeyboardInteractivity>,
+}
+
+impl LayerSurfaceBuilder {
+    pub fn namespace(self, namespace: impl Into<String>) -> Self {
+        Self { namespace: Some(namespace.into()), ..self }
+    }
+
+    pub fn output(self, output: &wl_output::WlOutput) -> Self {
+        Self { output: Some(output.clone()), ..self }
+    }
+
+    pub fn size(self, size: (u32, u32)) -> Self {
+        Self { size: Some(size), ..self }
+    }
+
+    pub fn anchor(self, anchor: Anchor) -> Self {
+        Self { anchor: Some(anchor), ..self }
+    }
+
+    pub fn exclusive_zone(self, zone: i32) -> Self {
+        Self { zone: Some(zone), ..self }
+    }
+
+    pub fn margin(self, top: i32, right: i32, bottom: i32, left: i32) -> Self {
+        Self { margin: Some((top, right, bottom, left)), ..self }
+    }
+
+    pub fn keyboard_interactivity(self, interactivity: KeyboardInteractivity) -> Self {
+        Self { interactivity: Some(interactivity), ..self }
+    }
+
+    /// Build and map the layer
+    ///
+    /// This function will create the layer and send the initial commit.
+    ///
+    /// # Protocol errors
+    ///
+    /// If the surface already has a role object, the compositor will raise a protocol error.
+    ///
+    /// A surface is considered to have a role object if some other type of surface was created using the
+    /// surface. For example, creating a window, popup, layer or subsurface all assign a role object to a
+    /// surface.
+    ///
+    /// The function here takes an owned reference to the surface to hint the surface will be consumed by the
+    /// layer.
+    ///
+    /// [`WlSurface`]: wl_surface::WlSurface
+    #[must_use = "The layer is destroyed if dropped"]
+    pub fn map<D>(
+        self,
+        conn: &mut ConnectionHandle,
+        qh: &QueueHandle<D>,
+        layer_state: &mut LayerState,
+        surface: wl_surface::WlSurface,
+        layer: Layer,
+    ) -> Result<LayerSurface, LayerSurfaceError>
+    where
+        D: Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, UserData = LayerSurfaceData>
+            + 'static,
+    {
+        // The layer is required in ext-layer-shell-v1 but is not part of the factory request. So the param
+        // will stay for ext-layer-shell-v1 support.
+
+        let layer_shell =
+            layer_state.wlr_layer_shell().ok_or(LayerSurfaceError::MissingRequiredGlobals)?;
+        let layer_surface = layer_shell.get_layer_surface(
+            conn,
+            &surface,
+            self.output.as_ref(),
+            layer.into(),
+            self.namespace.unwrap_or_default(),
+            qh,
+            LayerSurfaceData {},
+        )?;
+
+        // Set data for initial commit
+        if let Some(size) = self.size {
+            layer_surface.set_size(conn, size.0, size.1);
+        }
+
+        if let Some(anchor) = self.anchor {
+            // We currently rely on the bitsets matching
+            layer_surface
+                .set_anchor(conn, zwlr_layer_surface_v1::Anchor::from_bits_truncate(anchor.bits()));
+        }
+
+        if let Some(zone) = self.zone {
+            layer_surface.set_exclusive_zone(conn, zone);
+        }
+
+        if let Some(margin) = self.margin {
+            layer_surface.set_margin(conn, margin.0, margin.1, margin.2, margin.3);
+        }
+
+        if let Some(interactivity) = self.interactivity {
+            layer_surface.set_keyboard_interactivity(conn, interactivity.into())
+        }
+
+        // Initial commit
+        surface.commit(conn);
+
+        let layer_surface = LayerSurface {
+            kind: SurfaceKind::Wlr(layer_surface),
+            wl_surface: surface,
+            primary: true,
+            death_signal: Arc::new(AtomicBool::new(false)),
+        };
+
+        layer_state.surfaces.push(layer_surface.impl_clone());
+
+        Ok(layer_surface)
+    }
+}
+
+#[derive(Debug)]
+pub struct LayerSurface {
+    kind: SurfaceKind,
+
+    wl_surface: wl_surface::WlSurface,
+
+    /// Whether this is the primary handle to the layer.
+    ///
+    /// This is only true for [`Layer`] given the user from [`LayerBuilder::map`]. Since we pass
+    /// a reference to a [`Layer`] in some traits the user implements, we need to make sure the layer isn't
+    /// actually destroyed while the user still holds the layer. If this field is true, the drop implementation
+    /// will mark the layer as dead and will clean up when possible.
+    pub(crate) primary: bool,
+
+    /// Indicates whether the primary handle to the layer has been destroyed.
+    ///
+    /// Since we can't destroy wayland objects without a connection handle, we need to mark the layer for
+    /// cleanup.
+    pub(crate) death_signal: Arc<AtomicBool>,
+}
+
+impl PartialEq for LayerSurface {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
+impl LayerSurface {
+    pub fn builder() -> LayerSurfaceBuilder {
+        LayerSurfaceBuilder {
+            output: None,
+            namespace: None,
+            size: None,
+            anchor: None,
+            zone: None,
+            margin: None,
+            interactivity: None,
+        }
+    }
+
+    // TODO: get_popup
+
+    // Double buffered state
+
+    pub fn set_size(&self, conn: &mut ConnectionHandle, width: u32, height: u32) {
+        match self.kind {
+            SurfaceKind::Wlr(ref wlr) => wlr.set_size(conn, width, height),
+        }
+    }
+
+    pub fn set_anchor(&self, conn: &mut ConnectionHandle, anchor: Anchor) {
+        match self.kind {
+            // We currently rely on the bitsets being the same
+            SurfaceKind::Wlr(ref wlr) => wlr
+                .set_anchor(conn, zwlr_layer_surface_v1::Anchor::from_bits_truncate(anchor.bits())),
+        }
+    }
+
+    pub fn set_exclusive_zone(&self, conn: &mut ConnectionHandle, zone: i32) {
+        match self.kind {
+            SurfaceKind::Wlr(ref wlr) => wlr.set_exclusive_zone(conn, zone),
+        }
+    }
+
+    pub fn set_margin(
+        &self,
+        conn: &mut ConnectionHandle,
+        top: i32,
+        right: i32,
+        bottom: i32,
+        left: i32,
+    ) {
+        match self.kind {
+            SurfaceKind::Wlr(ref wlr) => wlr.set_margin(conn, top, right, bottom, left),
+        }
+    }
+
+    pub fn set_keyboard_interactivity(
+        &self,
+        conn: &mut ConnectionHandle,
+        value: KeyboardInteractivity,
+    ) {
+        match self.kind {
+            SurfaceKind::Wlr(ref wlr) => wlr.set_keyboard_interactivity(conn, value.into()),
+        }
+    }
+
+    pub fn set_layer(&self, conn: &mut ConnectionHandle, depth: Layer) {
+        match self.kind {
+            SurfaceKind::Wlr(ref wlr) => wlr.set_layer(conn, depth.into()),
+        }
+    }
+
+    pub fn kind(&self) -> &SurfaceKind {
+        &self.kind
+    }
+
+    pub fn wl_surface(&self) -> &wl_surface::WlSurface {
+        &self.wl_surface
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub enum SurfaceKind {
+    Wlr(zwlr_layer_surface_v1::ZwlrLayerSurfaceV1),
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum KeyboardInteractivity {
+    /// No keyboard focus is possible.
+    ///
+    /// This is the default value for all newly created layer shells.
+    None,
+
+    /// Request exclusive keyboard focus if the layer is above shell surfaces.
+    ///
+    /// For [`Layer::Top`] and [`Layer::Overlay`], the seat will always give exclusive access to the layer
+    /// which has this interactivity mode set.
+    ///
+    /// This setting is intended for applications that need to ensure they receive all keyboard events, such
+    /// as a lock screen or a password prompt.
+    Exclusive,
+
+    /// The compositor should focus and unfocus this surface by the user in an implementation specific manner.
+    ///
+    /// Compositors may use their normal mechanisms to manage keyboard focus between layers and regular
+    /// desktop surfaces.
+    ///
+    /// This setting is intended for applications which allow keyboard interaction.  
+    OnDemand,
+}
+
+impl Default for KeyboardInteractivity {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// The z-depth of a layer.
+///
+/// These values indicate which order in which layer surfaces are rendered.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Layer {
+    Background,
+
+    Bottom,
+
+    Top,
+
+    Overlay,
+}
+
+/// Error when converting a [`zwlr_layer_shell_v1::Layer`] to a [`Layer`]
+#[derive(Debug, thiserror::Error)]
+#[error("unknown layer")]
+pub struct UnknownLayer;
+
+bitflags! {
+    /// Specifies which edges and corners a layer should be placed at in the anchor rectangle.
+    ///
+    /// A combination of two orthogonal edges will cause the layer's anchor point to be the intersection of
+    /// the edges. For example [`Anchor::TOP`] and [`Anchor::LEFT`] will result in an anchor point in the top
+    /// left of the anchor rectangle.
+    pub struct Anchor: u32 {
+        /// Top edge of the anchor rectangle.
+        const TOP = 1;
+
+        /// The bottom edge of the anchor rectangle.
+        const BOTTOM = 2;
+
+        /// The left edge of the anchor rectangle.
+        const LEFT = 4;
+
+        /// The right edge of the anchor rectangle.
+        const RIGHT = 8;
+    }
+}
+
+/// The configure state of a layer
+///
+/// This type indicates compositor changes to the layer, such as a new size.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct LayerSurfaceConfigure {
+    /// The compositor suggested new size of the layer.
+    ///
+    /// The size is a hint, meaning the client is free to ignore the new size (if the client does not resize),
+    /// pick a smaller size to satisfy aspect ratio or resize in steps. If you pick a small size and the
+    /// surface is anchored to two opposite anchors, then surface will be centered on the axis.
+    ///
+    /// If either the width or height is 0, the compositor may choose any size for that specific width or height.
+    pub new_size: (u32, u32),
+}
+
+#[derive(Debug)]
+pub struct LayerSurfaceData {
+    // This is empty right now, but may be populated in the future.
+}
+
+#[macro_export]
+macro_rules! delegate_layer {
+    ($ty: ty) => {
+        $crate::reexports::client::delegate_dispatch!($ty: [
+            $crate::reexports::protocols::wlr::unstable::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1,
+            $crate::reexports::protocols::wlr::unstable::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1
+        ] => $crate::shell::layer::LayerState);
+    };
+}
+
+impl TryFrom<zwlr_layer_shell_v1::Layer> for Layer {
+    type Error = UnknownLayer;
+
+    fn try_from(layer: zwlr_layer_shell_v1::Layer) -> Result<Self, Self::Error> {
+        match layer {
+            zwlr_layer_shell_v1::Layer::Background => Ok(Self::Background),
+            zwlr_layer_shell_v1::Layer::Bottom => Ok(Self::Bottom),
+            zwlr_layer_shell_v1::Layer::Top => Ok(Self::Top),
+            zwlr_layer_shell_v1::Layer::Overlay => Ok(Self::Overlay),
+            _ => Err(UnknownLayer),
+        }
+    }
+}
+
+impl From<Layer> for zwlr_layer_shell_v1::Layer {
+    fn from(depth: Layer) -> Self {
+        match depth {
+            Layer::Background => Self::Background,
+            Layer::Bottom => Self::Bottom,
+            Layer::Top => Self::Top,
+            Layer::Overlay => Self::Overlay,
+        }
+    }
+}
+
+impl From<KeyboardInteractivity> for zwlr_layer_surface_v1::KeyboardInteractivity {
+    fn from(interactivity: KeyboardInteractivity) -> Self {
+        match interactivity {
+            KeyboardInteractivity::None => zwlr_layer_surface_v1::KeyboardInteractivity::None,
+            KeyboardInteractivity::Exclusive => {
+                zwlr_layer_surface_v1::KeyboardInteractivity::Exclusive
+            }
+            KeyboardInteractivity::OnDemand => {
+                zwlr_layer_surface_v1::KeyboardInteractivity::OnDemand
+            }
+        }
+    }
+}
+
+impl LayerSurface {
+    /// Clone is an implementation detail of Layer.
+    ///
+    /// This function creates another layer handle that is not marked as a primary handle.
+    pub(crate) fn impl_clone(&self) -> LayerSurface {
+        LayerSurface {
+            kind: self.kind.clone(),
+            wl_surface: self.wl_surface.clone(),
+            primary: false,
+            death_signal: self.death_signal.clone(),
+        }
+    }
+}
+
+impl Drop for LayerSurface {
+    fn drop(&mut self) {
+        // If we are the primary handle (an owned value given to the user), mark ourselves for cleanup.
+        if self.primary {
+            self.death_signal.store(true, Ordering::SeqCst);
+        }
+    }
+}
+
+impl LayerState {
+    pub(crate) fn cleanup(&mut self, conn: &mut ConnectionHandle) {
+        self.surfaces.retain(|layer| {
+            let alive = !layer.death_signal.load(Ordering::SeqCst);
+
+            if !alive {
+                // Layer shell protocol dictates we must destroy the role object before the surface.
+                match layer.kind() {
+                    SurfaceKind::Wlr(wlr) => wlr.destroy(conn),
+                }
+
+                layer.wl_surface().destroy(conn);
+            }
+
+            alive
+        })
+    }
+}

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -18,11 +18,29 @@
 //!
 //! See the [XDG shell module documentation] for more information about creating application windows.
 //!
+//! ## Layer shell
+//!
+//! The layer shell is a protocol which allows the creation of "layers". A layer refers to a surface rendered
+//! at some specific z-depth relative to other layers. A layer may also be anchored to some edge and corner of
+//! the screen.
+//!
+//! The layer shell defines one type of surface: the [`Layer`].
+//!
+//! There is no guarantee that the layer shell will be available in every compositor.
+//!
+//! ### Why use the layer shell
+//!
+//! The layer shell may be used to implement many desktop shell components, such as backgrounds, docks and
+//! launchers.
+//!
 //! [^window]: The XDG shell protocol actually refers to a window as a toplevel surface, but we use the more
 //! familiar term "window" for the sake of clarity.
 //!
 //! [XDG shell module documentation]: self::xdg
 //! [`Window`]: self::xdg::window::Window
+//!
+//! [`Layer`]: self::layer::Layer
 
+pub mod layer;
 pub mod xdg;
 // TODO: Would be nice to support the layer shell.


### PR DESCRIPTION
Shell abstractions for the layer shell. This is modeled off the xdg shell abstractions currently in 0.30.

We intentionally wrap types used by the wlr protocol since there is a future ext extension being proposed. We do not implement the ext extension (but it was considered during the design).
