### PR TITLE
0.30: add missing PartialEq for window

### DIFF
--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -492,6 +492,12 @@ impl Window {
     }
 }
 
+impl PartialEq for Window {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct WindowData(pub(crate) Arc<WindowDataInner>);
 


### PR DESCRIPTION
Window isn't very usable in contexts where multiple exist without a way to identify a window