### PR TITLE
outputs: Add `logical_position` and `logical_size` properties

### DIFF
--- a/examples/list_outputs.rs
+++ b/examples/list_outputs.rs
@@ -150,6 +150,12 @@ fn print_output(info: &OutputInfo) {
     println!("\tx: {}, y: {}", info.location.0, info.location.1);
     println!("\tsubpixel: {:?}", info.subpixel);
     println!("\tphysical_size: {}×{}mm", info.physical_size.0, info.physical_size.1);
+    if let Some((x, y)) = info.logical_position.as_ref() {
+        println!("\tlogical x: {}, y: {}", x, y);
+    }
+    if let Some((width, height)) = info.logical_size.as_ref() {
+        println!("\tlogical width: {}, height: {}", width, height);
+    }
     println!("\tmodes:");
 
     for mode in &info.modes {


### PR DESCRIPTION
The documentation for `wl_output::mode` and `wl_output::geometry` specifically states to use the information from these `xdg_output` events for "logical" size and position within the "global compositor space". Which may be impacted by scaling and transform. Given this, the properties are not redundant and should be handled.

Testing under Sway, and looking at the implementation of wlroots, `x` and `y` in the `geometry` event are always given as `0`, but the `logical_position` has useful values.