### PR TITLE
seat/pointer: fix `ThemedPointer::set_cursor` udata

### DIFF
--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -134,7 +134,7 @@ impl SeatState {
         seat: &wl_seat::WlSeat,
         theme: ThemeSpec,
         scale: i32,
-    ) -> Result<(wl_pointer::WlPointer, ThemedPointer), SeatError>
+    ) -> Result<(wl_pointer::WlPointer, ThemedPointer<PointerData>), SeatError>
     where
         D: Dispatch<wl_pointer::WlPointer, PointerData> + PointerHandler + 'static,
     {
@@ -178,7 +178,7 @@ impl SeatState {
         theme: ThemeSpec,
         scale: i32,
         pointer_data: U,
-    ) -> Result<(wl_pointer::WlPointer, ThemedPointer), SeatError>
+    ) -> Result<(wl_pointer::WlPointer, ThemedPointer<U>), SeatError>
     where
         D: Dispatch<wl_pointer::WlPointer, U> + PointerHandler + 'static,
         U: PointerDataExt + 'static,
@@ -197,6 +197,7 @@ impl SeatState {
                 themes: Arc::new(Mutex::new(Themes::new(theme))),
                 pointer: wl_ptr,
                 scale,
+                _marker: std::marker::PhantomData,
             },
         ))
     }


### PR DESCRIPTION
The `ThemedPointer` always assumed that it's being used with the `PointerData` leading to issues when used with custom udata.

--

Not sure if that's an ideal solution, maybe you can somehow avoid generic param all-together. 