### PR TITLE
layer_shell example: use Vec::retain_mut()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ['1.42.0', 'stable', 'beta']
+        rust: ['1.61.0', 'stable', 'beta']
       
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ The documentation for the releases can be found on [docs.rs](https://docs.rs/smi
 
 ## Requirements
 
-Requires at least rust 1.41 to be used and version 1.12 of the wayland system
+Requires at least rust 1.61 to be used and version 1.12 of the wayland system
 libraries.

--- a/examples/layer_shell.rs
+++ b/examples/layer_shell.rs
@@ -176,18 +176,9 @@ fn main() {
     WaylandSource::new(queue).quick_insert(event_loop.handle()).unwrap();
 
     loop {
-        // This is ugly, let's hope that some version of drain_filter() gets stabilized soon
-        // https://github.com/rust-lang/rust/issues/43244
         {
-            let mut surfaces = surfaces.borrow_mut();
-            let mut i = 0;
-            while i != surfaces.len() {
-                if surfaces[i].1.handle_events() {
-                    surfaces.remove(i);
-                } else {
-                    i += 1;
-                }
-            }
+            // Using a new scope so that `surfaces` reference gets dropped
+            surfaces.borrow_mut().retain_mut(|surface| !surface.1.handle_events());
         }
 
         display.flush().unwrap();


### PR DESCRIPTION
`Vec::retain_mut()` is stabilized in Rust 1.61