### PR TITLE
Update nix to 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bitflags = "1.0"
-nix = { version = "0.24.1", default-features = false, features = ["fs", "mman"] }
+nix = { version = "0.25", default-features = false, features = ["fs", "mman"] }
 dlib = "0.5"
 lazy_static = "1.0"
 memmap2 = "0.5.0"


### PR DESCRIPTION
`calloop` depends on 0.25, so this avoid having two versions in the dependency tree.