### PR TITLE
Add ProvidesBoundGlobal trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ['1.53.0', 'stable', 'beta']
+        rust: ['1.61.0', 'stable', 'beta']
 
     runs-on: ubuntu-latest
 

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -1,5 +1,3 @@
-extern crate image;
-
 use std::env;
 
 use smithay_client_toolkit::{

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -10,6 +10,7 @@ use wayland_client::{
 
 use crate::{
     error::GlobalError,
+    globals::ProvidesBoundGlobal,
     output::OutputData,
     registry::{GlobalProxy, ProvidesRegistryState, RegistryHandler},
 };
@@ -241,6 +242,12 @@ where
         _: &QueueHandle<D>,
     ) {
         unreachable!("wl_compositor has no events")
+    }
+}
+
+impl ProvidesBoundGlobal<wl_compositor::WlCompositor, 5> for CompositorState {
+    fn bound_global(&self) -> Result<wl_compositor::WlCompositor, GlobalError> {
+        self.wl_compositor().cloned()
     }
 }
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -166,6 +166,12 @@ impl Surface {
     }
 }
 
+impl From<wl_surface::WlSurface> for Surface {
+    fn from(surface: wl_surface::WlSurface) -> Self {
+        Surface(surface)
+    }
+}
+
 impl Drop for Surface {
     fn drop(&mut self) {
         self.0.destroy();

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -45,3 +45,9 @@ pub trait ProvidesBoundGlobal<I: Proxy, const API_COMPAT_VERSION: u32> {
         }
     }
 }
