### PR TITLE
seat: remove mut from `ThemedPointer::set_cursor`

### DIFF
--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -196,7 +196,6 @@ impl SeatState {
             ThemedPointer {
                 themes: Arc::new(Mutex::new(Themes::new(theme))),
                 pointer: wl_ptr,
-                current_ptr: "left_ptr".to_string(),
                 scale,
             },
         ))


### PR DESCRIPTION
The mut was basically never used.