### PR TITLE
Updates for infallible creation methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ lazy_static = "1.0"
 memmap2 = "0.5.0"
 log = "0.4"
 thiserror = "1.0.30"
-wayland-backend = "=0.1.0-beta.8"
-wayland-client = "=0.30.0-beta.8"
-wayland-protocols = { version = "=0.30.0-beta.8", features = ["client", "unstable"] }
-wayland-protocols-wlr = { version = "=0.1.0-beta.8", features = ["client"] }
-wayland-cursor = "=0.30.0-beta.8"
-wayland-scanner = "=0.30.0-beta.8"
+wayland-backend = "=0.1.0-beta.9"
+wayland-client = "=0.30.0-beta.9"
+wayland-protocols = { version = "=0.30.0-beta.9", features = ["client", "unstable"] }
+wayland-protocols-wlr = { version = "=0.1.0-beta.9", features = ["client"] }
+wayland-cursor = "=0.30.0-beta.9"
+wayland-scanner = "=0.30.0-beta.9"
 
 # Explicit dependency until release
 xkbcommon = { git = "https://github.com/rust-x-bindings/xkbcommon-rs", optional = true, features = ["wayland"] }

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -289,7 +289,7 @@ impl State {
             viewer.damaged = false;
 
             // Request our next frame
-            window.wl_surface().frame(qh, window.wl_surface().clone()).expect("create callback");
+            window.wl_surface().frame(qh, window.wl_surface().clone());
 
             // Attach and commit to present.
             buffer.attach_to(window.wl_surface()).expect("buffer attach");

--- a/examples/image_viewporter.rs
+++ b/examples/image_viewporter.rs
@@ -73,12 +73,11 @@ fn main() {
             .map(&qh, &state.xdg_shell_state, &mut state.xdg_window_state, surface)
             .expect("window creation");
 
-        let viewport = state
-            .viewporter
-            .get()
-            .expect("Requires wp_viewporter")
-            .get_viewport(window.wl_surface(), &qh, ())
-            .expect("viewport");
+        let viewport = state.viewporter.get().expect("Requires wp_viewporter").get_viewport(
+            window.wl_surface(),
+            &qh,
+            (),
+        );
 
         state.windows.push(ImageViewer {
             width: image.width(),

--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -392,7 +392,7 @@ impl SimpleLayer {
             window.wl_surface().damage_buffer(0, 0, width as i32, height as i32);
 
             // Request our next frame
-            window.wl_surface().frame(qh, window.wl_surface().clone()).expect("create callback");
+            window.wl_surface().frame(qh, window.wl_surface().clone());
 
             // Attach and commit to present.
             buffer.attach_to(window.wl_surface()).expect("buffer attach");

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -428,7 +428,7 @@ impl SimpleWindow {
             window.wl_surface().damage_buffer(0, 0, self.width as i32, self.height as i32);
 
             // Request our next frame
-            window.wl_surface().frame(qh, window.wl_surface().clone()).expect("create callback");
+            window.wl_surface().frame(qh, window.wl_surface().clone());
 
             // Attach and commit to present.
             buffer.attach_to(window.wl_surface()).expect("buffer attach");

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -183,20 +183,36 @@ macro_rules! delegate_compositor {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty:
             [
-                $crate::reexports::client::protocol::wl_compositor::WlCompositor: $crate::globals::GlobalData,
-                $crate::reexports::client::protocol::wl_surface::WlSurface: $crate::compositor::SurfaceData,
-                $crate::reexports::client::protocol::wl_callback::WlCallback: $crate::reexports::client::protocol::wl_surface::WlSurface,
+                $crate::reexports::client::protocol::wl_compositor::WlCompositor: $crate::globals::GlobalData
+            ] => $crate::compositor::CompositorState
+        );
+        $crate::reexports::client::delegate_dispatch!($ty:
+            [
+                $crate::reexports::client::protocol::wl_surface::WlSurface: $crate::compositor::SurfaceData
+            ] => $crate::compositor::CompositorState
+        );
+        $crate::reexports::client::delegate_dispatch!($ty:
+            [
+                $crate::reexports::client::protocol::wl_callback::WlCallback: $crate::reexports::client::protocol::wl_surface::WlSurface
             ] => $crate::compositor::CompositorState
         );
     };
     ($ty: ty, surface: [$($surface: ty),*$(,)?]) => {
         $crate::reexports::client::delegate_dispatch!($ty:
             [
-                $crate::reexports::client::protocol::wl_compositor::WlCompositor: $crate::globals::GlobalData,
-                $(
-                    $crate::reexports::client::protocol::wl_surface::WlSurface: $surface,
-                )*
-                $crate::reexports::client::protocol::wl_callback::WlCallback: $crate::reexports::client::protocol::wl_surface::WlSurface,
+                $crate::reexports::client::protocol::wl_compositor::WlCompositor: $crate::globals::GlobalData
+            ] => $crate::compositor::CompositorState
+        );
+        $(
+            $crate::reexports::client::delegate_dispatch!($ty:
+                [
+                    $crate::reexports::client::protocol::wl_surface::WlSurface: $surface
+                ] => $crate::compositor::CompositorState
+            );
+        )*
+        $crate::reexports::client::delegate_dispatch!($ty:
+            [
+                $crate::reexports::client::protocol::wl_callback::WlCallback: $crate::reexports::client::protocol::wl_surface::WlSurface
             ] => $crate::compositor::CompositorState
         );
     };

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -85,7 +85,7 @@ impl CompositorState {
     {
         let compositor = self.wl_compositor.get()?;
 
-        let surface = compositor.create_surface(qh, data)?;
+        let surface = compositor.create_surface(qh, data);
 
         Ok(surface)
     }
@@ -158,7 +158,7 @@ impl Surface {
         D: Dispatch<wl_surface::WlSurface, U> + 'static,
         U: Send + Sync + 'static,
     {
-        Ok(Surface(compositor.bound_global()?.create_surface(qh, data)?))
+        Ok(Surface(compositor.bound_global()?.create_surface(qh, data)))
     }
 
     pub fn wl_surface(&self) -> &wl_surface::WlSurface {

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -298,10 +298,12 @@ impl Region {
         compositor: &impl ProvidesBoundGlobal<wl_compositor::WlCompositor, 5>,
     ) -> Result<Region, GlobalError> {
         compositor
-            .bound_global()?
-            .send_constructor(wl_compositor::Request::CreateRegion {}, Arc::new(RegionData))
+            .bound_global()
+            .map(|c| {
+                c.send_constructor(wl_compositor::Request::CreateRegion {}, Arc::new(RegionData))
+                    .unwrap_or_else(|_| Proxy::inert(c.backend().clone()))
+            })
             .map(Region)
-            .map_err(Into::into)
     }
 
     pub fn add(&self, x: i32, y: i32, width: i32, height: i32) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,3 @@
-use wayland_backend::client::InvalidId;
-
 /// An error that may occur when creating objects using a global.
 #[derive(Debug, thiserror::Error)]
 pub enum GlobalError {
@@ -14,10 +12,4 @@ pub enum GlobalError {
     /// This is likely a programming error due to a missing entry in the registry_handlers! macro.
     #[error("global enumeration is not finished or missing ProvidesRegistryState delegation")]
     NotReady,
-
-    /// An invalid id was acted upon
-    ///
-    /// This likely means a request was sent to a dead protocol object.
-    #[error(transparent)]
-    Id(#[from] InvalidId),
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -181,7 +181,7 @@ impl OutputState {
         let xdg_output = if pending_xdg {
             let xdg = self.xdg.get().unwrap();
 
-            Some(xdg.get_xdg_output(&wl_output, qh, data).unwrap())
+            Some(xdg.get_xdg_output(&wl_output, qh, data))
         } else {
             None
         };

--- a/src/output.rs
+++ b/src/output.rs
@@ -344,9 +344,13 @@ pub struct OutputInfo {
 macro_rules! delegate_output {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty: [
-            $crate::reexports::client::protocol::wl_output::WlOutput: $crate::output::OutputData,
-            $crate::reexports::protocols::xdg::xdg_output::zv1::client::zxdg_output_manager_v1::ZxdgOutputManagerV1: $crate::globals::GlobalData,
-            $crate::reexports::protocols::xdg::xdg_output::zv1::client::zxdg_output_v1::ZxdgOutputV1: $crate::output::OutputData,
+            $crate::reexports::client::protocol::wl_output::WlOutput: $crate::output::OutputData
+        ] => $crate::output::OutputState);
+        $crate::reexports::client::delegate_dispatch!($ty: [
+            $crate::reexports::protocols::xdg::xdg_output::zv1::client::zxdg_output_manager_v1::ZxdgOutputManagerV1: $crate::globals::GlobalData
+        ] => $crate::output::OutputState);
+        $crate::reexports::client::delegate_dispatch!($ty: [
+            $crate::reexports::protocols::xdg::xdg_output::zv1::client::zxdg_output_v1::ZxdgOutputV1: $crate::output::OutputData
         ] => $crate::output::OutputState);
     };
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -216,8 +216,8 @@ impl RegistryState {
             + 'static,
     {
         let display = conn.display();
-        let registry = display.get_registry(qh, GlobalData).unwrap();
-        display.sync(qh, RegistryReady).unwrap();
+        let registry = display.get_registry(qh, GlobalData);
+        display.sync(qh, RegistryReady);
         RegistryState { registry, globals: Vec::new(), ready: false }
     }
 
@@ -295,7 +295,7 @@ impl RegistryState {
                 return Err(BindError::UnsupportedVersion);
             }
             let version = global.version.min(*version.end());
-            let proxy = self.registry.bind(global.name, version, qh, udata)?;
+            let proxy = self.registry.bind(global.name, version, qh, udata);
             log::debug!(target: "sctk", "Bound new global [{}] {} v{}", global.name, iface.name, version);
 
             return Ok(proxy);
@@ -334,7 +334,7 @@ impl RegistryState {
                 return Err(BindError::UnsupportedVersion);
             }
             let version = global.version.min(*version.end());
-            let proxy = self.registry.bind(global.name, version, qh, udata)?;
+            let proxy = self.registry.bind(global.name, version, qh, udata);
             log::debug!(target: "sctk", "Bound new global [{}] {} v{}", global.name, iface.name, version);
 
             return Ok(proxy);
@@ -371,7 +371,7 @@ impl RegistryState {
             }
             let version = global.version.min(*version.end());
             let udata = make_udata(global.name);
-            let proxy = self.registry.bind(global.name, version, qh, udata)?;
+            let proxy = self.registry.bind(global.name, version, qh, udata);
             log::debug!(target: "sctk", "Bound new global [{}] {} v{}", global.name, iface.name, version);
 
             rv.push(proxy);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -420,9 +420,13 @@ macro_rules! delegate_registry {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty:
             [
-                $crate::reexports::client::protocol::wl_registry::WlRegistry: $crate::globals::GlobalData,
-                $crate::reexports::client::protocol::wl_callback::WlCallback: $crate::registry::RegistryReady,
-            ]  => $crate::registry::RegistryState
+                $crate::reexports::client::protocol::wl_registry::WlRegistry: $crate::globals::GlobalData
+            ] => $crate::registry::RegistryState
+        );
+        $crate::reexports::client::delegate_dispatch!($ty:
+            [
+                $crate::reexports::client::protocol::wl_callback::WlCallback: $crate::registry::RegistryReady
+            ] => $crate::registry::RegistryState
         );
     };
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -72,7 +72,6 @@ use crate::{
     globals::{GlobalData, ProvidesBoundGlobal},
 };
 use wayland_client::{
-    backend::InvalidId,
     protocol::{wl_callback, wl_registry},
     Connection, Dispatch, Proxy, QueueHandle,
 };
@@ -168,10 +167,6 @@ pub enum BindError {
     /// The requested version of the global is not supported.
     #[error("the requested version of the global is not supported")]
     UnsupportedVersion,
-
-    /// Protocol error.
-    #[error(transparent)]
-    Protocol(#[from] InvalidId),
 
     /// The requested global was not found in the registry.
     #[error("the requested global was not found in the registry")]

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -90,7 +90,7 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Keyboard).into());
         }
 
-        Ok(seat.get_keyboard(qh, udata).map_err(Into::<SeatError>::into)?)
+        Ok(seat.get_keyboard(qh, udata))
     }
 }
 

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -275,7 +275,7 @@ macro_rules! delegate_seat {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty:
             [
-                $crate::reexports::client::protocol::wl_seat::WlSeat: $crate::seat::SeatData,
+                $crate::reexports::client::protocol::wl_seat::WlSeat: $crate::seat::SeatData
             ] => $crate::seat::SeatState
         );
     };

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -11,7 +11,6 @@ use std::{
     },
 };
 
-use wayland_backend::client::InvalidId;
 use wayland_client::{
     protocol::{wl_pointer, wl_seat, wl_touch},
     Connection, Dispatch, Proxy, QueueHandle,
@@ -53,10 +52,6 @@ pub enum SeatError {
     /// The seat is dead.
     #[error("the seat is dead")]
     DeadObject,
-
-    /// Protocol error.
-    #[error(transparent)]
-    Protocol(#[from] InvalidId),
 }
 
 #[derive(Debug)]

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -129,7 +129,7 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Pointer));
         }
 
-        let pointer = seat.get_pointer(qh, pointer_data)?;
+        let pointer = seat.get_pointer(qh, pointer_data);
         Ok(pointer)
     }
 
@@ -171,7 +171,7 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Touch));
         }
 
-        let touch = seat.get_touch(qh, udata)?;
+        let touch = seat.get_touch(qh, udata);
         Ok(touch)
     }
 }

