### PR TITLE
Expose globals via State objects

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -73,6 +73,10 @@ impl CompositorState {
         CompositorState { wl_compositor: None }
     }
 
+    pub fn wl_compositor(&self) -> Option<&wl_compositor::WlCompositor> {
+        self.wl_compositor.as_ref().map(|g| &g.1)
+    }
+
     pub fn create_surface<D>(
         &self,
         conn: &mut ConnectionHandle,

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -24,6 +24,10 @@ impl ShmState {
         ShmState { wl_shm: None, formats: vec![] }
     }
 
+    pub fn wl_shm(&self) -> Option<&wl_shm::WlShm> {
+        self.wl_shm.as_ref().map(|(_, shm)| shm)
+    }
+
     pub fn new_simple_pool<D, U>(
         &self,
         len: usize,


### PR DESCRIPTION
Most RegistryHandlers expose their contained global; add it to Shm and Compositor.