### PR TITLE
Fix window's `wl_pointer` not releasing on drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Bugfixes
+
+- `Window`'s `wl_pointer` not being relased on `Drop`.
+
 ## 0.15.3 - 2021-12-27
 
 #### Bugfixes

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -708,6 +708,11 @@ impl<F: Frame + 'static> Window<F> {
 impl<F: Frame> Drop for Window<F> {
     fn drop(&mut self) {
         self.inner.borrow_mut().take();
+
+        // Destroy decorations manager, so the inner frame could be dropped.
+        if let Some(decoration) = self.decoration.take() {
+            decoration.destroy();
+        }
     }
 }
 


### PR DESCRIPTION
Due to decorations manager not being destroyed, its callback was keeping
alive holding the reference to window's inner frame storage preventing
`wl_pointer`s from being released on drop.

That caused issue [1] downstream.

[1] - https://github.com/rust-windowing/winit/issues/2248