### PR TITLE
Make `RegistryState` depend on use of `registry_queue_init`

### DIFF
--- a/examples/generic_list_seats.rs
+++ b/examples/generic_list_seats.rs
@@ -15,8 +15,8 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut list_seats = ListSeats {
-        registry_state: RegistryState::new(&globals, &conn, &qh),
-        seat_state: SeatState::new(),
+        registry_state: RegistryState::new(&globals),
+        seat_state: SeatState::new(&globals, &qh),
         _dummy: MyTest {},
     };
 

--- a/examples/generic_list_seats.rs
+++ b/examples/generic_list_seats.rs
@@ -4,18 +4,18 @@ use smithay_client_toolkit::{
     registry_handlers,
     seat::{Capability, SeatHandler, SeatState},
 };
-use wayland_client::{protocol::wl_seat, Connection, QueueHandle};
+use wayland_client::{globals::registry_queue_init, protocol::wl_seat, Connection, QueueHandle};
 
 fn main() {
     env_logger::init();
 
     let conn = Connection::connect_to_env().unwrap();
 
-    let mut event_queue = conn.new_event_queue();
+    let (globals, mut event_queue) = registry_queue_init(&conn).unwrap();
     let qh = event_queue.handle();
 
     let mut list_seats = ListSeats {
-        registry_state: RegistryState::new(&conn, &qh),
+        registry_state: RegistryState::new(&globals, &conn, &qh),
         seat_state: SeatState::new(),
         _dummy: MyTest {},
     };

--- a/examples/generic_simple_window.rs
+++ b/examples/generic_simple_window.rs
@@ -36,9 +36,9 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut simple_window = SimpleWindow {
-        registry_state: RegistryState::new(&globals, &conn, &qh),
-        seat_state: SeatState::new(),
-        output_state: OutputState::new(),
+        registry_state: RegistryState::new(&globals),
+        seat_state: SeatState::new(&globals, &qh),
+        output_state: OutputState::new(&globals, &qh),
         compositor_state: CompositorState::bind(&globals, &qh)
             .expect("wl_compositor is not available"),
         shm_state: ShmState::bind(&globals, &qh).expect("wl_shm is not available"),
@@ -58,10 +58,6 @@ fn main() {
         pointer: None,
         _dummy: MyTest {},
     };
-
-    while !simple_window.registry_state.ready() {
-        event_queue.blocking_dispatch(&mut simple_window).unwrap();
-    }
 
     let pool = SlotPool::new(
         simple_window.width as usize * simple_window.height as usize * 4,

--- a/examples/generic_simple_window.rs
+++ b/examples/generic_simple_window.rs
@@ -22,9 +22,9 @@ use smithay_client_toolkit::{
     },
 };
 use wayland_client::{
-    globals::{registry_queue_init, GlobalListContents},
-    protocol::{wl_keyboard, wl_output, wl_pointer, wl_registry, wl_seat, wl_shm, wl_surface},
-    Connection, Dispatch, QueueHandle,
+    globals::registry_queue_init,
+    protocol::{wl_keyboard, wl_output, wl_pointer, wl_seat, wl_shm, wl_surface},
+    Connection, QueueHandle,
 };
 
 fn main() {
@@ -36,7 +36,7 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut simple_window = SimpleWindow {
-        registry_state: RegistryState::new(&conn, &qh),
+        registry_state: RegistryState::new(&globals, &conn, &qh),
         seat_state: SeatState::new(),
         output_state: OutputState::new(),
         compositor_state: CompositorState::bind(&globals, &qh)
@@ -455,17 +455,4 @@ impl<T: Test + 'static> ProvidesRegistryState for SimpleWindow<T> {
         &mut self.registry_state
     }
     registry_handlers![OutputState, SeatState,];
-}
-
-impl<T: Test + 'static> Dispatch<wl_registry::WlRegistry, GlobalListContents> for SimpleWindow<T> {
-    fn event(
-        _state: &mut Self,
-        _registry: &wl_registry::WlRegistry,
-        _event: wl_registry::Event,
-        _data: &GlobalListContents,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-    ) {
-        // We don't need any other globals.
-    }
 }

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -17,9 +17,9 @@ use smithay_client_toolkit::{
     },
 };
 use wayland_client::{
-    globals::{registry_queue_init, GlobalListContents},
-    protocol::{wl_output, wl_registry, wl_shm, wl_surface},
-    Connection, Dispatch, QueueHandle,
+    globals::registry_queue_init,
+    protocol::{wl_output, wl_shm, wl_surface},
+    Connection, QueueHandle,
 };
 
 fn main() {
@@ -31,7 +31,7 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut state = State {
-        registry_state: RegistryState::new(&conn, &qh),
+        registry_state: RegistryState::new(&globals, &conn, &qh),
         output_state: OutputState::new(),
         compositor_state: CompositorState::bind(&globals, &qh)
             .expect("wl_compositor not available"),
@@ -301,17 +301,4 @@ impl ProvidesRegistryState for State {
     }
 
     registry_handlers!(OutputState);
-}
-
-impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for State {
-    fn event(
-        _state: &mut Self,
-        _registry: &wl_registry::WlRegistry,
-        _event: wl_registry::Event,
-        _data: &GlobalListContents,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-    ) {
-        // We don't need any other globals.
-    }
 }

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -31,8 +31,8 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut state = State {
-        registry_state: RegistryState::new(&globals, &conn, &qh),
-        output_state: OutputState::new(),
+        registry_state: RegistryState::new(&globals),
+        output_state: OutputState::new(&globals, &qh),
         compositor_state: CompositorState::bind(&globals, &qh)
             .expect("wl_compositor not available"),
         shm_state: ShmState::bind(&globals, &qh).expect("wl_shm not available"),
@@ -42,10 +42,6 @@ fn main() {
         pool: None,
         windows: Vec::new(),
     };
-
-    while !state.registry_state.ready() {
-        event_queue.blocking_dispatch(&mut state).unwrap();
-    }
 
     let mut pool_size = 0;
 

--- a/examples/image_viewporter.rs
+++ b/examples/image_viewporter.rs
@@ -32,8 +32,8 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut state = State {
-        registry_state: RegistryState::new(&globals, &conn, &qh),
-        output_state: OutputState::new(),
+        registry_state: RegistryState::new(&globals),
+        output_state: OutputState::new(&globals, &qh),
         compositor_state: CompositorState::bind(&globals, &qh)
             .expect("wl_compositor not available"),
         shm_state: ShmState::bind(&globals, &qh).expect("wl_shm not available"),
@@ -44,10 +44,6 @@ fn main() {
         pool: None,
         windows: Vec::new(),
     };
-
-    while !state.registry_state.ready() {
-        event_queue.blocking_dispatch(&mut state).unwrap();
-    }
 
     let mut pool_size = 0;
 

--- a/examples/image_viewporter.rs
+++ b/examples/image_viewporter.rs
@@ -14,8 +14,8 @@ use smithay_client_toolkit::{
     shm::{slot::SlotPool, ShmHandler, ShmState},
 };
 use wayland_client::{
-    globals::{registry_queue_init, GlobalListContents},
-    protocol::{wl_output, wl_registry, wl_shm, wl_surface},
+    globals::registry_queue_init,
+    protocol::{wl_output, wl_shm, wl_surface},
     Connection, Dispatch, QueueHandle,
 };
 use wayland_protocols::wp::viewporter::client::{
@@ -32,7 +32,7 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut state = State {
-        registry_state: RegistryState::new(&conn, &qh),
+        registry_state: RegistryState::new(&globals, &conn, &qh),
         output_state: OutputState::new(),
         compositor_state: CompositorState::bind(&globals, &qh)
             .expect("wl_compositor not available"),
@@ -310,18 +310,5 @@ impl Dispatch<WpViewport, ()> for State {
 impl Drop for ImageViewer {
     fn drop(&mut self) {
         self.viewport.destroy()
-    }
-}
-
-impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for State {
-    fn event(
-        _state: &mut Self,
-        _registry: &wl_registry::WlRegistry,
-        _event: wl_registry::Event,
-        _data: &GlobalListContents,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-    ) {
-        // We don't need any other globals.
     }
 }

--- a/examples/list_outputs.rs
+++ b/examples/list_outputs.rs
@@ -24,10 +24,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Initialize the registry handling so other parts of Smithay's client toolkit may bind
     // globals.
-    let registry_state = RegistryState::new(&globals, &conn, &qh);
+    let registry_state = RegistryState::new(&globals);
 
     // Initialize the delegate we will use for outputs.
-    let output_delegate = OutputState::new();
+    let output_delegate = OutputState::new(&globals, &qh);
 
     // Set up application state.
     //
@@ -35,15 +35,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     // application is running.
     let mut list_outputs = ListOutputs { registry_state, output_state: output_delegate };
 
-    // Send requests to the server and block until we receive events from the server.
-    while !list_outputs.registry_state.ready() {
-        event_queue.blocking_dispatch(&mut list_outputs)?;
-    }
-
-    // We do this again here because the first time we let the delegates bind their globals.
+    // `OutputState::new()` binds the output globals found in `registry_queue_init()`.
     //
-    // After the delegates have bound their globals and created the necessary objects, we need to dispatch
-    // again so that events may be sent to the newly created objects.
+    // After the globals are bound, we need to dispatch again so that events may be sent to the newly
+    // created objects.
     event_queue.roundtrip(&mut list_outputs)?;
 
     // Now our outputs have been initialized with data, we may access what outputs exist and information about

--- a/examples/list_outputs.rs
+++ b/examples/list_outputs.rs
@@ -8,7 +8,7 @@ use smithay_client_toolkit::{
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
 };
-use wayland_client::{protocol::wl_output, Connection, QueueHandle};
+use wayland_client::{globals::registry_queue_init, protocol::wl_output, Connection, QueueHandle};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // We initialize the logger for the purpose of debugging.
@@ -19,12 +19,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let conn = Connection::connect_to_env()?;
 
     // Now create an event queue and a handle to the queue so we can create objects.
-    let mut event_queue = conn.new_event_queue();
+    let (globals, mut event_queue) = registry_queue_init(&conn).unwrap();
     let qh = event_queue.handle();
 
     // Initialize the registry handling so other parts of Smithay's client toolkit may bind
     // globals.
-    let registry_state = RegistryState::new(&conn, &qh);
+    let registry_state = RegistryState::new(&globals, &conn, &qh);
 
     // Initialize the delegate we will use for outputs.
     let output_delegate = OutputState::new();

--- a/examples/list_seats.rs
+++ b/examples/list_seats.rs
@@ -15,11 +15,10 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut list_seats = ListSeats {
-        registry_state: RegistryState::new(&globals, &conn, &qh),
-        seat_state: SeatState::new(),
+        registry_state: RegistryState::new(&globals),
+        seat_state: SeatState::new(&globals, &qh),
     };
 
-    event_queue.blocking_dispatch(&mut list_seats).unwrap();
     event_queue.blocking_dispatch(&mut list_seats).unwrap();
 
     println!("Available seats:");

--- a/examples/list_seats.rs
+++ b/examples/list_seats.rs
@@ -4,18 +4,20 @@ use smithay_client_toolkit::{
     registry_handlers,
     seat::{Capability, SeatHandler, SeatState},
 };
-use wayland_client::{protocol::wl_seat, Connection, QueueHandle};
+use wayland_client::{globals::registry_queue_init, protocol::wl_seat, Connection, QueueHandle};
 
 fn main() {
     env_logger::init();
 
     let conn = Connection::connect_to_env().unwrap();
 
-    let mut event_queue = conn.new_event_queue();
+    let (globals, mut event_queue) = registry_queue_init(&conn).unwrap();
     let qh = event_queue.handle();
 
-    let mut list_seats =
-        ListSeats { registry_state: RegistryState::new(&conn, &qh), seat_state: SeatState::new() };
+    let mut list_seats = ListSeats {
+        registry_state: RegistryState::new(&globals, &conn, &qh),
+        seat_state: SeatState::new(),
+    };
 
     event_queue.blocking_dispatch(&mut list_seats).unwrap();
     event_queue.blocking_dispatch(&mut list_seats).unwrap();

--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -35,9 +35,9 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut simple_layer = SimpleLayer {
-        registry_state: RegistryState::new(&globals, &conn, &qh),
-        seat_state: SeatState::new(),
-        output_state: OutputState::new(),
+        registry_state: RegistryState::new(&globals),
+        seat_state: SeatState::new(&globals, &qh),
+        output_state: OutputState::new(&globals, &qh),
         compositor_state: CompositorState::bind(&globals, &qh)
             .expect("wl_compositor is not available"),
         shm_state: ShmState::bind(&globals, &qh).expect("wl_shm is not available"),
@@ -54,10 +54,6 @@ fn main() {
         keyboard_focus: false,
         pointer: None,
     };
-
-    while !simple_layer.registry_state.ready() {
-        event_queue.blocking_dispatch(&mut simple_layer).unwrap();
-    }
 
     let pool = SlotPool::new(
         simple_layer.width as usize * simple_layer.height as usize * 4,

--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -21,9 +21,9 @@ use smithay_client_toolkit::{
     shm::{slot::SlotPool, ShmHandler, ShmState},
 };
 use wayland_client::{
-    globals::{registry_queue_init, GlobalListContents},
-    protocol::{wl_keyboard, wl_output, wl_pointer, wl_registry, wl_seat, wl_shm, wl_surface},
-    Connection, Dispatch, QueueHandle,
+    globals::registry_queue_init,
+    protocol::{wl_keyboard, wl_output, wl_pointer, wl_seat, wl_shm, wl_surface},
+    Connection, QueueHandle,
 };
 
 fn main() {
@@ -35,7 +35,7 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut simple_layer = SimpleLayer {
-        registry_state: RegistryState::new(&conn, &qh),
+        registry_state: RegistryState::new(&globals, &conn, &qh),
         seat_state: SeatState::new(),
         output_state: OutputState::new(),
         compositor_state: CompositorState::bind(&globals, &qh)
@@ -416,17 +416,4 @@ impl ProvidesRegistryState for SimpleLayer {
         &mut self.registry_state
     }
     registry_handlers![OutputState, SeatState];
-}
-
-impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for SimpleLayer {
-    fn event(
-        _state: &mut Self,
-        _registry: &wl_registry::WlRegistry,
-        _event: wl_registry::Event,
-        _data: &GlobalListContents,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-    ) {
-        // We don't need any other globals.
-    }
 }

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -36,9 +36,9 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut simple_window = SimpleWindow {
-        registry_state: RegistryState::new(&globals, &conn, &qh),
-        seat_state: SeatState::new(),
-        output_state: OutputState::new(),
+        registry_state: RegistryState::new(&globals),
+        seat_state: SeatState::new(&globals, &qh),
+        output_state: OutputState::new(&globals, &qh),
         compositor_state: CompositorState::bind(&globals, &qh)
             .expect("wl_compositor not available"),
         shm_state: ShmState::bind(&globals, &qh).expect("wl_shm not available"),
@@ -57,10 +57,6 @@ fn main() {
         keyboard_focus: false,
         pointer: None,
     };
-
-    while !simple_window.registry_state.ready() {
-        event_queue.blocking_dispatch(&mut simple_window).unwrap();
-    }
 
     let pool = SlotPool::new(
         simple_window.width as usize * simple_window.height as usize * 4,

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -22,9 +22,9 @@ use smithay_client_toolkit::{
     },
 };
 use wayland_client::{
-    globals::{registry_queue_init, GlobalListContents},
-    protocol::{wl_keyboard, wl_output, wl_pointer, wl_registry, wl_seat, wl_shm, wl_surface},
-    Connection, Dispatch, QueueHandle,
+    globals::registry_queue_init,
+    protocol::{wl_keyboard, wl_output, wl_pointer, wl_seat, wl_shm, wl_surface},
+    Connection, QueueHandle,
 };
 
 fn main() {
@@ -36,7 +36,7 @@ fn main() {
     let qh = event_queue.handle();
 
     let mut simple_window = SimpleWindow {
-        registry_state: RegistryState::new(&conn, &qh),
+        registry_state: RegistryState::new(&globals, &conn, &qh),
         seat_state: SeatState::new(),
         output_state: OutputState::new(),
         compositor_state: CompositorState::bind(&globals, &qh)
@@ -443,17 +443,4 @@ impl ProvidesRegistryState for SimpleWindow {
         &mut self.registry_state
     }
     registry_handlers![OutputState, SeatState,];
-}
-
-impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for SimpleWindow {
-    fn event(
-        _state: &mut Self,
-        _registry: &wl_registry::WlRegistry,
-        _event: wl_registry::Event,
-        _data: &GlobalListContents,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-    ) {
-        // We don't need any other globals.
-    }
 }

--- a/examples/wgpu.rs
+++ b/examples/wgpu.rs
@@ -13,9 +13,9 @@ use smithay_client_toolkit::{
     },
 };
 use wayland_client::{
-    globals::{registry_queue_init, GlobalListContents},
-    protocol::{wl_output, wl_registry, wl_seat, wl_surface},
-    Connection, Dispatch, Proxy, QueueHandle,
+    globals::registry_queue_init,
+    protocol::{wl_output, wl_seat, wl_surface},
+    Connection, Proxy, QueueHandle,
 };
 
 fn main() {
@@ -76,9 +76,9 @@ fn main() {
         .expect("Failed to request device");
 
     let mut wgpu = Wgpu {
-        registry_state: RegistryState::new(&conn, &qh),
-        seat_state: SeatState::new(),
-        output_state: OutputState::new(),
+        registry_state: RegistryState::new(&globals),
+        seat_state: SeatState::new(&globals, &qh),
+        output_state: OutputState::new(&globals, &qh),
 
         exit: false,
         width: 256,
@@ -89,10 +89,6 @@ fn main() {
         adapter,
         queue,
     };
-
-    while !wgpu.registry_state.ready() {
-        event_queue.blocking_dispatch(&mut wgpu).unwrap();
-    }
 
     // We don't draw immediately, the configure will notify us when to first draw.
     loop {
@@ -287,17 +283,4 @@ impl ProvidesRegistryState for Wgpu {
         &mut self.registry_state
     }
     registry_handlers![OutputState];
-}
-
-impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for Wgpu {
-    fn event(
-        _state: &mut Self,
-        _registry: &wl_registry::WlRegistry,
-        _event: wl_registry::Event,
-        _data: &GlobalListContents,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-    ) {
-        // We don't need any other globals.
-    }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -14,7 +14,8 @@
 //! use smithay_client_toolkit::reexports::client::{
 //!     Connection, Dispatch, QueueHandle,
 //!     delegate_dispatch,
-//!     protocol::wl_compositor,
+//!     globals::GlobalList,
+//!     protocol::wl_output,
 //! };
 //!
 //! use smithay_client_toolkit::registry::{
@@ -30,15 +31,14 @@
 //!
 //! /// The delegate a global should be provided to.
 //! struct Delegate {
-//!     // You usually want to cache the bound global so you can use it later
-//!     compositor: GlobalProxy<wl_compositor::WlCompositor>,
+//!     outputs: Vec<wl_output::WlOutput>,
 //! }
 //!
 //! // When implementing RegistryHandler, you must be able to dispatch any type you could bind using the registry state.
 //! impl<D> RegistryHandler<D> for Delegate
 //! where
 //!     // In order to bind a global, you must statically assert the global may be handled with the data type.
-//!     D: Dispatch<wl_compositor::WlCompositor, ()>
+//!     D: Dispatch<wl_output::WlOutput, ()>
 //!         // ProvidesRegistryState provides a function to access the RegistryState within the impl.
 //!         + ProvidesRegistryState
 //!         // We need some way to access our part of the application's state.  This uses AsMut,
@@ -46,18 +46,20 @@
 //!         + AsMut<Delegate>
 //!         + 'static,
 //! {
-//!     // When all globals have been enumerated, this is called.
-//!     fn ready(
-//!         data: &mut D,
-//!         conn: &Connection,
-//!         qh: &QueueHandle<D>,
-//!     ) {
-//!         // Bind the global and store it in our state.
-//!         data.as_mut().compositor = data.registry().bind_one(
-//!             qh,
-//!             1..=2, // we want to bind version 1 or 2 of the global.
-//!             (), // and we provide the user data for the wl_compositor being created.
-//!         ).into();
+//!   /// New global added after initial enumeration.
+//!    fn new_global(
+//!        data: &mut D,
+//!        conn: &Connection,
+//!        qh: &QueueHandle<D>,
+//!        name: u32,
+//!        interface: &str,
+//!        version: u32,
+//!    ) {
+//!         if interface == "wl_output" {
+//!             // Bind `wl_output` with newest version from 1 to 4 the compositor supports
+//!             let output = data.registry().bind_specific(qh, name, 1..=4, ()).unwrap();
+//!             data.as_mut().outputs.push(output);
+//!         }
 //!
 //!         // You could either handle errors here or when attempting to use the interface.  Most
 //!         // Wayland protocols are optional, so if your application can function without a
@@ -70,7 +72,7 @@
 use crate::{error::GlobalError, globals::ProvidesBoundGlobal};
 use wayland_client::{
     globals::{BindError, Global, GlobalList, GlobalListContents},
-    protocol::{wl_callback, wl_registry},
+    protocol::wl_registry,
     Connection, Dispatch, Proxy, QueueHandle,
 };
 
@@ -88,11 +90,6 @@ pub trait RegistryHandler<D>
 where
     D: ProvidesRegistryState,
 {
-    /// Called when initial enumeration of globals has been completed.
-    ///
-    /// This should be used to bind capability globals.
-    fn ready(data: &mut D, conn: &Connection, qh: &QueueHandle<D>);
-
     /// Called when a new global has been advertised by the compositor.
     ///
     /// The provided registry handle may be used to bind the global.  This is not called during
@@ -134,9 +131,6 @@ pub trait ProvidesRegistryState: Sized {
     /// Returns a mutable reference to the registry state.
     fn registry(&mut self) -> &mut RegistryState;
 
-    /// Called when initial enumeration of globals has been completed.
-    fn global_enumeration_finished(&mut self, conn: &Connection, qh: &QueueHandle<Self>);
-
     /// Called when a new global has been advertised by the compositor.
     ///
     /// This is not called during initial global enumeration.
@@ -166,45 +160,21 @@ pub trait ProvidesRegistryState: Sized {
 pub struct RegistryState {
     registry: wl_registry::WlRegistry,
     globals: Vec<Global>,
-    ready: bool,
 }
 
 impl RegistryState {
     /// Creates a new registry handle.
     ///
     /// This type may be used to bind globals as they are advertised.
-    pub fn new<D>(global_list: &GlobalList, conn: &Connection, qh: &QueueHandle<D>) -> Self
-    where
-        D: Dispatch<wl_registry::WlRegistry, GlobalListContents>
-            + Dispatch<wl_callback::WlCallback, RegistryReady>
-            + ProvidesRegistryState
-            + 'static,
-    {
+    pub fn new(global_list: &GlobalList) -> Self {
         let registry = global_list.registry().clone();
         let globals = global_list.contents().clone_list();
-        conn.display().sync(qh, RegistryReady);
 
-        RegistryState { registry, globals, ready: false }
-    }
-
-    /// Uses an existing WlRegistry for handling registry state.
-    ///
-    /// Note: prefer using [Self::new] unless you need access to the registry for other reasons.
-    ///
-    /// You will need to ensure the RegistryReady signal is sent to this object after initial
-    /// enumeration of the registry is complete.
-    pub fn from_registry(registry: wl_registry::WlRegistry) -> Self {
-        RegistryState { registry, globals: Vec::new(), ready: false }
+        RegistryState { registry, globals }
     }
 
     pub fn registry(&self) -> &wl_registry::WlRegistry {
         &self.registry
-    }
-
-    /// Returns true if the registry has completed the initial enumeration of globals and is ready
-    /// to serve bind requests.
-    pub fn ready(&self) -> bool {
-        self.ready
     }
 
     /// Returns an iterator over all globals.
@@ -242,31 +212,7 @@ impl RegistryState {
         I: Proxy + 'static,
         U: Send + Sync + 'static,
     {
-        let iface = I::interface();
-        if *version.end() > iface.version {
-            // This is a panic because it's a compile-time programmer error, not a runtime error.
-            panic!("Maximum version ({}) of {} was higher than the proxy's maximum version ({}); outdated wayland XML files?",
-                version.end(), iface.name, iface.version);
-        }
-        if *version.end() < iface.version {
-            // This is a reminder to evaluate the new API and bump the maximum in order to be able
-            // to use new APIs.  Actual use of new APIs still needs runtime version checks.
-            log::trace!(target: "sctk", "Version {} of {} is available; binding is currently limited to {}", iface.version, iface.name, version.end());
-        }
-        for global in &self.globals {
-            if global.interface != iface.name {
-                continue;
-            }
-            if global.version < *version.start() {
-                return Err(BindError::UnsupportedVersion);
-            }
-            let version = global.version.min(*version.end());
-            let proxy = self.registry.bind(global.name, version, qh, udata);
-            log::debug!(target: "sctk", "Bound new global [{}] {} v{}", global.name, iface.name, version);
-
-            return Ok(proxy);
-        }
-        Err(BindError::NotPresent)
+        bind_one(&self.registry, &self.globals, qh, version, udata)
     }
 
     /// Binds a global, returning a new object associated with the global.
@@ -313,7 +259,7 @@ impl RegistryState {
         &self,
         qh: &QueueHandle<D>,
         version: std::ops::RangeInclusive<u32>,
-        mut make_udata: F,
+        make_udata: F,
     ) -> Result<Vec<I>, BindError>
     where
         D: Dispatch<I, U> + 'static,
@@ -321,28 +267,7 @@ impl RegistryState {
         F: FnMut(u32) -> U,
         U: Send + Sync + 'static,
     {
-        let iface = I::interface();
-        if *version.end() > iface.version {
-            // This is a panic because it's a compile-time programmer error, not a runtime error.
-            panic!("Maximum version ({}) was higher than the proxy's maximum version ({}); outdated wayland XML files?",
-                version.end(), iface.version);
-        }
-        let mut rv = Vec::new();
-        for global in &self.globals {
-            if global.interface != iface.name {
-                continue;
-            }
-            if global.version < *version.start() {
-                return Err(BindError::UnsupportedVersion);
-            }
-            let version = global.version.min(*version.end());
-            let udata = make_udata(global.name);
-            let proxy = self.registry.bind(global.name, version, qh, udata);
-            log::debug!(target: "sctk", "Bound new global [{}] {} v{}", global.name, iface.name, version);
-
-            rv.push(proxy);
-        }
-        Ok(rv)
+        bind_all(&self.registry, &self.globals, qh, version, make_udata)
     }
 }
 
@@ -379,11 +304,6 @@ macro_rules! delegate_registry {
                 $crate::reexports::client::protocol::wl_registry::WlRegistry: $crate::reexports::client::globals::GlobalListContents
             ]  => $crate::registry::RegistryState
         );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::client::protocol::wl_callback::WlCallback: $crate::registry::RegistryReady
-            ]  => $crate::registry::RegistryState
-        );
     };
 }
 
@@ -403,17 +323,13 @@ where
             wl_registry::Event::Global { name, interface, version } => {
                 let iface = interface.clone();
                 state.registry().globals.push(Global { name, interface, version });
-                if state.registry().ready {
-                    state.runtime_add_global(conn, qh, name, &iface, version);
-                }
+                state.runtime_add_global(conn, qh, name, &iface, version);
             }
 
             wl_registry::Event::GlobalRemove { name } => {
                 if let Some(i) = state.registry().globals.iter().position(|g| g.name == name) {
                     let global = state.registry().globals.swap_remove(i);
-                    if state.registry().ready {
-                        state.runtime_remove_global(conn, qh, name, &global.interface);
-                    }
+                    state.runtime_remove_global(conn, qh, name, &global.interface);
                 }
             }
 
@@ -421,27 +337,6 @@ where
         }
     }
 }
-
-impl<D> Dispatch<wl_callback::WlCallback, RegistryReady, D> for RegistryState
-where
-    D: Dispatch<wl_callback::WlCallback, RegistryReady> + ProvidesRegistryState,
-{
-    fn event(
-        state: &mut D,
-        _: &wl_callback::WlCallback,
-        _: wl_callback::Event,
-        _: &RegistryReady,
-        conn: &Connection,
-        qh: &QueueHandle<D>,
-    ) {
-        state.registry().ready = true;
-        state.global_enumeration_finished(conn, qh);
-    }
-}
-
-/// A helper that sets [RegistryState::ready] when enumeration is finished.
-#[derive(Debug)]
-pub struct RegistryReady;
 
 /// A helper for storing a bound global.
 ///
@@ -501,10 +396,6 @@ pub struct SimpleGlobal<I, const MAX_VERSION: u32> {
 }
 
 impl<I: Proxy + 'static, const MAX_VERSION: u32> SimpleGlobal<I, MAX_VERSION> {
-    pub fn not_ready() -> Self {
-        Self { proxy: GlobalProxy::NotReady }
-    }
-
     pub fn bind<State>(globals: &GlobalList, qh: &QueueHandle<State>) -> Result<Self, BindError>
     where
         State: Dispatch<I, (), State> + 'static,
@@ -530,16 +421,6 @@ impl<I: Proxy + Clone, const MAX_VERSION: u32> ProvidesBoundGlobal<I, MAX_VERSIO
     }
 }
 
-impl<D, I, const MAX_VERSION: u32> RegistryHandler<D> for SimpleGlobal<I, MAX_VERSION>
-where
-    D: ProvidesRegistryState + AsMut<Self> + Dispatch<I, ()> + 'static,
-    I: Proxy + 'static,
-{
-    fn ready(data: &mut D, _: &Connection, qh: &QueueHandle<D>) {
-        data.as_mut().proxy = data.registry().bind_one(qh, 0..=MAX_VERSION, ()).into();
-    }
-}
-
 impl<D, I, const MAX_VERSION: u32> Dispatch<I, (), D> for SimpleGlobal<I, MAX_VERSION>
 where
     D: Dispatch<I, ()>,
@@ -548,6 +429,84 @@ where
     fn event(_: &mut D, _: &I, _: <I as Proxy>::Event, _: &(), _: &Connection, _: &QueueHandle<D>) {
         unreachable!("SimpleGlobal is not suitable for {} which has events", I::interface().name);
     }
+}
+
+/// Binds all globals with a given interface.
+pub(crate) fn bind_all<I, D, U, F>(
+    registry: &wl_registry::WlRegistry,
+    globals: &[Global],
+    qh: &QueueHandle<D>,
+    version: std::ops::RangeInclusive<u32>,
+    mut make_udata: F,
+) -> Result<Vec<I>, BindError>
+where
+    D: Dispatch<I, U> + 'static,
+    I: Proxy + 'static,
+    F: FnMut(u32) -> U,
+    U: Send + Sync + 'static,
+{
+    let iface = I::interface();
+    if *version.end() > iface.version {
+        // This is a panic because it's a compile-time programmer error, not a runtime error.
+        panic!("Maximum version ({}) was higher than the proxy's maximum version ({}); outdated wayland XML files?",
+            version.end(), iface.version);
+    }
+    let mut rv = Vec::new();
+    for global in globals {
+        if global.interface != iface.name {
+            continue;
+        }
+        if global.version < *version.start() {
+            return Err(BindError::UnsupportedVersion);
+        }
+        let version = global.version.min(*version.end());
+        let udata = make_udata(global.name);
+        let proxy = registry.bind(global.name, version, qh, udata);
+        log::debug!(target: "sctk", "Bound new global [{}] {} v{}", global.name, iface.name, version);
+
+        rv.push(proxy);
+    }
+    Ok(rv)
+}
+
+/// Binds a global, returning a new object associated with the global.
+pub(crate) fn bind_one<I, D, U>(
+    registry: &wl_registry::WlRegistry,
+    globals: &[Global],
+    qh: &QueueHandle<D>,
+    version: std::ops::RangeInclusive<u32>,
+    udata: U,
+) -> Result<I, BindError>
+where
+    D: Dispatch<I, U> + 'static,
+    I: Proxy + 'static,
+    U: Send + Sync + 'static,
+{
+    let iface = I::interface();
+    if *version.end() > iface.version {
+        // This is a panic because it's a compile-time programmer error, not a runtime error.
+        panic!("Maximum version ({}) of {} was higher than the proxy's maximum version ({}); outdated wayland XML files?",
+            version.end(), iface.name, iface.version);
+    }
+    if *version.end() < iface.version {
+        // This is a reminder to evaluate the new API and bump the maximum in order to be able
+        // to use new APIs.  Actual use of new APIs still needs runtime version checks.
+        log::trace!(target: "sctk", "Version {} of {} is available; binding is currently limited to {}", iface.version, iface.name, version.end());
+    }
+    for global in globals {
+        if global.interface != iface.name {
+            continue;
+        }
+        if global.version < *version.start() {
+            return Err(BindError::UnsupportedVersion);
+        }
+        let version = global.version.min(*version.end());
+        let proxy = registry.bind(global.name, version, qh, udata);
+        log::debug!(target: "sctk", "Bound new global [{}] {} v{}", global.name, iface.name, version);
+
+        return Ok(proxy);
+    }
+    Err(BindError::NotPresent)
 }
 
 #[macro_export]
@@ -565,16 +524,6 @@ macro_rules! delegate_simple {
 #[macro_export]
 macro_rules! registry_handlers {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $($ty:ty),* $(,)?) => {
-        fn global_enumeration_finished(
-            &mut self,
-            conn: &$crate::reexports::client::Connection,
-            qh: &$crate::reexports::client::QueueHandle<Self>,
-        ) {
-            $(
-                <$ty as $crate::registry::RegistryHandler<Self>>::ready(self, conn, qh);
-            )*
-        }
-
         fn runtime_add_global(
             &mut self,
             conn: &$crate::reexports::client::Connection,

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use wayland_client::{
+    globals::GlobalList,
     protocol::{wl_pointer, wl_seat, wl_touch},
     Connection, Dispatch, Proxy, QueueHandle,
 };
@@ -61,8 +62,28 @@ pub struct SeatState {
 }
 
 impl SeatState {
-    pub fn new() -> SeatState {
-        SeatState { seats: vec![] }
+    pub fn new<D: Dispatch<wl_seat::WlSeat, SeatData> + 'static>(
+        global_list: &GlobalList,
+        qh: &QueueHandle<D>,
+    ) -> SeatState {
+        let seats = global_list.contents().with_list(|globals| {
+            crate::registry::bind_all(global_list.registry(), globals, qh, 1..=7, |id| SeatData {
+                has_keyboard: Arc::new(AtomicBool::new(false)),
+                has_pointer: Arc::new(AtomicBool::new(false)),
+                has_touch: Arc::new(AtomicBool::new(false)),
+                name: Arc::new(Mutex::new(None)),
+                id,
+            })
+            .expect("failed to bind global")
+        });
+
+        let mut state = SeatState { seats: vec![] };
+        for seat in seats {
+            let data = seat.data::<SeatData>().unwrap().clone();
+
+            state.seats.push(SeatInner { seat: seat.clone(), data });
+        }
+        state
     }
 
     /// Returns an iterator over all the seats.
@@ -354,26 +375,6 @@ impl<D> RegistryHandler<D> for SeatState
 where
     D: Dispatch<wl_seat::WlSeat, SeatData> + SeatHandler + ProvidesRegistryState + 'static,
 {
-    fn ready(state: &mut D, conn: &Connection, qh: &QueueHandle<D>) {
-        let seats = state
-            .registry()
-            .bind_all(qh, 1..=7, |id| SeatData {
-                has_keyboard: Arc::new(AtomicBool::new(false)),
-                has_pointer: Arc::new(AtomicBool::new(false)),
-                has_touch: Arc::new(AtomicBool::new(false)),
-                name: Arc::new(Mutex::new(None)),
-                id,
-            })
-            .expect("failed to bind global");
-
-        for seat in seats {
-            let data = seat.data::<SeatData>().unwrap().clone();
-
-            state.seat_state().seats.push(SeatInner { seat: seat.clone(), data });
-            state.new_seat(conn, qh, seat);
-        }
-    }
-
     fn new_global(
         state: &mut D,
         conn: &Connection,


### PR DESCRIPTION
This prevents the need to create two registry objects in examples like `simple_window`, and eliminates the need to manually implement `Dispatch`.

This would perhaps make it harder if an application wants to handle custom globals, instead of just putting that in the `Dispatch` implementation, but if the `RegistryState` helper doesn't already provide an ergonomic way to do that, maybe the way the `ProvidesRegistryState` trait and `registry_handlers!` macro work isn't ideal?

Leaving as a draft because I think it might be good to remove `ready()` and make things like `OutputState::new()` also take a `&GlobalList`. But does this seem like a generally good approach?