### PR TITLE
0.30 replace XYZError::MissingGlobals with GlobalError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,17 @@
+use wayland_backend::client::InvalidId;
+
+/// An error that may occur when creating objects using a global.
+#[derive(Debug, thiserror::Error)]
+pub enum GlobalError {
+    /// Some compositor globals were not available
+    ///
+    /// The value of this variant should contain the names of the missing globals.
+    #[error("the following globals are not available: {0:?}")]
+    MissingGlobals(&'static [&'static str]),
+
+    /// An invalid id was acted upon
+    ///
+    /// This likely means a request was sent to a dead protocol object.
+    #[error(transparent)]
+    Id(#[from] InvalidId),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod reexports {
 }
 
 pub mod compositor;
+pub mod error;
 #[cfg(feature = "calloop")]
 pub mod event_loop;
 pub mod output;

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -15,9 +15,11 @@ use wayland_protocols::{
     },
 };
 
+use crate::error::GlobalError;
+
 use self::inner::{WindowDataInner, WindowInner};
 
-use super::{ConfigureHandler, XdgShellHandler, XdgShellState, XdgSurfaceData, XdgSurfaceError};
+use super::{ConfigureHandler, XdgShellHandler, XdgShellState, XdgSurfaceData};
 
 pub(super) mod inner;
 
@@ -252,7 +254,7 @@ impl WindowBuilder {
         shell_state: &XdgShellState<D>,
         window_state: &mut XdgWindowState,
         surface: wl_surface::WlSurface,
-    ) -> Result<Window, XdgSurfaceError>
+    ) -> Result<Window, GlobalError>
     where
         D: Dispatch<xdg_surface::XdgSurface, UserData = XdgSurfaceData<D>>
             + Dispatch<xdg_toplevel::XdgToplevel, UserData = WindowData>

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -5,7 +5,10 @@ use wayland_client::{
     ConnectionHandle, DelegateDispatch, DelegateDispatchBase, Dispatch, QueueHandle, WEnum,
 };
 
-use crate::registry::{ProvidesRegistryState, RegistryHandler};
+use crate::{
+    error::GlobalError,
+    registry::{ProvidesRegistryState, RegistryHandler},
+};
 
 use self::pool::{raw::RawPool, simple::SimplePool, CreatePoolError};
 
@@ -56,7 +59,7 @@ impl ShmState {
         D: Dispatch<wl_shm_pool::WlShmPool, UserData = U> + 'static,
         U: Send + Sync + 'static,
     {
-        let (_, shm) = self.wl_shm.as_ref().ok_or(CreatePoolError::MissingShmGlobal)?;
+        let (_, shm) = self.wl_shm.as_ref().ok_or(GlobalError::MissingGlobals(&["wl_shm"]))?;
 
         RawPool::new(len, shm, conn, qh, udata)
     }

--- a/src/shm/pool/mod.rs
+++ b/src/shm/pool/mod.rs
@@ -4,18 +4,15 @@ pub mod simple;
 use std::io;
 
 use nix::errno::Errno;
-use wayland_client::backend::InvalidId;
+
+use crate::error::GlobalError;
 
 /// An error that may occur when creating a pool.
 #[derive(Debug, thiserror::Error)]
 pub enum CreatePoolError {
     /// The wl_shm global is not bound.
-    #[error("wl_shm global is not bound")]
-    MissingShmGlobal,
-
-    /// Could not create the underlying wayland object for the pool.
     #[error(transparent)]
-    Protocol(#[from] InvalidId),
+    Global(#[from] GlobalError),
 
     /// Error while allocating the shared memory.
     #[error(transparent)]

--- a/src/shm/pool/raw.rs
+++ b/src/shm/pool/raw.rs
@@ -23,6 +23,8 @@ use wayland_client::{
     ConnectionHandle, Dispatch, QueueHandle,
 };
 
+use crate::error::GlobalError;
+
 use super::CreatePoolError;
 
 /// A raw handler for file backed shared memory pools.
@@ -140,7 +142,8 @@ impl RawPool {
         let mem_file = unsafe { File::from_raw_fd(shm_fd) };
         mem_file.set_len(len as u64)?;
 
-        let pool = shm.create_pool(conn, shm_fd, len as i32, qh, udata)?;
+        let pool =
+            shm.create_pool(conn, shm_fd, len as i32, qh, udata).map_err(GlobalError::from)?;
         let mmap = unsafe { MmapMut::map_mut(&mem_file)? };
 
         Ok(RawPool { pool, len, mem_file, mmap })


### PR DESCRIPTION
Replace all the duplicate errors with one common error type.