+
+/// A struct used as the UserData field for globals bound by SCTK.
+///
+/// This is used instead of `()` to allow multiple `Dispatch` impls on the same object.
+#[derive(Debug)]
+pub struct GlobalData(pub(crate) ());

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -1,0 +1,47 @@
+use crate::error::GlobalError;
+use wayland_client::Proxy;
+
+/// A trait implemented by types that provide access to capability globals.
+///
+/// The returned global must be fully compatible with the provided `API_COMPAT_VERSION` generic
+/// argument.  For example:
+///
+/// - A global that binds to `wl_compositor` with maximum version 4 could implement
+/// `ProvidesBoundGlobal<WlCompositor, 4>`, `ProvidesBoundGlobal<WlCompositor, 3>`,
+/// `ProvidesBoundGlobal<WlCompositor, 2>`, and `ProvidesBoundGlobal<WlCompositor, 1>` because
+/// versions 2-4 only add additional requests to the `wl_surface` API.
+/// - A global that binds to `wl_compositor` with maximum version 5 may only implement
+/// `ProvidesBoundGlobal<WlCompositor, 5>` because version 5 makes using `wl_surface::attach` with
+/// a nonzero offset a protocol error.  A caller who is only aware of the version 4 API risks
+/// causing these protocol errors if it uses surfaces created by such a global.
+///
+/// Changes that cause compatibility breaks include:
+///
+/// - Adding a new event to the global or to any object created by the global.
+/// - Adding a new requirement to an existing request.
+///
+/// The resulting global may have a version lower than `API_COMPAT_VERSION` if, at runtime, the
+/// compositor does not support the new version.  Clients should either be prepared to handle
+/// earlier versions of the protocol or use [`ProvidesBoundGlobal::with_min_version`] to produce an
+/// error in this case.
+///
+/// It is permitted to implement `ProvidesBoundGlobal` for versions that are higher than the
+/// maximum version you bind.  When rustc gains the ability to constrain const parameters with
+/// integer bounds (`where API_COMPAT_VERSION >= 5`), implementations of this trait should be
+/// provided by specifying a lower bound for the compat version in order to avoid requiring version
+/// updates be done in lock-step.
+pub trait ProvidesBoundGlobal<I: Proxy, const API_COMPAT_VERSION: u32> {
+    fn bound_global(&self) -> Result<I, GlobalError>;
+    fn with_min_version(&self, version: u32) -> Result<I, GlobalError> {
+        let proxy = self.bound_global()?;
+        if proxy.version() < version {
+            Err(GlobalError::InvalidVersion {
+                name: I::interface().name,
+                required: version,
+                available: proxy.version(),
+            })
+        } else {
+            Ok(proxy)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod compositor;
 pub mod error;
 #[cfg(feature = "calloop")]
 pub mod event_loop;
+pub mod globals;
 pub mod output;
 pub mod registry;
 pub mod seat;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -68,7 +68,7 @@
 //! }
 //! ```
 
-use crate::error::GlobalError;
+use crate::{error::GlobalError, globals::ProvidesBoundGlobal};
 use wayland_client::{
     backend::InvalidId,
     protocol::{wl_callback, wl_registry},
@@ -505,6 +505,62 @@ impl<I: Proxy> GlobalProxy<I> {
             GlobalProxy::NotReady => Err(GlobalError::NotReady),
         }
     }
+}
+
+#[derive(Debug)]
+pub struct SimpleGlobal<I, const MAX_VERSION: u32> {
+    proxy: GlobalProxy<I>,
+}
+
+impl<I: Proxy, const MAX_VERSION: u32> SimpleGlobal<I, MAX_VERSION> {
+    pub fn new() -> Self {
+        Self { proxy: GlobalProxy::NotReady }
+    }
+
+    pub fn get(&self) -> Result<&I, GlobalError> {
+        self.proxy.get()
+    }
+
+    pub fn with_min_version(&self, min_version: u32) -> Result<&I, GlobalError> {
+        self.proxy.with_min_version(min_version)
+    }
+}
+
+impl<I: Proxy + Clone, const MAX_VERSION: u32> ProvidesBoundGlobal<I, MAX_VERSION>
+    for SimpleGlobal<I, MAX_VERSION>
+{
+    fn bound_global(&self) -> Result<I, GlobalError> {
+        self.proxy.get().cloned()
+    }
+}
+
+impl<D, I, const MAX_VERSION: u32> RegistryHandler<D> for SimpleGlobal<I, MAX_VERSION>
+where
+    D: ProvidesRegistryState + AsMut<Self> + Dispatch<I, ()> + 'static,
+    I: Proxy + 'static,
+{
+    fn ready(data: &mut D, _: &Connection, qh: &QueueHandle<D>) {
+        data.as_mut().proxy = data.registry().bind_one(qh, 0..=MAX_VERSION, ()).into();
+    }
+}
+
+impl<D, I, const MAX_VERSION: u32> DelegateDispatch<I, (), D> for SimpleGlobal<I, MAX_VERSION>
+where
+    D: Dispatch<I, ()>,
+    I: Proxy,
+{
+    fn event(_: &mut D, _: &I, _: <I as Proxy>::Event, _: &(), _: &Connection, _: &QueueHandle<D>) {
+        unreachable!("SimpleGlobal is not suitable for {} which has events", I::interface().name);
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_simple {
+    ($ty:ty, $iface:ty, $max:expr) => {
+        $crate::reexports::client::delegate_dispatch!($ty: [ $iface: () ]
+            => $crate::registry::SimpleGlobal<$iface, $max>
+        );
+    };
 }
 
 /// A helper macro for implementing [`ProvidesRegistryState`].

--- a/src/shell/layer/dispatch.rs
+++ b/src/shell/layer/dispatch.rs
@@ -1,7 +1,11 @@
 use wayland_client::{Connection, DelegateDispatch, Dispatch, QueueHandle};
 use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
 
-use crate::registry::{ProvidesRegistryState, RegistryHandler};
+use crate::{
+    error::GlobalError,
+    globals::ProvidesBoundGlobal,
+    registry::{ProvidesRegistryState, RegistryHandler},
+};
 
 use super::{LayerHandler, LayerState, LayerSurfaceConfigure, LayerSurfaceData};
 
@@ -14,6 +18,32 @@ where
 {
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
         data.layer_state().wlr_layer_shell = data.registry().bind_one(qh, 1..=4, ()).into();
+    }
+}
+
+// Layer shell has only added requests and enum variants in versions 2-4, so its client-facing API
+// is still compatible.
+impl ProvidesBoundGlobal<zwlr_layer_shell_v1::ZwlrLayerShellV1, 1> for LayerState {
+    fn bound_global(&self) -> Result<zwlr_layer_shell_v1::ZwlrLayerShellV1, GlobalError> {
+        self.wlr_layer_shell.get().cloned()
+    }
+}
+
+impl ProvidesBoundGlobal<zwlr_layer_shell_v1::ZwlrLayerShellV1, 2> for LayerState {
+    fn bound_global(&self) -> Result<zwlr_layer_shell_v1::ZwlrLayerShellV1, GlobalError> {
+        self.wlr_layer_shell.get().cloned()
+    }
+}
+
+impl ProvidesBoundGlobal<zwlr_layer_shell_v1::ZwlrLayerShellV1, 3> for LayerState {
+    fn bound_global(&self) -> Result<zwlr_layer_shell_v1::ZwlrLayerShellV1, GlobalError> {
+        self.wlr_layer_shell.get().cloned()
+    }
+}
+
+impl ProvidesBoundGlobal<zwlr_layer_shell_v1::ZwlrLayerShellV1, 4> for LayerState {
+    fn bound_global(&self) -> Result<zwlr_layer_shell_v1::ZwlrLayerShellV1, GlobalError> {
+        self.wlr_layer_shell.get().cloned()
     }
 }
 

--- a/src/shell/layer/dispatch.rs
+++ b/src/shell/layer/dispatch.rs
@@ -3,7 +3,7 @@ use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_l
 
 use crate::{
     error::GlobalError,
-    globals::ProvidesBoundGlobal,
+    globals::{GlobalData, ProvidesBoundGlobal},
     registry::{ProvidesRegistryState, RegistryHandler},
 };
 
@@ -11,13 +11,14 @@ use super::{LayerHandler, LayerState, LayerSurfaceConfigure, LayerSurfaceData};
 
 impl<D> RegistryHandler<D> for LayerState
 where
-    D: Dispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, ()>
+    D: Dispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, GlobalData>
         + LayerHandler
         + ProvidesRegistryState
         + 'static,
 {
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
-        data.layer_state().wlr_layer_shell = data.registry().bind_one(qh, 1..=4, ()).into();
+        data.layer_state().wlr_layer_shell =
+            data.registry().bind_one(qh, 1..=4, GlobalData(())).into();
     }
 }
 
@@ -47,15 +48,15 @@ impl ProvidesBoundGlobal<zwlr_layer_shell_v1::ZwlrLayerShellV1, 4> for LayerStat
     }
 }
 