--- a/src/seat/touch.rs
+++ b/src/seat/touch.rs
@@ -21,18 +21,18 @@ macro_rules! delegate_touch {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty:
             [
-                $crate::reexports::client::protocol::wl_touch::WlTouch: $crate::seat::touch::TouchData,
+                $crate::reexports::client::protocol::wl_touch::WlTouch: $crate::seat::touch::TouchData
             ] => $crate::seat::SeatState
         );
     };
     ($ty: ty, touch: [$($td:ty),* $(,)?]) => {
-        $crate::reexports::client::delegate_dispatch!($ty:
-            [
-                $(
-                    $crate::reexports::client::protocol::wl_touch::WlTouch: $td,
-                )*
-            ] => $crate::seat::SeatState
-        );
+        $(
+            $crate::reexports::client::delegate_dispatch!($ty:
+                [
+                    $crate::reexports::client::protocol::wl_touch::WlTouch: $td
+                ] => $crate::seat::SeatState
+            );
+        )*
     };
 }
 

--- a/src/shell/layer/mod.rs
+++ b/src/shell/layer/mod.rs
@@ -212,13 +212,13 @@ impl LayerSurface {
     // Double buffered state
 
     pub fn set_size(&self, width: u32, height: u32) {
-        match self.inner().kind {
+        match self.0.kind {
             SurfaceKind::Wlr(ref wlr) => wlr.set_size(width, height),
         }
     }
 
     pub fn set_anchor(&self, anchor: Anchor) {
-        match self.inner().kind {
+        match self.0.kind {
             // We currently rely on the bitsets being the same
             SurfaceKind::Wlr(ref wlr) => {
                 wlr.set_anchor(zwlr_layer_surface_v1::Anchor::from_bits_truncate(anchor.bits()))
@@ -227,35 +227,35 @@ impl LayerSurface {
     }
 
     pub fn set_exclusive_zone(&self, zone: i32) {
-        match self.inner().kind {
+        match self.0.kind {
             SurfaceKind::Wlr(ref wlr) => wlr.set_exclusive_zone(zone),
         }
     }
 
     pub fn set_margin(&self, top: i32, right: i32, bottom: i32, left: i32) {
-        match self.inner().kind {
+        match self.0.kind {
             SurfaceKind::Wlr(ref wlr) => wlr.set_margin(top, right, bottom, left),
         }
     }
 
     pub fn set_keyboard_interactivity(&self, value: KeyboardInteractivity) {
-        match self.inner().kind {
+        match self.0.kind {
             SurfaceKind::Wlr(ref wlr) => wlr.set_keyboard_interactivity(value.into()),
         }
     }
 
     pub fn set_layer(&self, layer: Layer) {
-        match self.inner().kind {
+        match self.0.kind {
             SurfaceKind::Wlr(ref wlr) => wlr.set_layer(layer.into()),
         }
     }
 
     pub fn kind(&self) -> &SurfaceKind {
-        &self.inner().kind
+        &self.0.kind
     }
 
     pub fn wl_surface(&self) -> &wl_surface::WlSurface {
-        &self.inner().wl_surface
+        &self.0.wl_surface
     }
 }
 
@@ -376,12 +376,6 @@ macro_rules! delegate_layer {
             $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1: $crate::shell::layer::LayerSurfaceData
         ] => $crate::shell::layer::LayerState);
     };
-}
-
-impl LayerSurface {
-    fn inner(&self) -> &LayerSurfaceInner {
-        &self.0
-    }
 }
 
 #[derive(Debug)]

--- a/src/shell/layer/mod.rs
+++ b/src/shell/layer/mod.rs
@@ -370,8 +370,10 @@ impl LayerSurfaceData {
 macro_rules! delegate_layer {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty: [
-            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1: $crate::globals::GlobalData,
-            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1: $crate::shell::layer::LayerSurfaceData,
+            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1: $crate::globals::GlobalData
+        ] => $crate::shell::layer::LayerState);
+        $crate::reexports::client::delegate_dispatch!($ty: [
+            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1: $crate::shell::layer::LayerSurfaceData
         ] => $crate::shell::layer::LayerState);
     };
 }

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -113,8 +113,7 @@ impl XdgShellSurface {
         U: Send + Sync + 'static,
     {
         let surface = surface.into();
-        let xdg_surface =
-            wm_base.bound_global()?.get_xdg_surface(surface.wl_surface(), qh, udata)?;
+        let xdg_surface = wm_base.bound_global()?.get_xdg_surface(surface.wl_surface(), qh, udata);
 
         Ok(XdgShellSurface { xdg_surface, surface })
     }

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -41,10 +41,16 @@ impl XdgPositioner {
         wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4>,
     ) -> Result<Self, GlobalError> {
         wm_base
-            .bound_global()?
-            .send_constructor(xdg_wm_base::Request::CreatePositioner {}, Arc::new(PositionerData))
+            .bound_global()
+            .map(|wm_base| {
+                wm_base
+                    .send_constructor(
+                        xdg_wm_base::Request::CreatePositioner {},
+                        Arc::new(PositionerData),
+                    )
+                    .unwrap_or_else(|_| Proxy::inert(wm_base.backend().clone()))
+            })
             .map(XdgPositioner)
-            .map_err(From::from)
     }
 }
 

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -141,7 +141,7 @@ pub trait XdgShellHandler: Sized {
 macro_rules! delegate_xdg_shell {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty: [
-            $crate::reexports::protocols::xdg::shell::client::xdg_wm_base::XdgWmBase: $crate::globals::GlobalData,
+            $crate::reexports::protocols::xdg::shell::client::xdg_wm_base::XdgWmBase: $crate::globals::GlobalData
         ] => $crate::shell::xdg::XdgShellState);
     };
 }

--- a/src/shell/xdg/popup.rs
+++ b/src/shell/xdg/popup.rs
@@ -117,24 +117,20 @@ impl Popup {
         Ok(Popup { inner })
     }
 
-    fn inner(&self) -> &PopupInner {
-        &self.inner
-    }
-
     pub fn xdg_popup(&self) -> &xdg_popup::XdgPopup {
-        &self.inner().xdg_popup
+        &self.inner.xdg_popup
     }
 
     pub fn xdg_shell_surface(&self) -> &XdgShellSurface {
-        &self.inner().surface
+        &self.inner.surface
     }
 
     pub fn xdg_surface(&self) -> &xdg_surface::XdgSurface {
-        self.inner().surface.xdg_surface()
+        self.inner.surface.xdg_surface()
     }
 
     pub fn wl_surface(&self) -> &wl_surface::WlSurface {
-        self.inner().surface.wl_surface()
+        self.inner.surface.wl_surface()
     }
 
     pub fn reposition(&self, position: &xdg_positioner::XdgPositioner, token: u32) {
@@ -216,7 +212,7 @@ where
             Some(popup) => popup,
             None => return,
         };
-        let inner = popup.inner();
+        let inner = &popup.inner;
         match event {
             xdg_surface::Event::Configure { serial } => {
                 xdg_surface.ack_configure(serial);
@@ -259,7 +255,7 @@ where
             Some(popup) => popup,
             None => return,
         };
-        let inner = popup.inner();
+        let inner = &popup.inner;
         match event {
             xdg_popup::Event::Configure { x, y, width, height } => {
                 inner.pending_position.0.store(x, Relaxed);

--- a/src/shell/xdg/popup.rs
+++ b/src/shell/xdg/popup.rs
@@ -283,8 +283,10 @@ where
 macro_rules! delegate_xdg_popup {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty: [
-            $crate::reexports::protocols::xdg::shell::client::xdg_popup::XdgPopup: $crate::shell::xdg::popup::PopupData,
-            $crate::reexports::protocols::xdg::shell::client::xdg_surface::XdgSurface: $crate::shell::xdg::popup::PopupData,
+            $crate::reexports::protocols::xdg::shell::client::xdg_popup::XdgPopup: $crate::shell::xdg::popup::PopupData
+        ] => $crate::shell::xdg::popup::PopupData);
+        $crate::reexports::client::delegate_dispatch!($ty: [
+            $crate::reexports::protocols::xdg::shell::client::xdg_surface::XdgSurface: $crate::shell::xdg::popup::PopupData
         ] => $crate::shell::xdg::popup::PopupData);
     };
 }

--- a/src/shell/xdg/window/inner.rs
+++ b/src/shell/xdg/window/inner.rs
@@ -153,7 +153,7 @@ where
                     // Acknowledge the configure per protocol requirements.
                     xdg_surface.ack_configure(serial);
 
-                    let configure = { window.inner().pending_configure.lock().unwrap().clone() };
+                    let configure = { window.0.pending_configure.lock().unwrap().clone() };
                     WindowHandler::configure(data, conn, qh, &window, configure, serial);
                 }
 
@@ -193,7 +193,7 @@ where
                         Some((width as u32, height as u32))
                     };
 
-                    let pending_configure = &mut window.inner().pending_configure.lock().unwrap();
+                    let pending_configure = &mut window.0.pending_configure.lock().unwrap();
                     pending_configure.new_size = new_size;
                     pending_configure.states = states;
                 }
@@ -203,7 +203,7 @@ where
                 }
 
                 xdg_toplevel::Event::ConfigureBounds { width, height } => {
-                    let pending_configure = &mut window.inner().pending_configure.lock().unwrap();
+                    let pending_configure = &mut window.0.pending_configure.lock().unwrap();
                     if width == 0 && height == 0 {
                         pending_configure.suggested_bounds = None;
                     } else {
@@ -260,7 +260,7 @@ where
                             _ => unreachable!(),
                         };
 
-                        window.inner().pending_configure.lock().unwrap().decoration_mode = mode;
+                        window.0.pending_configure.lock().unwrap().decoration_mode = mode;
                     }
 
                     wayland_client::WEnum::Unknown(unknown) => {

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -530,10 +530,16 @@ pub struct WindowData(pub(crate) Weak<WindowInner>);
 macro_rules! delegate_xdg_window {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty: [
-            $crate::reexports::protocols::xdg::shell::client::xdg_surface::XdgSurface: $crate::shell::xdg::window::WindowData,
-            $crate::reexports::protocols::xdg::shell::client::xdg_toplevel::XdgToplevel: $crate::shell::xdg::window::WindowData,
-            $crate::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1: $crate::globals::GlobalData,
-            $crate::reexports::protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1: $crate::shell::xdg::window::WindowData,
+            $crate::reexports::protocols::xdg::shell::client::xdg_surface::XdgSurface: $crate::shell::xdg::window::WindowData
+        ] => $crate::shell::xdg::window::XdgWindowState);
+        $crate::reexports::client::delegate_dispatch!($ty: [
+            $crate::reexports::protocols::xdg::shell::client::xdg_toplevel::XdgToplevel: $crate::shell::xdg::window::WindowData
+        ] => $crate::shell::xdg::window::XdgWindowState);
+        $crate::reexports::client::delegate_dispatch!($ty: [
+            $crate::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1: $crate::globals::GlobalData
+        ] => $crate::shell::xdg::window::XdgWindowState);
+        $crate::reexports::client::delegate_dispatch!($ty: [
+            $crate::reexports::protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1: $crate::shell::xdg::window::WindowData
         ] => $crate::shell::xdg::window::XdgWindowState);
     };
 }

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -429,39 +429,39 @@ impl Window {
     }
 
     pub fn show_window_menu(&self, seat: &wl_seat::WlSeat, serial: u32, position: (u32, u32)) {
-        self.inner().show_window_menu(seat, serial, position.0, position.1)
+        self.0.show_window_menu(seat, serial, position.0, position.1)
     }
 
     pub fn set_title(&self, title: impl Into<String>) {
-        self.inner().set_title(title.into())
+        self.0.set_title(title.into())
     }
 
     pub fn set_app_id(&self, app_id: impl Into<String>) {
-        self.inner().set_app_id(app_id.into())
+        self.0.set_app_id(app_id.into())
     }
 
     pub fn set_parent(&self, parent: Option<&Window>) {
-        self.inner().set_parent(parent)
+        self.0.set_parent(parent)
     }
 
     pub fn set_maximized(&self) {
-        self.inner().set_maximized()
+        self.0.set_maximized()
     }
 
     pub fn unset_maximized(&self) {
-        self.inner().unset_maximized()
+        self.0.unset_maximized()
     }
 
     pub fn set_mimimized(&self) {
-        self.inner().set_minmized()
+        self.0.set_minmized()
     }
 
     pub fn set_fullscreen(&self, output: Option<&wl_output::WlOutput>) {
-        self.inner().set_fullscreen(output)
+        self.0.set_fullscreen(output)
     }
 
     pub fn unset_fullscreen(&self) {
-        self.inner().unset_fullscreen()
+        self.0.unset_fullscreen()
     }
 
     /// Requests the window should use the specified decoration mode.
