### PR TITLE
Make GlobalData fully public

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -388,7 +388,7 @@ where
         + 'static,
 {
     fn ready(state: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
-        let compositor = state.registry().bind_one(qh, 1..=5, GlobalData(()));
+        let compositor = state.registry().bind_one(qh, 1..=5, GlobalData);
 
         state.compositor_state().wl_compositor = compositor.into();
     }

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -50,4 +50,4 @@ pub trait ProvidesBoundGlobal<I: Proxy, const API_COMPAT_VERSION: u32> {
 ///
 /// This is used instead of `()` to allow multiple `Dispatch` impls on the same object.
 #[derive(Debug)]
-pub struct GlobalData(());
+pub struct GlobalData;

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -50,4 +50,4 @@ pub trait ProvidesBoundGlobal<I: Proxy, const API_COMPAT_VERSION: u32> {
 ///
 /// This is used instead of `()` to allow multiple `Dispatch` impls on the same object.
 #[derive(Debug)]
-pub struct GlobalData(pub(crate) ());
+pub struct GlobalData(());

--- a/src/output.rs
+++ b/src/output.rs
@@ -593,7 +593,7 @@ where
 
         // Only bind xdg output manager if it's needed
         let xdg = if outputs.iter().any(|o| o.version() < 4) {
-            data.registry().bind_one(qh, 1..=3, GlobalData(())).into()
+            data.registry().bind_one(qh, 1..=3, GlobalData).into()
         } else {
             GlobalProxy::NotReady
         };
@@ -618,7 +618,7 @@ where
             // Lazily bind xdg output manager if it's needed
             if version < 4 && matches!(data.output_state().xdg, GlobalProxy::NotReady) {
                 data.output_state().xdg =
-                    data.registry().bind_one(qh, 1..=3, GlobalData(())).into();
+                    data.registry().bind_one(qh, 1..=3, GlobalData).into();
             }
 
             let output = data

--- a/src/output.rs
+++ b/src/output.rs
@@ -617,8 +617,7 @@ where
         if interface == "wl_output" {
             // Lazily bind xdg output manager if it's needed
             if version < 4 && matches!(data.output_state().xdg, GlobalProxy::NotReady) {
-                data.output_state().xdg =
-                    data.registry().bind_one(qh, 1..=3, GlobalData).into();
+                data.output_state().xdg = data.registry().bind_one(qh, 1..=3, GlobalData).into();
             }
 
             let output = data

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -206,7 +206,7 @@ impl RegistryState {
             + 'static,
     {
         let display = conn.display();
-        let registry = display.get_registry(qh, GlobalData(())).unwrap();
+        let registry = display.get_registry(qh, GlobalData).unwrap();
         display.sync(qh, RegistryReady).unwrap();
         RegistryState { registry, globals: Vec::new(), ready: false }
     }

--- a/src/shell/layer/dispatch.rs
+++ b/src/shell/layer/dispatch.rs
@@ -17,8 +17,7 @@ where
         + 'static,
 {
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
-        data.layer_state().wlr_layer_shell =
-            data.registry().bind_one(qh, 1..=4, GlobalData).into();
+        data.layer_state().wlr_layer_shell = data.registry().bind_one(qh, 1..=4, GlobalData).into();
     }
 }
 

--- a/src/shell/layer/dispatch.rs
+++ b/src/shell/layer/dispatch.rs
@@ -18,7 +18,7 @@ where
 {
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
         data.layer_state().wlr_layer_shell =
-            data.registry().bind_one(qh, 1..=4, GlobalData(())).into();
+            data.registry().bind_one(qh, 1..=4, GlobalData).into();
     }
 }
 

--- a/src/shell/xdg/inner.rs
+++ b/src/shell/xdg/inner.rs
@@ -18,7 +18,7 @@ where
 {
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
         data.xdg_shell_state().xdg_wm_base =
-            data.registry().bind_one(qh, 1..=4, GlobalData(())).into();
+            data.registry().bind_one(qh, 1..=4, GlobalData).into();
     }
 }
 

--- a/src/shell/xdg/inner.rs
+++ b/src/shell/xdg/inner.rs
@@ -17,8 +17,7 @@ where
         + 'static,
 {
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
-        data.xdg_shell_state().xdg_wm_base =
-            data.registry().bind_one(qh, 1..=4, GlobalData).into();
+        data.xdg_shell_state().xdg_wm_base = data.registry().bind_one(qh, 1..=4, GlobalData).into();
     }
 }
 

--- a/src/shell/xdg/window/inner.rs
+++ b/src/shell/xdg/window/inner.rs
@@ -125,7 +125,7 @@ where
 {
     fn ready(data: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
         data.xdg_window_state().xdg_decoration_manager =
-            data.registry().bind_one(qh, 1..=DECORATION_MANAGER_VERSION, GlobalData(())).into();
+            data.registry().bind_one(qh, 1..=DECORATION_MANAGER_VERSION, GlobalData).into();
     }
 }
 

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -137,6 +137,6 @@ where
     D: Dispatch<wl_shm::WlShm, GlobalData> + ShmHandler + ProvidesRegistryState + 'static,
 {
     fn ready(state: &mut D, _conn: &Connection, qh: &QueueHandle<D>) {
-        state.shm_state().wl_shm = state.registry().bind_one(qh, 1..=1, GlobalData(())).into();
+        state.shm_state().wl_shm = state.registry().bind_one(qh, 1..=1, GlobalData).into();
     }
 }


### PR DESCRIPTION
People that don't commit fully to the SCTK can use GlobalData to satisfy trait implementations necessary to use other SCTK types.