### PR TITLE
Add From implementation to ShmState

### DIFF
--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -21,6 +21,15 @@ pub struct ShmState {
     formats: Vec<wl_shm::Format>,
 }
 
+impl From<wl_shm::WlShm> for ShmState {
+    fn from(wl_shm: wl_shm::WlShm) -> Self {
+        Self {
+            wl_shm: GlobalProxy::Bound(wl_shm),
+            formats: Vec::new()
+        }
+    }
+}
+
 impl ShmState {
     pub fn new() -> ShmState {
         ShmState { wl_shm: GlobalProxy::NotReady, formats: vec![] }


### PR DESCRIPTION
`ShmState` doesn't really need a `Registry` to function or to be created but currently, it's complicated if not impossible to use `ShmState` without the `Registry`.

This PR adds a `From<WlShm>` implementation to `ShmState` so it can be used without a `Registry`. 