@@ -475,7 +475,7 @@ impl Window {
     ///
     /// You should avoid sending multiple decoration mode requests to ensure you do not enter a configure loop.
     pub fn request_decoration_mode(&self, mode: Option<DecorationMode>) {
-        self.inner().request_decoration_mode(mode)
+        self.0.request_decoration_mode(mode)
     }
 
     // TODO: Move
@@ -485,14 +485,14 @@ impl Window {
     // Double buffered window state
 
     pub fn set_min_size(&self, min_size: Option<(u32, u32)>) {
-        self.inner().set_min_size(min_size)
+        self.0.set_min_size(min_size)
     }
 
     /// # Protocol errors
     ///
     /// The maximum size of the window may not be smaller than the minimum size.
     pub fn set_max_size(&self, max_size: Option<(u32, u32)>) {
-        self.inner().set_max_size(max_size)
+        self.0.set_max_size(max_size)
     }
 
     // TODO: Window geometry
@@ -503,17 +503,17 @@ impl Window {
 
     /// Returns the underlying surface wrapped by this window.
     pub fn wl_surface(&self) -> &wl_surface::WlSurface {
-        self.inner().xdg_surface.wl_surface()
+        self.0.xdg_surface.wl_surface()
     }
 
     /// Returns the underlying xdg surface wrapped by this window.
     pub fn xdg_surface(&self) -> &xdg_surface::XdgSurface {
-        self.inner().xdg_surface.xdg_surface()
+        self.0.xdg_surface.xdg_surface()
     }
 
     /// Returns the underlying xdg toplevel wrapped by this window.
     pub fn xdg_toplevel(&self) -> &xdg_toplevel::XdgToplevel {
-        &self.inner().xdg_toplevel
+        &self.0.xdg_toplevel
     }
 }
 
@@ -542,10 +542,4 @@ macro_rules! delegate_xdg_window {
             $crate::reexports::protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1: $crate::shell::xdg::window::WindowData
         ] => $crate::shell::xdg::window::XdgWindowState);
     };
