### PR TITLE
Simplify PointerHandler

### DIFF
--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -11,7 +11,7 @@ use smithay_client_toolkit::{
     registry_handlers,
     seat::{
         keyboard::{KeyEvent, KeyboardHandler, Modifiers},
-        pointer::{PointerHandler, PointerScroll},
+        pointer::{PointerEvent, PointerEventKind, PointerHandler},
         Capability, SeatHandler, SeatState,
     },
     shell::layer::{
@@ -51,7 +51,6 @@ fn main() {
         keyboard: None,
         keyboard_focus: false,
         pointer: None,
-        pointer_focus: false,
     };
 
     while !simple_layer.registry_state.ready() {
@@ -106,7 +105,6 @@ struct SimpleLayer {
     keyboard: Option<wl_keyboard::WlKeyboard>,
     keyboard_focus: bool,
     pointer: Option<wl_pointer::WlPointer>,
-    pointer_focus: bool,
 }
 
 impl CompositorHandler for SimpleLayer {
@@ -313,94 +311,37 @@ impl KeyboardHandler for SimpleLayer {
 }
 
 impl PointerHandler for SimpleLayer {
-    fn pointer_focus(
+    fn pointer_frame(
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
         _pointer: &wl_pointer::WlPointer,
-        surface: &wl_surface::WlSurface,
-        entered: (f64, f64),
-        _serial: u32,
+        events: &[PointerEvent],
     ) {
-        if self.layer.as_ref().map(LayerSurface::wl_surface) == Some(surface) {
-            println!("Pointer focus on layer, entering at {:?}", entered);
-            self.pointer_focus = true;
-        }
-    }
-
-    fn pointer_release_focus(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _pointer: &wl_pointer::WlPointer,
-        surface: &wl_surface::WlSurface,
-        _serial: u32,
-    ) {
-        if self.layer.as_ref().map(LayerSurface::wl_surface) == Some(surface) {
-            println!("Release pointer focus on layer");
-            self.pointer_focus = false;
-        }
-    }
-
-    fn pointer_motion(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _pointer: &wl_pointer::WlPointer,
-        time: u32,
-        position: (f64, f64),
-    ) {
-        if self.pointer_focus {
-            println!("Pointer motion: {:?} @ {}", position, time);
-        }
-    }
-
-    fn pointer_press_button(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _pointer: &wl_pointer::WlPointer,
-        time: u32,
-        button: u32,
-        _serial: u32,
-    ) {
-        if self.pointer_focus {
-            println!("Pointer press button: {:?} @ {}", button, time);
-            self.shift = self.shift.xor(Some(0));
-        }
-    }
-
-    fn pointer_release_button(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        _pointer: &wl_pointer::WlPointer,
-        time: u32,
-        button: u32,
-        _serial: u32,
-    ) {
-        if self.pointer_focus {
-            println!("Pointer release button: {:?} @ {}", button, time);
-        }
-    }
-
-    fn pointer_axis(
-        &mut self,
-        _: &Connection,
-        _: &QueueHandle<Self>,
-        _: &wl_pointer::WlPointer,
-        time: u32,
-        scroll: PointerScroll,
-    ) {
-        if self.pointer_focus {
-            println!("Pointer scroll: @ {}", time);
-
-            if let Some(vertical) = scroll.axis(wl_pointer::Axis::VerticalScroll) {
-                println!("\nV: {:?}", vertical);
+        use PointerEventKind::*;
+        for event in events {
+            // Ignore events for other surfaces
+            if Some(&event.surface) != self.layer.as_ref().map(LayerSurface::wl_surface) {
+                continue;
             }
-
-            if let Some(horizontal) = scroll.axis(wl_pointer::Axis::HorizontalScroll) {
-                println!("\nH: {:?}", horizontal);
+            match event.kind {
+                Enter { .. } => {
+                    println!("Pointer entered @{:?}", event.position);
+                }
+                Leave { .. } => {
+                    println!("Pointer left");
+                }
+                Motion { .. } => {}
+                Press { button, .. } => {
+                    println!("Press {:x} @ {:?}", button, event.position);
+                    self.shift = self.shift.xor(Some(0));
+                }
+                Release { button, .. } => {
+                    println!("Release {:x} @ {:?}", button, event.position);
+                }
+                Axis { horizontal, vertical, .. } => {
+                    println!("Scroll H:{:?}, V:{:?}", horizontal, vertical);
+                }
             }
         }
     }

--- a/src/seat/pointer.rs
+++ b/src/seat/pointer.rs
@@ -8,6 +8,21 @@ use wayland_client::{
 
 use super::{SeatHandler, SeatState};
 
+/* From linux/input-event-codes.h - the buttons usually used by mice */
+pub const BTN_LEFT: u32 = 0x110;
+pub const BTN_RIGHT: u32 = 0x111;
+pub const BTN_MIDDLE: u32 = 0x112;
+/// The fourth non-scroll button, which is often used as "back" in web browsers.
+pub const BTN_SIDE: u32 = 0x113;
+/// The fifth non-scroll button, which is often used as "forward" in web browsers.
+pub const BTN_EXTRA: u32 = 0x114;
+
+/// See also [`BTN_EXTRA`].
+pub const BTN_FORWARD: u32 = 0x115;
+/// See also [`BTN_SIDE`].
+pub const BTN_BACK: u32 = 0x116;
+pub const BTN_TASK: u32 = 0x117;
+
 /// Describes a scroll along one axis
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct AxisScroll {

--- a/src/seat/pointer.rs
+++ b/src/seat/pointer.rs
@@ -1,4 +1,5 @@
-use std::sync::Mutex;
+use std::{mem, sync::Mutex};
+use wayland_backend::smallvec::SmallVec;
 
 use wayland_client::{
     protocol::{wl_pointer, wl_surface},
@@ -7,124 +8,87 @@ use wayland_client::{
 
 use super::{SeatHandler, SeatState};
 
-/// Describes a kind of pointer axis event.
-#[derive(Debug, Clone, Copy)]
-pub enum AxisKind {
-    /// The axis scrolling is in an absolute number of pixels.
-    Absolute(f64),
+/// Describes a scroll along one axis
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct AxisScroll {
+    /// The scroll measured in pixels.
+    pub absolute: f64,
 
-    /// The axis scrolling is in discrete units of lines or columns.
-    Discrete(i32),
-
-    /// The axis scrolling was stopped.
+    /// The scroll measured in steps.
     ///
-    /// Generally this variant is encountered when hardware indicates the end of some continuous scrolling.
-    Stop,
+    /// Note: this might always be zero if the scrolling is due to a touchpad or other continuous
+    /// source.
+    pub discrete: i32,
+
+    /// The scroll was stopped.
+    ///
+    /// Generally this is encountered when hardware indicates the end of some continuous scrolling.
+    pub stop: bool,
 }
 
-/// A type representing a scroll event.
-///
-/// A scroll event may consist of a vertical and horizontal component.
-#[derive(Debug)]
-pub struct PointerScroll {
-    horizontal: Option<AxisKind>,
-    vertical: Option<AxisKind>,
-    source: Option<wl_pointer::AxisSource>,
+impl AxisScroll {
+    /// Returns true if there was no movement along this axis.
+    pub fn is_none(&self) -> bool {
+        *self == Self::default()
+    }
+
+    fn merge(&mut self, other: &Self) {
+        self.absolute += other.absolute;
+        self.discrete += other.discrete;
+        self.stop |= other.stop;
+    }
 }
 
-impl PointerScroll {
-    pub fn axis(&self, axis: wl_pointer::Axis) -> Option<AxisKind> {
-        match axis {
-            wl_pointer::Axis::VerticalScroll => self.vertical,
-            wl_pointer::Axis::HorizontalScroll => self.horizontal,
+/// A single pointer event.
+#[derive(Debug, Clone)]
+pub struct PointerEvent {
+    pub surface: wl_surface::WlSurface,
+    pub position: (f64, f64),
+    pub kind: PointerEventKind,
+}
 
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn source(&self) -> Option<wl_pointer::AxisSource> {
-        self.source
-    }
-
-    pub fn has_axis(&self, axis: wl_pointer::Axis) -> bool {
-        match axis {
-            wl_pointer::Axis::VerticalScroll => self.vertical.is_some(),
-            wl_pointer::Axis::HorizontalScroll => self.horizontal.is_some(),
-
-            _ => unreachable!(),
-        }
-    }
+#[derive(Debug, Clone)]
+pub enum PointerEventKind {
+    Enter {
+        serial: u32,
+    },
+    Leave {
+        serial: u32,
+    },
+    Motion {
+        time: u32,
+    },
+    Press {
+        time: u32,
+        button: u32,
+        serial: u32,
+    },
+    Release {
+        time: u32,
+        button: u32,
+        serial: u32,
+    },
+    Axis {
+        time: u32,
+        horizontal: AxisScroll,
+        vertical: AxisScroll,
+        source: Option<wl_pointer::AxisSource>,
+    },
 }
 
 pub trait PointerHandler: SeatHandler + Sized {
-    /// The pointer focus is set to a surface.
+    /// One or more pointer events are available.
     ///
-    /// The `entered` parameter are the surface local coordinates from the top left corner where the cursor
-    /// has entered.
+    /// Multiple related events may be grouped together in a single frame.  Some examples:
     ///
-    /// The pos
-    fn pointer_focus(
+    /// - A drag that terminates outside the surface may send the Release and Leave events as one frame
+    /// - Movement from one surface to another may send the Enter and Leave events in one frame
+    fn pointer_frame(
         &mut self,
         conn: &Connection,
         qh: &QueueHandle<Self>,
         pointer: &wl_pointer::WlPointer,
-        surface: &wl_surface::WlSurface,
-        entered: (f64, f64),
-        serial: u32,
-    );
-
-    /// The pointer focus is released from the surface.
-    fn pointer_release_focus(
-        &mut self,
-        conn: &Connection,
-        qh: &QueueHandle<Self>,
-        pointer: &wl_pointer::WlPointer,
-        surface: &wl_surface::WlSurface,
-        serial: u32,
-    );
-
-    /// The pointer has moved.
-    ///
-    /// The position is in surface relative coordinates.
-    fn pointer_motion(
-        &mut self,
-        conn: &Connection,
-        qh: &QueueHandle<Self>,
-        pointer: &wl_pointer::WlPointer,
-        time: u32,
-        position: (f64, f64),
-    );
-
-    /// A pointer button is pressed.
-    fn pointer_press_button(
-        &mut self,
-        conn: &Connection,
-        qh: &QueueHandle<Self>,
-        pointer: &wl_pointer::WlPointer,
-        time: u32,
-        button: u32,
-        serial: u32,
-    );
-
-    /// A pointer button is released.
-    fn pointer_release_button(
-        &mut self,
-        conn: &Connection,
-        qh: &QueueHandle<Self>,
-        pointer: &wl_pointer::WlPointer,
-        time: u32,
-        button: u32,
-        serial: u32,
-    );
-
-    /// A pointer's axis has scrolled.
-    fn pointer_axis(
-        &mut self,
-        conn: &Connection,
-        qh: &QueueHandle<Self>,
-        pointer: &wl_pointer::WlPointer,
-        time: u32,
-        scroll: PointerScroll,
+        events: &[PointerEvent],
     );
 }
 
@@ -146,35 +110,13 @@ macro_rules! delegate_pointer {
 
 #[derive(Debug, Default)]
 pub(crate) struct PointerDataInner {
-    /// Pending axis event.
-    axis: Option<Axis>,
-    /// Pending motion event.
-    motion: Option<Motion>,
-    /// Pending button event.
-    button: Option<Button>,
-}
+    /// Surface the pointer most recently entered
+    surface: Option<wl_surface::WlSurface>,
+    /// Position relative to the surface
+    position: (f64, f64),
 
-#[derive(Debug)]
-pub(crate) struct Axis {
-    horizontal: Option<AxisKind>,
-    vertical: Option<AxisKind>,
-    source: Option<wl_pointer::AxisSource>,
-    time: Option<u32>,
-}
-
-#[derive(Debug)]
-pub(crate) struct Motion {
-    x: f64,
-    y: f64,
-    time: u32,
-}
-
-#[derive(Debug)]
-pub(crate) struct Button {
-    time: u32,
-    state: wl_pointer::ButtonState,
-    button: u32,
-    serial: u32,
+    /// List of pending events.  Only used for version >= 5.
+    pending: SmallVec<[PointerEvent; 3]>,
 }
 
 impl<D> DelegateDispatch<wl_pointer::WlPointer, PointerData, D> for SeatState
@@ -189,272 +131,177 @@ where
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        match event {
+        let mut guard = udata.inner.lock().unwrap();
+        let mut leave_surface = None;
+        let kind = match event {
             wl_pointer::Event::Enter { surface, surface_x, surface_y, serial } => {
-                data.pointer_focus(conn, qh, pointer, &surface, (surface_x, surface_y), serial);
+                guard.surface = Some(surface);
+                guard.position = (surface_x, surface_y);
+
+                PointerEventKind::Enter { serial }
             }
 
             wl_pointer::Event::Leave { surface, serial } => {
-                data.pointer_release_focus(conn, qh, pointer, &surface, serial);
+                if guard.surface.as_ref() == Some(&surface) {
+                    guard.surface = None;
+                }
+                leave_surface = Some(surface);
+
+                PointerEventKind::Leave { serial }
             }
 
-            /*
-            Pointer events
-
-            The wl_pointer protocol starting in version 5 requires the following of clients:
-            > A client is expected to accumulate the data in all events within the frame before proceeding.
-
-            If the protocol version is 5 or greater, each of these events will accumulate state until a frame
-            event.
-            */
             wl_pointer::Event::Motion { time, surface_x, surface_y } => {
-                if pointer.version() < 5 {
-                    data.pointer_motion(conn, qh, pointer, time, (surface_x, surface_y));
-                } else {
-                    let mut guard = udata.inner.lock().unwrap();
-                    guard.motion = Some(Motion { x: surface_x, y: surface_y, time });
-                }
+                guard.position = (surface_x, surface_y);
+
+                PointerEventKind::Motion { time }
             }
 
             wl_pointer::Event::Button { time, button, state, serial } => match state {
-                WEnum::Value(state) => {
-                    if pointer.version() < 5 {
-                        match state {
-                            wl_pointer::ButtonState::Released => {
-                                data.pointer_release_button(conn, qh, pointer, time, button, serial)
-                            }
-                            wl_pointer::ButtonState::Pressed => {
-                                data.pointer_press_button(conn, qh, pointer, time, button, serial)
-                            }
-
-                            _ => unreachable!(),
-                        }
-                    } else {
-                        let mut guard = udata.inner.lock().unwrap();
-                        guard.button = Some(Button { time, state, button, serial });
-                    }
+                WEnum::Value(wl_pointer::ButtonState::Pressed) => {
+                    PointerEventKind::Press { time, button, serial }
                 }
-
+                WEnum::Value(wl_pointer::ButtonState::Released) => {
+                    PointerEventKind::Release { time, button, serial }
+                }
                 WEnum::Unknown(unknown) => {
-                    log::warn!(target: "sctk", "{}: invalid pointer button state: {:x}", pointer.id(), unknown)
+                    log::warn!(target: "sctk", "{}: invalid pointer button state: {:x}", pointer.id(), unknown);
+                    return;
                 }
+                _ => unreachable!(),
             },
 
             // Axis logical events.
-            wl_pointer::Event::Axis { time, axis, value } => {
-                match axis {
-                    WEnum::Value(axis) => {
-                        let (horizontal, vertical) = match axis {
-                            wl_pointer::Axis::VerticalScroll => {
-                                (None, Some(AxisKind::Absolute(value)))
-                            }
-                            wl_pointer::Axis::HorizontalScroll => {
-                                (Some(AxisKind::Absolute(value)), None)
-                            }
-
-                            _ => unreachable!(),
-                        };
-
-                        // Old seats must emit two events, one for each axis.
-                        if pointer.version() < 5 {
-                            let scroll = PointerScroll {
-                                horizontal,
-                                vertical,
-                                // A source cannot exist below version 5.
-                                source: None,
-                            };
-
-                            data.pointer_axis(conn, qh, pointer, time, scroll);
-                        } else {
-                            // Starting in version 5, we must wait for a `frame` event before invoking the
-                            // handler trait functions.
-
-                            let mut guard = udata.inner.lock().unwrap();
-
-                            if let Some(pending_axis) = guard.axis.as_mut() {
-                                // Set time if it is not set yet.
-                                // The time is `None` beforehand if some other axis event started the frame.
-                                pending_axis.time.get_or_insert(time);
-                            }
-
-                            // Add absolute axis events to the pending frame.
-                            let axis = guard.axis.get_or_insert(Axis {
-                                horizontal,
-                                vertical,
-                                source: None,
-                                time: Some(time),
-                            });
-
-                            if let Some(horizontal) = horizontal {
-                                axis.horizontal.get_or_insert(horizontal);
-                            }
-
-                            if let Some(vertical) = vertical {
-                                axis.vertical.get_or_insert(vertical);
-                            }
-                        }
-                    }
-
-                    WEnum::Unknown(unknown) => {
-                        log::warn!(target: "sctk", "{}: invalid pointer axis: {:x}", pointer.id(), unknown)
-                    }
-                }
-            }
-
-            // Introduced in version 5
-            wl_pointer::Event::AxisSource { axis_source } => match axis_source {
-                WEnum::Value(source) => {
-                    let mut guard = udata.inner.lock().unwrap();
-
-                    let axis = guard.axis.get_or_insert(Axis {
-                        horizontal: None,
-                        vertical: None,
-                        source: Some(source),
-                        time: None,
-                    });
-
-                    axis.source.get_or_insert(source);
-                }
-
-                WEnum::Unknown(unknown) => {
-                    log::warn!(target: "sctk", "unknown pointer axis source: {:x}", unknown);
-                }
-            },
-
-            // Introduced in version 5
-            wl_pointer::Event::AxisStop { time, axis } => match axis {
+            wl_pointer::Event::Axis { time, axis, value } => match axis {
                 WEnum::Value(axis) => {
-                    let mut guard = udata.inner.lock().unwrap();
-
-                    if let Some(pending_axis) = guard.axis.as_mut() {
-                        // Set time if it is not set yet.
-                        // The time is `None` beforehand if some other axis event started the frame.
-                        pending_axis.time.get_or_insert(time);
-                    }
-
-                    let (horizontal, vertical) = match axis {
-                        wl_pointer::Axis::VerticalScroll => (None, Some(AxisKind::Stop)),
-
-                        wl_pointer::Axis::HorizontalScroll => (Some(AxisKind::Stop), None),
-
+                    let (mut horizontal, mut vertical) = <(AxisScroll, AxisScroll)>::default();
+                    match axis {
+                        wl_pointer::Axis::VerticalScroll => {
+                            vertical.absolute = value;
+                        }
+                        wl_pointer::Axis::HorizontalScroll => {
+                            horizontal.absolute = value;
+                        }
                         _ => unreachable!(),
                     };
 
-                    let axis = guard.axis.get_or_insert(Axis {
-                        horizontal,
-                        vertical,
-                        source: None,
-                        time: Some(time),
-                    });
+                    PointerEventKind::Axis { time, horizontal, vertical, source: None }
+                }
+                WEnum::Unknown(unknown) => {
+                    log::warn!(target: "sctk", "{}: invalid pointer axis: {:x}", pointer.id(), unknown);
+                    return;
+                }
+            },
 
-                    if let Some(horizontal) = horizontal {
-                        axis.horizontal.get_or_insert(horizontal);
+            wl_pointer::Event::AxisSource { axis_source } => match axis_source {
+                WEnum::Value(source) => PointerEventKind::Axis {
+                    horizontal: AxisScroll::default(),
+                    vertical: AxisScroll::default(),
+                    source: Some(source),
+                    time: 0,
+                },
+                WEnum::Unknown(unknown) => {
+                    log::warn!(target: "sctk", "unknown pointer axis source: {:x}", unknown);
+                    return;
+                }
+            },
+
+            wl_pointer::Event::AxisStop { time, axis } => match axis {
+                WEnum::Value(axis) => {
+                    let (mut horizontal, mut vertical) = <(AxisScroll, AxisScroll)>::default();
+                    match axis {
+                        wl_pointer::Axis::VerticalScroll => vertical.stop = true,
+                        wl_pointer::Axis::HorizontalScroll => horizontal.stop = true,
+
+                        _ => unreachable!(),
                     }
 
-                    if let Some(vertical) = vertical {
-                        axis.vertical.get_or_insert(vertical);
-                    }
+                    PointerEventKind::Axis { time, horizontal, vertical, source: None }
                 }
 
                 WEnum::Unknown(unknown) => {
                     log::warn!(target: "sctk", "{}: invalid pointer axis: {:x}", pointer.id(), unknown);
+                    return;
                 }
             },
 
-            // Introduced in version 5
             wl_pointer::Event::AxisDiscrete { axis, discrete } => match axis {
                 WEnum::Value(axis) => {
-                    let mut guard = udata.inner.lock().unwrap();
-
-                    let (horizontal, vertical) = match axis {
+                    let (mut horizontal, mut vertical) = <(AxisScroll, AxisScroll)>::default();
+                    match axis {
                         wl_pointer::Axis::VerticalScroll => {
-                            (None, Some(AxisKind::Discrete(discrete)))
+                            vertical.discrete = discrete;
                         }
 
                         wl_pointer::Axis::HorizontalScroll => {
-                            (Some(AxisKind::Discrete(discrete)), None)
+                            horizontal.discrete = discrete;
                         }
 
                         _ => unreachable!(),
                     };
 
-                    let axis = guard.axis.get_or_insert(Axis {
-                        horizontal,
-                        vertical,
-                        source: None,
-                        time: None,
-                    });
-
-                    if let Some(horizontal) = horizontal {
-                        axis.horizontal.get_or_insert(horizontal);
-                    }
-
-                    if let Some(vertical) = vertical {
-                        axis.vertical.get_or_insert(vertical);
-                    }
+                    PointerEventKind::Axis { time: 0, horizontal, vertical, source: None }
                 }
 
                 WEnum::Unknown(unknown) => {
                     log::warn!(target: "sctk", "{}: invalid pointer axis: {:x}", pointer.id(), unknown);
+                    return;
                 }
             },
 
             wl_pointer::Event::Frame => {
-                // `frame` is essentially an atomic signal that all events have been received.
-                let mut guard = udata.inner.lock().unwrap();
-                // The protocol says only one of each "logical event group" will correspond to a frame.
-                // However, compositor implementations are not all that consistent so let's be flexible.
-                let axis = guard.axis.take();
-                let motion = guard.motion.take();
-                let button = guard.button.take();
-
+                let pending = mem::take(&mut guard.pending);
                 drop(guard);
-
-                if let Some(axis) = axis {
-                    let scroll = PointerScroll {
-                        horizontal: axis.horizontal,
-                        vertical: axis.vertical,
-                        source: axis.source,
-                    };
-
-                    // If time isn't set for some reason, just pass 0.
-                    data.pointer_axis(conn, qh, pointer, axis.time.unwrap_or(0), scroll);
+                if !pending.is_empty() {
+                    data.pointer_frame(conn, qh, pointer, &pending);
                 }
-
-                if let Some(motion) = motion {
-                    data.pointer_motion(conn, qh, pointer, motion.time, (motion.x, motion.y));
-                }
-
-                if let Some(button) = button {
-                    match button.state {
-                        wl_pointer::ButtonState::Released => {
-                            data.pointer_release_button(
-                                conn,
-                                qh,
-                                pointer,
-                                button.time,
-                                button.button,
-                                button.serial,
-                            );
-                        }
-
-                        wl_pointer::ButtonState::Pressed => {
-                            data.pointer_press_button(
-                                conn,
-                                qh,
-                                pointer,
-                                button.time,
-                                button.button,
-                                button.serial,
-                            );
-                        }
-
-                        _ => unreachable!(),
-                    }
-                }
+                return;
             }
 
             _ => unreachable!(),
+        };
+
+        let surface = match (leave_surface, &guard.surface) {
+            (Some(surface), _) => surface,
+            (None, Some(surface)) => surface.clone(),
+            (None, None) => {
+                log::warn!(target: "sctk", "{}: got pointer event {:?} without an entered surface", pointer.id(), kind);
+                return;
+            }
+        };
+
+        let event = PointerEvent { surface, position: guard.position, kind };
+
+        if pointer.version() < 5 {
+            drop(guard);
+            // No Frame events, send right away
+            data.pointer_frame(conn, qh, pointer, &[event]);
+        } else {
+            // Merge a new Axis event with the previous event to create an event with more
+            // information and potentially diagonal scrolling.
+            if let (
+                Some(PointerEvent {
+                    kind:
+                        PointerEventKind::Axis { time: ot, horizontal: oh, vertical: ov, source: os },
+                    ..
+                }),
+                PointerEvent {
+                    kind:
+                        PointerEventKind::Axis { time: nt, horizontal: nh, vertical: nv, source: ns },
+                    ..
+                },
+            ) = (guard.pending.last_mut(), &event)
+            {
+                // A time of 0 is "don't know", so avoid using it if possible.
+                if *ot == 0 {
+                    *ot = *nt;
+                }
+                oh.merge(nh);
+                ov.merge(nv);
+                *os = os.or(*ns);
+                return;
+            }
+
+            guard.pending.push(event);
         }
     }
 }


### PR DESCRIPTION
This exposes all the events in a pointer frame in one user callback instead of making them distinct function calls.  It also provides tracking of the active surface and pointer position for all events, which is useful for button press/release.

Axis (scroll) events now correctly report both discrete and absolute distances, instead of just the first of the two that was reported.