### PR TITLE
DataOffer low level receive method & DataDevice with_dnd method

### DIFF
--- a/src/data_device/device.rs
+++ b/src/data_device/device.rs
@@ -209,6 +209,15 @@ impl DataDevice {
         let inner = self.inner.lock().unwrap();
         f(inner.selection.as_ref())
     }
+
+    /// Access the `DataOffer` currently associated with current DnD 
+    pub fn with_dnd<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(Option<&DataOffer>) -> T,
+    {
+        let inner = self.inner.lock().unwrap();
+        f(inner.current_dnd.as_ref())
+    }
 }
 
 impl Drop for DataDevice {

--- a/src/data_device/device.rs
+++ b/src/data_device/device.rs
@@ -210,7 +210,7 @@ impl DataDevice {
         f(inner.selection.as_ref())
     }
 
-    /// Access the `DataOffer` currently associated with current DnD 
+    /// Access the `DataOffer` currently associated with current DnD
     pub fn with_dnd<F, T>(&self, f: F) -> T
     where
         F: FnOnce(Option<&DataOffer>) -> T,

--- a/src/data_device/offer.rs
+++ b/src/data_device/offer.rs
@@ -106,6 +106,29 @@ impl DataOffer {
         Ok(unsafe { FromRawFd::from_raw_fd(readfd) })
     }
 
+    /// Receive data to the write end of a raw file descriptor. If you have the read end, you can read from it.
+    ///
+    /// You can do this several times, as a reaction to motion of
+    /// the dnd cursor, or to inspect the data in order to choose your
+    /// response.
+    ///
+    /// Note that you should *not* read the contents right away in a
+    /// blocking way, as you may deadlock your application doing so.
+    /// At least make sure you flush your events to the server before
+    /// doing so.
+    ///
+    pub unsafe fn receive_to_fd(&self, mime_type: String, writefd: i32) -> std::io::Result<()> {
+        use nix::unistd::close;
+
+        self.offer.receive(mime_type, writefd);
+
+        if let Err(err) = close(writefd) {
+            log::warn!("Failed to close write pipe: {}", err);
+        }
+
+        Ok(())
+    }
+
     /// Notify the send and compositor of the dnd actions you accept
     ///
     /// You need to provide the set of supported actions, as well as

--- a/src/data_device/offer.rs
+++ b/src/data_device/offer.rs
@@ -117,7 +117,7 @@ impl DataOffer {
     /// At least make sure you flush your events to the server before
     /// doing so.
     ///
-    pub unsafe fn receive_to_fd(&self, mime_type: String, writefd: i32) -> std::io::Result<()> {
+    pub unsafe fn receive_to_fd(&self, mime_type: String, writefd: i32) {
         use nix::unistd::close;
 
         self.offer.receive(mime_type, writefd);
@@ -125,8 +125,6 @@ impl DataOffer {
         if let Err(err) = close(writefd) {
             log::warn!("Failed to close write pipe: {}", err);
         }
-
-        Ok(())
     }
 
     /// Notify the send and compositor of the dnd actions you accept


### PR DESCRIPTION
This PR adds:
- a method to DataOffer which receives data to a raw file descriptor, then closes it.
- a method to DataDevice which gives access to the current DnD offer outside of a DnDEvent, which I've found useful.


I'm working on wrapping xdg windows with a layer shell window. One of the use cases I'd like to support is forwarding the clipboard contents into the embedded compositor inside the layer shell window. What I'm currently trying to do is:

1. set the compositor provided selection when the layer shell window gains keyboard focus for a seat. https://smithay.github.io/smithay/smithay/wayland/data_device/fn.set_data_device_selection.html

2. Wait for the SendSelection request in the callback I provided to init_data_device. https://docs.rs/smithay/latest/smithay/wayland/data_device/fn.init_data_device.html

3. Forward the provided fd from the SendSelection request (2) to the receive method of the data offer for the seat from (1)

Step 3 is what this PR is intended to make possible.