-}
-
-impl Window {
-    fn inner(&self) -> &WindowInner {
-        &self.0
-    }
 }

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -303,6 +303,9 @@ impl WindowBuilder {
 
         let surface = surface.into();
         let wm_base = wm_base.bound_global()?;
+        // Freeze the queue during the creation of the Arc to avoid a race between events on the
+        // new objects being processed and the Weak in the PopupData becoming usable.
+        let freeze = qh.freeze();
 
         let window = Window(Arc::new_cyclic(|weak| {
             let xdg_surface =
@@ -356,6 +359,7 @@ impl WindowBuilder {
                 }),
             }
         }));
+        drop(freeze);
 
         // Apply state from builder
         if let Some(title) = self.title {

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -96,7 +96,7 @@ macro_rules! delegate_shm {
     ($ty: ty) => {
         $crate::reexports::client::delegate_dispatch!($ty:
             [
-                $crate::reexports::client::protocol::wl_shm::WlShm: $crate::globals::GlobalData,
+                $crate::reexports::client::protocol::wl_shm::WlShm: $crate::globals::GlobalData
             ] => $crate::shm::ShmState
         );
     };

--- a/src/shm/multi.rs
+++ b/src/shm/multi.rs
@@ -260,12 +260,16 @@ impl<K> MultiPool<K> {
             }
             let free = Arc::new(AtomicBool::new(true));
             let data = BufferObjectData { free: free.clone() };
-            let buffer = self
-                .inner
-                .create_buffer_raw(offset as i32, width, height, stride, format, Arc::new(data))
-                .ok();
+            let buffer = self.inner.create_buffer_raw(
+                offset as i32,
+                width,
+                height,
+                stride,
+                format,
+                Arc::new(data),
+            );
             buf_slot.free = free;
-            buf_slot.buffer = buffer;
+            buf_slot.buffer = Some(buffer);
         }
         let buf = buf_slot.buffer.as_ref()?;
         buf_slot.free.store(false, Ordering::Relaxed);
@@ -321,12 +325,16 @@ impl<K> MultiPool<K> {
             }
             let free = Arc::new(AtomicBool::new(true));
             let data = BufferObjectData { free: free.clone() };
-            let buffer = self
-                .inner
-                .create_buffer_raw(offset as i32, width, height, stride, format, Arc::new(data))
-                .ok();
+            let buffer = self.inner.create_buffer_raw(
+                offset as i32,
+                width,
+                height,
+                stride,
+                format,
+                Arc::new(data),
+            );
             buf_slot.free = free;
-            buf_slot.buffer = buffer;
+            buf_slot.buffer = Some(buffer);
         }
         buf_slot.free.store(false, Ordering::Relaxed);
         let buf = buf_slot.buffer.as_ref().unwrap();
