### PR TITLE
Remove `GlobalProxy::NotReady` variant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,8 +8,4 @@ pub enum GlobalError {
     /// A compositor global was available, but did not support the given minimum version
     #[error("the '{name}' global does not support interface version {required} (using version {available})")]
     InvalidVersion { name: &'static str, required: u32, available: u32 },
-
-    /// This is likely a programming error due to a missing entry in the registry_handlers! macro.
-    #[error("global enumeration is not finished or missing ProvidesRegistryState delegation")]
-    NotReady,
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -344,9 +344,6 @@ where
 /// that cache a bound global.
 #[derive(Debug)]
 pub enum GlobalProxy<I> {
-    /// Initial state: registry has not yet finished enumeration or there is a missing
-    /// [RegistryHandler] delegtation.
-    NotReady,
     /// The requested global was not present after a complete enumeration.
     NotPresent,
     /// The cached global.
@@ -363,10 +360,6 @@ impl<I> From<Result<I, BindError>> for GlobalProxy<I> {
 }
 
 impl<I: Proxy> GlobalProxy<I> {
-    pub fn new() -> Self {
-        GlobalProxy::NotReady
-    }
-
     pub fn get(&self) -> Result<&I, GlobalError> {
         self.with_min_version(0)
     }
@@ -385,7 +378,6 @@ impl<I: Proxy> GlobalProxy<I> {
                 }
             }
             GlobalProxy::NotPresent => Err(GlobalError::MissingGlobal(I::interface().name)),
-            GlobalProxy::NotReady => Err(GlobalError::NotReady),
         }
     }
 }


### PR DESCRIPTION
This doesn't seem to serve any role after https://github.com/Smithay/client-toolkit/pull/313.