### PR TITLE
Don't require SeatHandler when unnecessary

### DIFF
--- a/src/seat/pointer.rs
+++ b/src/seat/pointer.rs
@@ -6,7 +6,7 @@ use wayland_client::{
     Connection, Dispatch, Proxy, QueueHandle, WEnum,
 };
 
-use super::{SeatHandler, SeatState};
+use super::SeatState;
 
 /* From linux/input-event-codes.h - the buttons usually used by mice */
 pub const BTN_LEFT: u32 = 0x110;
@@ -91,7 +91,7 @@ pub enum PointerEventKind {
     },
 }
 
-pub trait PointerHandler: SeatHandler + Sized {
+pub trait PointerHandler: Sized {
     /// One or more pointer events are available.
     ///
     /// Multiple related events may be grouped together in a single frame.  Some examples:

--- a/src/seat/touch.rs
+++ b/src/seat/touch.rs
@@ -4,7 +4,7 @@ use wayland_client::protocol::wl_surface::WlSurface;
 use wayland_client::protocol::wl_touch::{Event as TouchEvent, WlTouch};
 use wayland_client::{Connection, Dispatch, QueueHandle};
 
-use crate::seat::{SeatHandler, SeatState};
+use crate::seat::SeatState;
 
 #[derive(Debug, Default)]
 pub struct TouchData {
@@ -46,7 +46,7 @@ impl TouchDataExt for TouchData {
     }
 }
 
-pub trait TouchHandler: SeatHandler + Sized {
+pub trait TouchHandler: Sized {
     /// New touch point.
     ///
     /// Indicates a new touch point has appeared on the surface, starting a touch sequence. The ID


### PR DESCRIPTION
This is essentially ee4ed37a8b789b891299af7822da8e0c3d2f1788 for PointerHandler and TouchHandler.

See: https://github.com/Smithay/client-toolkit/pull/289