@@ -360,10 +368,14 @@ impl<K> MultiPool<K> {
         }
         let free = Arc::new(AtomicBool::new(true));
         let data = BufferObjectData { free: free.clone() };
-        let buffer = self
-            .inner
-            .create_buffer_raw(offset as i32, width, height, stride, format, Arc::new(data))
-            .ok()?;
+        let buffer = self.inner.create_buffer_raw(
+            offset as i32,
+            width,
+            height,
+            stride,
+            format,
+            Arc::new(data),
+        );
         self.buffer_list.push(BufferSlot {
             offset,
             used: 0,

--- a/src/shm/raw.rs
+++ b/src/shm/raw.rs
@@ -19,12 +19,12 @@ use nix::{
     unistd,
 };
 use wayland_client::{
-    backend::{InvalidId, ObjectData},
+    backend::ObjectData,
     protocol::{wl_buffer, wl_shm, wl_shm_pool},
     Dispatch, Proxy, QueueHandle, WEnum,
 };
 
-use crate::{error::GlobalError, globals::ProvidesBoundGlobal};
+use crate::globals::ProvidesBoundGlobal;
 
 use super::CreatePoolError;
 
@@ -56,7 +56,7 @@ impl RawPool {
                 wl_shm::Request::CreatePool { fd: shm_fd, size: len as i32 },
                 Arc::new(ShmPoolData),
             )
-            .map_err(GlobalError::from)?;
+            .unwrap_or_else(|_| Proxy::inert(shm.backend().clone()));
         let mmap = unsafe { MmapMut::map_mut(&mem_file)? };
 
         Ok(RawPool { pool, len, mem_file, mmap })
@@ -111,12 +111,12 @@ impl RawPool {
         format: wl_shm::Format,
         udata: U,
         qh: &QueueHandle<D>,
-    ) -> Result<wl_buffer::WlBuffer, InvalidId>
+    ) -> wl_buffer::WlBuffer
     where
         D: Dispatch<wl_buffer::WlBuffer, U> + 'static,
         U: Send + Sync + 'static,
     {
-        Ok(self.pool.create_buffer(offset, width, height, stride, format, qh, udata))
+        self.pool.create_buffer(offset, width, height, stride, format, qh, udata)
     }
 
     /// Create a new buffer to this pool.
@@ -132,17 +132,19 @@ impl RawPool {
         stride: i32,
         format: wl_shm::Format,
         data: Arc<dyn ObjectData + 'static>,
-    ) -> Result<wl_buffer::WlBuffer, InvalidId> {
-        self.pool.send_constructor(
-            wl_shm_pool::Request::CreateBuffer {
-                offset,
-                width,
-                height,
-                stride,
-                format: WEnum::Value(format),
-            },
-            data,
-        )
+    ) -> wl_buffer::WlBuffer {
+        self.pool
+            .send_constructor(
+                wl_shm_pool::Request::CreateBuffer {
+                    offset,
+                    width,
+                    height,
+                    stride,
+                    format: WEnum::Value(format),
+                },
+                data,
+            )
+            .unwrap_or_else(|_| Proxy::inert(self.pool.backend().clone()))
     }
 
     /// Returns the pool object used to communicate with the server.

--- a/src/shm/raw.rs
+++ b/src/shm/raw.rs
@@ -116,9 +116,7 @@ impl RawPool {
         D: Dispatch<wl_buffer::WlBuffer, U> + 'static,
         U: Send + Sync + 'static,
     {
-        let buffer = self.pool.create_buffer(offset, width, height, stride, format, qh, udata)?;
-
-        Ok(buffer)
+        Ok(self.pool.create_buffer(offset, width, height, stride, format, qh, udata))
     }
 
     /// Create a new buffer to this pool.


### PR DESCRIPTION
This is the SCTK side of https://github.com/Smithay/wayland-rs/pull/531 and https://github.com/Smithay/wayland-rs/pull/530 - it moves failures out of the `Arc::new_cyclic` closure, removing the need for the `Option` there.