### PR TITLE
Fix/ use xkbcommon git dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ wayland-protocols-wlr = { version = "=0.1.0-beta.8", features = ["client"] }
 wayland-cursor = "=0.30.0-beta.8"
 
 # Explicit dependency until release
-xkbcommon = { version = "=0.5.0-beta.0", optional = true, features = ["wayland"] }
+xkbcommon = { git = "https://github.com/rust-x-bindings/xkbcommon-rs", optional = true, features = ["wayland"] }
 calloop = { version = "0.10.0", optional = true }
 
 [features]

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -374,7 +374,7 @@ impl KeyboardData {
             // TODO: Pending new release of xkbcommon to use new_from_locale with OsStr
             if let Ok(table) = xkb::compose::Table::new_from_locale(
                 &xkb_context,
-                locale,
+                locale.as_ref(),
                 xkb::compose::COMPILE_NO_FLAGS,
             ) {
                 let compose_state =
@@ -472,14 +472,18 @@ where
                                     xkb::COMPILE_NO_FLAGS,
                                 )
                             } {
-                                Some(keymap) => {
+                                Ok(Some(keymap)) => {
                                     let state = xkb::State::new(&keymap);
                                     let mut state_guard = udata.xkb_state.lock().unwrap();
                                     *state_guard = Some(state);
                                 }
 
-                                None => {
+                                Ok(None) => {
                                     log::error!(target: "sctk", "invalid keymap");
+                                }
+
+                                Err(err) => {
+                                    log::error!(target: "sctk", "{}", err);
                                 }
                             }
                         }


### PR DESCRIPTION
https://wayland.freedesktop.org/docs/html/apa.html
From version 7 onwards, the fd must be mapped with MAP_PRIVATE by the recipient, as MAP_SHARED may fail. 

Binding to version 7 seems to be the reason that simple_window example is panicking, and is referenced here https://github.com/rust-x-bindings/xkbcommon-rs/blob/8d237eedc345a110797cbe8edc515c09c098244b/src/xkb/mod.rs#L719

