### PR TITLE
Documentation improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ wayland-client = "=0.30.0-beta.8"
 wayland-protocols = { version = "=0.30.0-beta.8", features = ["client", "unstable"] }
 wayland-protocols-wlr = { version = "=0.1.0-beta.8", features = ["client"] }
 wayland-cursor = "=0.30.0-beta.8"
+wayland-scanner = "=0.30.0-beta.8"
 
 # Explicit dependency until release
 xkbcommon = { git = "https://github.com/rust-x-bindings/xkbcommon-rs", optional = true, features = ["wayland"] }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -4,10 +4,9 @@
 //!
 //! [`RegistryState`] provides an interface to bind globals regularly, creating an object with each new
 //! instantiation or caching bound globals to prevent duplicate object instances from being created. Binding
-//! a global regularly is accomplished through [`RegistryState::bind_once`]. For caching a bound global use
-//! [`RegistryState::bind_cached`].
+//! a global regularly is accomplished through [`RegistryState::bind_one`].
 //!
-//! The [`delegate_registry`] macro is used to implement handling for [`wl_registry`].
+//! The [`delegate_registry`](crate::delegate_registry) macro is used to implement handling for [`wl_registry`].
 //!
 //! ## Sample implementation of [`RegistryHandler`]
 //!
@@ -84,6 +83,8 @@ use wayland_client::{
 /// Delegates that choose to implement this trait may be used in [`registry_handlers`] which
 /// automatically notifies delegates about the creation and destruction of globals.
 ///
+/// [`registry_handlers`]: crate::registry_handlers
+///
 /// Note that in order to delegate registry handling to a type which implements this trait, your `D` data type
 /// must implement [`ProvidesRegistryState`].
 pub trait RegistryHandler<D>
@@ -99,7 +100,7 @@ where
     ///
     /// The provided registry handle may be used to bind the global.  This is not called during
     /// initial enumeration of globals, only for globals added after the calls to
-    /// [`Registryhandler::ready`].  It is primarily useful for multi-instance globals such as
+    /// [`RegistryHandler::ready`].  It is primarily useful for multi-instance globals such as
     /// `wl_output` and `wl_seat`.
     ///
     /// The default implementation does nothing.

--- a/src/shell/layer/mod.rs
+++ b/src/shell/layer/mod.rs
@@ -272,7 +272,7 @@ impl LayerSurface {
 }
 
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SurfaceKind {
     Wlr(zwlr_layer_surface_v1::ZwlrLayerSurfaceV1),
 }

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -85,7 +85,7 @@ impl XdgShellSurface {
     /// Creates an [`XdgShellSurface`].
     ///
     /// This function is generally intended to be called in a higher level abstraction, such as
-    /// [`XdgWindowState::create_window`](self::window::XdgWindowState::create_window).
+    /// [`Window::builder`](self::window::Window::builder).
     ///
     /// The created [`XdgShellSurface`] will destroy the underlying [`XdgSurface`] or [`WlSurface`] when
     /// dropped. Higher level abstractions are responsible for ensuring the destruction order of protocol

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -262,7 +262,7 @@ impl WindowBuilder {
 
     /// Sets the decoration mode the window should be created with.
     ///
-    /// By default the decoration mode is set to [`DecorationMode::RequestServer`] to use server provided
+    /// By default the decoration mode is set to [`DecorationMode::Server`] to use server provided
     /// decorations where possible.
     pub fn decorations(self, decorations: WindowDecorations) -> Self {
         Self { decorations, ..self }

--- a/src/shm/slot.rs
+++ b/src/shm/slot.rs
@@ -78,7 +78,7 @@ struct SlotInner {
     all_refs: AtomicUsize,
 }
 
-/// A [`wl_buffer::WlBuffer`] allocated from a [SlotPool].
+/// A wrapper around a [`wl_buffer::WlBuffer`] which has been allocated via a [SlotPool].
 ///
 /// When this object is dropped, the buffer will be destroyed immediately if it is not active, or
 /// upon the server's release if it is.
@@ -398,9 +398,9 @@ impl Buffer {
     /// This marks the slot as active until the server releases the buffer, which will happen
     /// automatically assuming the surface is committed without attaching a different buffer.
     ///
-    /// Note: if you need to ensure that canvas() calls never return data that could be attached to
-    /// a surface in a multi-threaded client, make this call while you have exclusive access to the
-    /// corresponding SlotPool.
+    /// Note: if you need to ensure that [`canvas()`](Buffer::canvas) calls never return data that
+    /// could be attached to a surface in a multi-threaded client, make this call while you have
+    /// exclusive access to the corresponding [`SlotPool`].
     pub fn attach_to(&self, surface: &wl_surface::WlSurface) -> Result<(), ActivateSlotError> {
         self.activate()?;
         surface.attach(Some(&self.buffer), 0, 0);


### PR DESCRIPTION
1b2aaa92b701a8c04375ce0043b285ca4f2e39d6 is just to make `client-toolkit` build, since it won't build otherwise due to transitive dependencies. I can split that into a separate MR if that's preferring.

Other commits are probably best viewed individually, but they're all documentation tweaks (the one for `OutputState` also serves as a basic doctest too).