-impl<D> DelegateDispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, (), D> for LayerState
+impl<D> DelegateDispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, GlobalData, D> for LayerState
 where
-    D: Dispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, ()> + LayerHandler + 'static,
+    D: Dispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, GlobalData> + LayerHandler + 'static,
 {
     fn event(
         _: &mut D,
         _: &zwlr_layer_shell_v1::ZwlrLayerShellV1,
         _: zwlr_layer_shell_v1::Event,
-        _: &(),
+        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {

--- a/src/shell/layer/mod.rs
+++ b/src/shell/layer/mod.rs
@@ -373,7 +373,7 @@ pub struct LayerSurfaceData {
 macro_rules! delegate_layer {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty: [
-            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1: (),
+            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1: $crate::globals::GlobalData,
             $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1: $crate::shell::layer::LayerSurfaceData,
         ] => $crate::shell::layer::LayerState);
     };

--- a/src/shell/xdg/inner.rs
+++ b/src/shell/xdg/inner.rs
@@ -1,7 +1,11 @@
 use wayland_client::{Connection, DelegateDispatch, Dispatch, QueueHandle};
 use wayland_protocols::xdg::shell::client::xdg_wm_base;
 
-use crate::registry::{ProvidesRegistryState, RegistryHandler};
+use crate::{
+    error::GlobalError,
+    globals::ProvidesBoundGlobal,
+    registry::{ProvidesRegistryState, RegistryHandler},
+};
 
 use super::{XdgShellHandler, XdgShellState};
 
@@ -11,6 +15,13 @@ where
 {
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
         data.xdg_shell_state().xdg_wm_base = data.registry().bind_one(qh, 1..=4, ()).into();
+    }
+}
+
+// Version 4 adds the configure_bounds event, which is a break
+impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4> for XdgShellState {
+    fn bound_global(&self) -> Result<xdg_wm_base::XdgWmBase, GlobalError> {
+        self.xdg_wm_base.get().cloned()
     }
 }
 

--- a/src/shell/xdg/inner.rs
+++ b/src/shell/xdg/inner.rs
@@ -3,7 +3,7 @@ use wayland_protocols::xdg::shell::client::xdg_wm_base;
 
 use crate::{
     error::GlobalError,
-    globals::ProvidesBoundGlobal,
+    globals::{GlobalData, ProvidesBoundGlobal},
     registry::{ProvidesRegistryState, RegistryHandler},
 };
 
@@ -11,10 +11,14 @@ use super::{XdgShellHandler, XdgShellState};
 
 impl<D> RegistryHandler<D> for XdgShellState
 where
-    D: Dispatch<xdg_wm_base::XdgWmBase, ()> + XdgShellHandler + ProvidesRegistryState + 'static,
+    D: Dispatch<xdg_wm_base::XdgWmBase, GlobalData>
+        + XdgShellHandler
+        + ProvidesRegistryState
+        + 'static,
 {
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
-        data.xdg_shell_state().xdg_wm_base = data.registry().bind_one(qh, 1..=4, ()).into();
+        data.xdg_shell_state().xdg_wm_base =
+            data.registry().bind_one(qh, 1..=4, GlobalData(())).into();
     }
 }
 
@@ -27,15 +31,15 @@ impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4> for XdgShellState {
 
 /* Delegate trait impls */
 
-impl<D> DelegateDispatch<xdg_wm_base::XdgWmBase, (), D> for XdgShellState
+impl<D> DelegateDispatch<xdg_wm_base::XdgWmBase, GlobalData, D> for XdgShellState
 where
-    D: Dispatch<xdg_wm_base::XdgWmBase, ()> + XdgShellHandler,
+    D: Dispatch<xdg_wm_base::XdgWmBase, GlobalData> + XdgShellHandler,
 {
     fn event(
         _: &mut D,
         xdg_wm_base: &xdg_wm_base::XdgWmBase,
         event: xdg_wm_base::Event,
-        _: &(),
+        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -133,7 +133,7 @@ pub trait XdgShellHandler: Sized {
 macro_rules! delegate_xdg_shell {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty: [
-            $crate::reexports::protocols::xdg::shell::client::xdg_wm_base::XdgWmBase: (),
+            $crate::reexports::protocols::xdg::shell::client::xdg_wm_base::XdgWmBase: $crate::globals::GlobalData,
         ] => $crate::shell::xdg::XdgShellState);
     };
 }

--- a/src/shell/xdg/window/inner.rs
+++ b/src/shell/xdg/window/inner.rs
@@ -15,13 +15,12 @@ use wayland_protocols::{
     xdg::shell::client::{
         xdg_surface,
         xdg_toplevel::{self, State},
-        xdg_wm_base,
     },
 };
 
 use crate::{
     error::GlobalError,
-    globals::ProvidesBoundGlobal,
+    globals::{GlobalData, ProvidesBoundGlobal},
     registry::{ProvidesRegistryState, RegistryHandler},
     shell::xdg::XdgShellSurface,
 };
@@ -117,8 +116,7 @@ const DECORATION_MANAGER_VERSION: u32 = 1;
 
 impl<D> RegistryHandler<D> for XdgWindowState
 where
-    D: Dispatch<xdg_wm_base::XdgWmBase, ()>
-        + Dispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, ()>
+    D: Dispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, GlobalData>
         // Lateinit for decorations
         + Dispatch<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1, WindowData>
         + WindowHandler
@@ -127,7 +125,7 @@ where
 {
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
         data.xdg_window_state().xdg_decoration_manager =
-            data.registry().bind_one(qh, 1..=DECORATION_MANAGER_VERSION, ()).into();
+            data.registry().bind_one(qh, 1..=DECORATION_MANAGER_VERSION, GlobalData(())).into();
     }
 }
 
@@ -231,16 +229,16 @@ where
 
 // XDG decoration
 
-impl<D> DelegateDispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, (), D>
+impl<D> DelegateDispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, GlobalData, D>
     for XdgWindowState
 where
-    D: Dispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, ()> + WindowHandler,
+    D: Dispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, GlobalData> + WindowHandler,
 {
     fn event(
         _: &mut D,
         _: &zxdg_decoration_manager_v1::ZxdgDecorationManagerV1,
         _: zxdg_decoration_manager_v1::Event,
-        _: &(),
+        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {

--- a/src/shell/xdg/window/inner.rs
+++ b/src/shell/xdg/window/inner.rs
@@ -20,6 +20,8 @@ use wayland_protocols::{
 };
 
 use crate::{
+    error::GlobalError,
+    globals::ProvidesBoundGlobal,
     registry::{ProvidesRegistryState, RegistryHandler},
     shell::xdg::XdgShellSurface,
 };
@@ -126,6 +128,16 @@ where
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
         data.xdg_window_state().xdg_decoration_manager =
             data.registry().bind_one(qh, 1..=DECORATION_MANAGER_VERSION, ()).into();
+    }
+}
+
+impl ProvidesBoundGlobal<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, 1>
+    for XdgWindowState
+{
+    fn bound_global(
+        &self,
+    ) -> Result<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, GlobalError> {
+        self.xdg_decoration_manager.get().cloned()
     }
 }
 

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -480,7 +480,7 @@ macro_rules! delegate_xdg_window {
         $crate::reexports::client::delegate_dispatch!($ty: [
             $crate::reexports::protocols::xdg::shell::client::xdg_surface::XdgSurface: $crate::shell::xdg::window::WindowData,
             $crate::reexports::protocols::xdg::shell::client::xdg_toplevel::XdgToplevel: $crate::shell::xdg::window::WindowData,
-            $crate::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1: (),
+            $crate::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1: $crate::globals::GlobalData,
             $crate::reexports::protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1: $crate::shell::xdg::window::WindowData,
         ] => $crate::shell::xdg::window::XdgWindowState);
     };

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -16,6 +16,7 @@ use wayland_protocols::{
     },
 };
 
+use crate::compositor::Surface;
 use crate::error::GlobalError;
 use crate::globals::ProvidesBoundGlobal;
 use crate::registry::GlobalProxy;
@@ -262,7 +263,7 @@ impl WindowBuilder {
         qh: &QueueHandle<D>,
         wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4>,
         window_state: &mut XdgWindowState,
-        surface: wl_surface::WlSurface,
+        surface: impl Into<Surface>,
     ) -> Result<Window, GlobalError>
     where
         D: Dispatch<xdg_surface::XdgSurface, WindowData>

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -12,15 +12,17 @@ use wayland_protocols::{
     xdg::shell::client::{
         xdg_surface,
         xdg_toplevel::{self, State},
+        xdg_wm_base,
     },
 };
 
 use crate::error::GlobalError;
+use crate::globals::ProvidesBoundGlobal;
 use crate::registry::GlobalProxy;
 
 use self::inner::{WindowDataInner, WindowInner};
 
-use super::{XdgShellHandler, XdgShellState};
+use super::{XdgShellHandler, XdgShellSurface};
 
 pub(super) mod inner;
 
@@ -258,7 +260,7 @@ impl WindowBuilder {
     pub fn map<D>(
         self,
         qh: &QueueHandle<D>,
-        shell_state: &XdgShellState,
+        wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4>,
         window_state: &mut XdgWindowState,
         surface: wl_surface::WlSurface,
     ) -> Result<Window, GlobalError>
@@ -282,7 +284,7 @@ impl WindowBuilder {
         });
         let window_data = WindowData(data);
 
-        let xdg_surface = shell_state.create_xdg_surface(qh, surface, window_data.clone())?;
+        let xdg_surface = XdgShellSurface::new(wm_base, qh, surface, window_data.clone())?;
 
         let xdg_toplevel = xdg_surface.xdg_surface().get_toplevel(qh, window_data.clone())?;
 

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -6,7 +6,7 @@ use wayland_client::{
 
 use crate::{
     error::GlobalError,
-    globals::ProvidesBoundGlobal,
+    globals::{GlobalData, ProvidesBoundGlobal},
     registry::{GlobalProxy, ProvidesRegistryState, RegistryHandler},
 };
 
@@ -94,21 +94,21 @@ macro_rules! delegate_shm {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty:
             [
-                $crate::reexports::client::protocol::wl_shm::WlShm: (),
+                $crate::reexports::client::protocol::wl_shm::WlShm: $crate::globals::GlobalData,
             ] => $crate::shm::ShmState
         );
     };
 }
 
-impl<D> DelegateDispatch<wl_shm::WlShm, (), D> for ShmState
+impl<D> DelegateDispatch<wl_shm::WlShm, GlobalData, D> for ShmState
 where
-    D: Dispatch<wl_shm::WlShm, ()> + ShmHandler,
+    D: Dispatch<wl_shm::WlShm, GlobalData> + ShmHandler,
 {
     fn event(
         state: &mut D,
         _proxy: &wl_shm::WlShm,
         event: wl_shm::Event,
-        _: &(),
+        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
@@ -134,9 +134,9 @@ where
 
 impl<D> RegistryHandler<D> for ShmState
 where
-    D: Dispatch<wl_shm::WlShm, ()> + ShmHandler + ProvidesRegistryState + 'static,
+    D: Dispatch<wl_shm::WlShm, GlobalData> + ShmHandler + ProvidesRegistryState + 'static,
 {
     fn ready(state: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
-        state.shm_state().wl_shm = state.registry().bind_one(qh, 1..=1, ()).into();
+        state.shm_state().wl_shm = state.registry().bind_one(qh, 1..=1, GlobalData(())).into();
     }
 }

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -24,10 +24,7 @@ pub struct ShmState {
 
 impl From<wl_shm::WlShm> for ShmState {
     fn from(wl_shm: wl_shm::WlShm) -> Self {
-        Self {
-            wl_shm: GlobalProxy::Bound(wl_shm),
-            formats: Vec::new()
-        }
+        Self { wl_shm: GlobalProxy::Bound(wl_shm), formats: Vec::new() }
     }
 }
 

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -6,6 +6,7 @@ use wayland_client::{
 
 use crate::{
     error::GlobalError,
+    globals::ProvidesBoundGlobal,
     registry::{GlobalProxy, ProvidesRegistryState, RegistryHandler},
 };
 
@@ -40,7 +41,7 @@ impl ShmState {
     }
 
     pub fn new_slot_pool(&self, len: usize) -> Result<SlotPool, CreatePoolError> {
-        Ok(SlotPool::new(self.new_raw_pool(len)?))
+        SlotPool::new(len, self)
     }
 
     pub fn new_multi_pool<K>(&self, len: usize) -> Result<MultiPool<K>, CreatePoolError> {
@@ -59,6 +60,12 @@ impl ShmState {
     /// Returns the formats supported in memory pools.
     pub fn formats(&self) -> &[wl_shm::Format] {
         &self.formats[..]
+    }
+}
+
+impl ProvidesBoundGlobal<wl_shm::WlShm, 1> for ShmState {
+    fn bound_global(&self) -> Result<wl_shm::WlShm, GlobalError> {
+        self.wl_shm().cloned()
     }
 }
 


### PR DESCRIPTION
This allows decoupling users of globals from the `*State` types that bind them.