### PR TITLE
remove generics on XdgShellState

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1.0.30"
 wayland-backend = "=0.1.0-beta.1"
 wayland-client = "=0.30.0-beta.1"
 wayland-protocols = { version = "=0.30.0-beta.1", features = ["client", "unstable"] }
-wayland-protocols-wlr = { git = "https://github.com/Smithay/wayland-rs", features = ["client"] }
+wayland-protocols-wlr = { version = "=0.1.0-beta.1", features = ["client"] }
 wayland-cursor = "=0.30.0-beta.1"
 
 # Explicit dependency until release

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -99,7 +99,7 @@ struct SimpleWindow {
     output_state: OutputState,
     compositor_state: CompositorState,
     shm_state: ShmState,
-    xdg_shell_state: XdgShellState<Self>,
+    xdg_shell_state: XdgShellState,
     xdg_window_state: XdgWindowState,
 
     exit: bool,
@@ -173,7 +173,7 @@ impl OutputHandler for SimpleWindow {
 }
 
 impl XdgShellHandler for SimpleWindow {
-    fn xdg_shell_state(&mut self) -> &mut XdgShellState<Self> {
+    fn xdg_shell_state(&mut self) -> &mut XdgShellState {
         &mut self.xdg_shell_state
     }
 }
@@ -513,7 +513,7 @@ delegate_registry!(SimpleWindow: [
     OutputState,
     ShmState,
     SeatState,
-    XdgShellState<Self>,
+    XdgShellState,
     XdgWindowState,
 ]);
 

--- a/src/shell/layer/dispatch.rs
+++ b/src/shell/layer/dispatch.rs
@@ -59,7 +59,8 @@ where
     }
 }
 
-impl<D> DelegateDispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, LayerSurfaceData, D> for LayerState
+impl<D> DelegateDispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, LayerSurfaceData, D>
+    for LayerState
 where
     D: Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, LayerSurfaceData>
         + LayerHandler

--- a/src/shell/layer/mod.rs
+++ b/src/shell/layer/mod.rs
@@ -142,8 +142,7 @@ impl LayerSurfaceBuilder {
         layer: Layer,
     ) -> Result<LayerSurface, GlobalError>
     where
-        D: Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, LayerSurfaceData>
-            + 'static,
+        D: Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, LayerSurfaceData> + 'static,
     {
         // The layer is required in ext-layer-shell-v1 but is not part of the factory request. So the param
         // will stay for ext-layer-shell-v1 support.
@@ -375,8 +374,8 @@ pub struct LayerSurfaceData {
 macro_rules! delegate_layer {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty: [
-            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1,
-            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1
+            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1: (),
+            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1: $crate::shell::layer::LayerSurfaceData,
         ] => $crate::shell::layer::LayerState);
     };
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -41,5 +41,5 @@
 //!
 //! [`Layer`]: self::layer::Layer
 
-// pub mod layer;
+pub mod layer;
 pub mod xdg;

--- a/src/shell/xdg/inner.rs
+++ b/src/shell/xdg/inner.rs
@@ -1,11 +1,11 @@
 use wayland_client::{Connection, DelegateDispatch, Dispatch, QueueHandle};
-use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_wm_base};
+use wayland_protocols::xdg::shell::client::xdg_wm_base;
 
 use crate::registry::{ProvidesRegistryState, RegistryHandler};
 
-use super::{XdgShellHandler, XdgShellState, XdgSurfaceData};
+use super::{XdgShellHandler, XdgShellState};
 
-impl<D> RegistryHandler<D> for XdgShellState<D>
+impl<D> RegistryHandler<D> for XdgShellState
 where
     D: Dispatch<xdg_wm_base::XdgWmBase, ()> + XdgShellHandler + ProvidesRegistryState + 'static,
 {
@@ -38,7 +38,7 @@ where
 
 /* Delegate trait impls */
 
-impl<D> DelegateDispatch<xdg_wm_base::XdgWmBase, (), D> for XdgShellState<D>
+impl<D> DelegateDispatch<xdg_wm_base::XdgWmBase, (), D> for XdgShellState
 where
     D: Dispatch<xdg_wm_base::XdgWmBase, ()> + XdgShellHandler,
 {
@@ -53,30 +53,6 @@ where
         match event {
             xdg_wm_base::Event::Ping { serial } => {
                 xdg_wm_base.pong(serial);
-            }
-
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl<D> DelegateDispatch<xdg_surface::XdgSurface, XdgSurfaceData<D>, D> for XdgShellState<D>
-where
-    D: Dispatch<xdg_surface::XdgSurface, XdgSurfaceData<D>> + XdgShellHandler + 'static,
-{
-    fn event(
-        data: &mut D,
-        surface: &xdg_surface::XdgSurface,
-        event: xdg_surface::Event,
-        udata: &XdgSurfaceData<D>,
-        conn: &Connection,
-        qh: &QueueHandle<D>,
-    ) {
-        match event {
-            xdg_surface::Event::Configure { serial } => {
-                // Ack the configure
-                surface.ack_configure(serial);
-                udata.configure_handler.configure(data, conn, qh, surface, serial);
             }
 
             _ => unreachable!(),


### PR DESCRIPTION
Beta 1 now allows per instance user data, so each xdg surface role should provide a delegate implementation for it's surface and type of data.