### PR TITLE
Add relative pointer, and an example using it

### DIFF
--- a/examples/relative_pointer.rs
+++ b/examples/relative_pointer.rs
@@ -1,0 +1,295 @@
+use smithay_client_toolkit::{
+    compositor::{CompositorHandler, CompositorState},
+    delegate_compositor, delegate_output, delegate_pointer, delegate_registry,
+    delegate_relative_pointer, delegate_seat, delegate_shm, delegate_xdg_shell,
+    delegate_xdg_window,
+    output::{OutputHandler, OutputState},
+    registry::{ProvidesRegistryState, RegistryState},
+    registry_handlers,
+    seat::{
+        pointer::{PointerEvent, PointerHandler},
+        relative_pointer::{RelativeMotionEvent, RelativePointerHandler, RelativePointerState},
+        Capability, SeatHandler, SeatState,
+    },
+    shell::xdg::{
+        window::{Window, WindowConfigure, WindowHandler, XdgWindowState},
+        XdgShellState,
+    },
+    shm::{slot::SlotPool, ShmHandler, ShmState},
+};
+use wayland_client::{
+    globals::registry_queue_init,
+    protocol::{wl_output, wl_pointer, wl_seat, wl_shm, wl_surface},
+    Connection, QueueHandle,
+};
+use wayland_protocols::wp::relative_pointer::zv1::client::zwp_relative_pointer_v1;
+
+fn main() {
+    env_logger::init();
+
+    let conn = Connection::connect_to_env().unwrap();
+
+    let (globals, mut event_queue) = registry_queue_init(&conn).unwrap();
+    let qh = event_queue.handle();
+
+    let mut simple_window = SimpleWindow {
+        registry_state: RegistryState::new(&globals),
+        seat_state: SeatState::new(&globals, &qh),
+        output_state: OutputState::new(&globals, &qh),
+        compositor_state: CompositorState::bind(&globals, &qh)
+            .expect("wl_compositor not available"),
+        shm_state: ShmState::bind(&globals, &qh).expect("wl_shm not available"),
+        xdg_shell_state: XdgShellState::bind(&globals, &qh).expect("xdg shell not available"),
+        xdg_window_state: XdgWindowState::bind(&globals, &qh),
+        relative_pointer_state: RelativePointerState::bind(&globals, &qh),
+
+        exit: false,
+        width: 256,
+        height: 256,
+        window: None,
+        pointer: None,
+        relative_pointer: None,
+    };
+
+    let surface = simple_window.compositor_state.create_surface(&qh);
+
+    let window = Window::builder()
+        .title("A wayland window")
+        // GitHub does not let projects use the `org.github` domain but the `io.github` domain is fine.
+        .app_id("io.github.smithay.client-toolkit.RelativePointer")
+        .min_size((256, 256))
+        .map(&qh, &simple_window.xdg_shell_state, &mut simple_window.xdg_window_state, surface)
+        .expect("window creation");
+
+    simple_window.window = Some(window);
+
+    while !simple_window.exit {
+        event_queue.blocking_dispatch(&mut simple_window).unwrap();
+    }
+}
+
+struct SimpleWindow {
+    registry_state: RegistryState,
+    seat_state: SeatState,
+    output_state: OutputState,
+    compositor_state: CompositorState,
+    shm_state: ShmState,
+    xdg_shell_state: XdgShellState,
+    xdg_window_state: XdgWindowState,
+    relative_pointer_state: RelativePointerState,
+
+    exit: bool,
+    width: u32,
+    height: u32,
+    window: Option<Window>,
+    pointer: Option<wl_pointer::WlPointer>,
+    relative_pointer: Option<zwp_relative_pointer_v1::ZwpRelativePointerV1>,
+}
+
+impl CompositorHandler for SimpleWindow {
+    fn scale_factor_changed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _new_factor: i32,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn frame(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _time: u32,
+    ) {
+    }
+}
+
+impl OutputHandler for SimpleWindow {
+    fn output_state(&mut self) -> &mut OutputState {
+        &mut self.output_state
+    }
+
+    fn new_output(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+
+    fn update_output(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+
+    fn output_destroyed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+}
+
+impl WindowHandler for SimpleWindow {
+    fn request_close(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &Window) {
+        self.exit = true;
+    }
+
+    fn configure(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        _window: &Window,
+        configure: WindowConfigure,
+        _serial: u32,
+    ) {
+        match configure.new_size {
+            Some(size) => {
+                self.width = size.0;
+                self.height = size.1;
+            }
+            None => {
+                self.width = 256;
+                self.height = 256;
+            }
+        }
+
+        self.draw(conn, qh);
+    }
+}
+
+impl SeatHandler for SimpleWindow {
+    fn seat_state(&mut self) -> &mut SeatState {
+        &mut self.seat_state
+    }
+
+    fn new_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_seat::WlSeat) {}
+
+    fn new_capability(
+        &mut self,
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+        seat: wl_seat::WlSeat,
+        capability: Capability,
+    ) {
+        if capability == Capability::Pointer && self.pointer.is_none() {
+            println!("Set pointer capability");
+            let pointer = self.seat_state.get_pointer(qh, &seat).expect("Failed to create pointer");
+            let relative_pointer =
+                self.relative_pointer_state.get_relative_pointer(&pointer, qh).ok();
+            if relative_pointer.is_some() {
+                println!("Created relative pointer");
+            } else {
+                println!("Compositor does not support relative pointer events");
+            }
+            self.pointer = Some(pointer);
+            self.relative_pointer = relative_pointer;
+        }
+    }
+
+    fn remove_capability(
+        &mut self,
+        _conn: &Connection,
+        _: &QueueHandle<Self>,
+        _: wl_seat::WlSeat,
+        capability: Capability,
+    ) {
+        if capability == Capability::Pointer && self.pointer.is_some() {
+            println!("Unset pointer capability");
+            self.pointer.take().unwrap().release();
+        }
+    }
+
+    fn remove_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_seat::WlSeat) {}
+}
+
+impl PointerHandler for SimpleWindow {
+    fn pointer_frame(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _pointer: &wl_pointer::WlPointer,
+        _events: &[PointerEvent],
+    ) {
+    }
+}
+
+impl RelativePointerHandler for SimpleWindow {
+    fn relative_pointer_motion(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _relative_pointer: &zwp_relative_pointer_v1::ZwpRelativePointerV1,
+        _pointer: &wl_pointer::WlPointer,
+        event: RelativeMotionEvent,
+    ) {
+        println!("{:?}", event);
+    }
+}
+
+impl ShmHandler for SimpleWindow {
+    fn shm_state(&mut self) -> &mut ShmState {
+        &mut self.shm_state
+    }
+}
+
+impl SimpleWindow {
+    pub fn draw(&mut self, _conn: &Connection, qh: &QueueHandle<Self>) {
+        if let Some(window) = self.window.as_ref() {
+            let width = self.width;
+            let height = self.height;
+            let stride = self.width as i32 * 4;
+
+            let mut pool = SlotPool::new(width as usize * height as usize * 4, &self.shm_state)
+                .expect("Failed to create pool");
+
+            let buffer = pool
+                .create_buffer(width as i32, height as i32, stride, wl_shm::Format::Xrgb8888)
+                .expect("create buffer")
+                .0;
+
+            for i in pool.canvas(&buffer).unwrap().chunks_exact_mut(4) {
+                i[0] = 255;
+                i[1] = 255;
+                i[2] = 255;
+            }
+
+            // Damage the entire window
+            window.wl_surface().damage_buffer(0, 0, self.width as i32, self.height as i32);
+
+            // Request our next frame
+            window.wl_surface().frame(qh, window.wl_surface().clone());
+
+            // Attach and commit to present.
+            buffer.attach_to(window.wl_surface()).expect("buffer attach");
+            window.wl_surface().commit();
+        }
+    }
+}
+
+delegate_compositor!(SimpleWindow);
+delegate_output!(SimpleWindow);
+delegate_shm!(SimpleWindow);
+
+delegate_seat!(SimpleWindow);
+delegate_pointer!(SimpleWindow);
+delegate_relative_pointer!(SimpleWindow);
+
+delegate_xdg_shell!(SimpleWindow);
+delegate_xdg_window!(SimpleWindow);
+
+delegate_registry!(SimpleWindow);
+
+impl ProvidesRegistryState for SimpleWindow {
+    fn registry(&mut self) -> &mut RegistryState {
+        &mut self.registry_state
+    }
+    registry_handlers![OutputState, SeatState,];
+}

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "xkbcommon")]
 pub mod keyboard;
 pub mod pointer;
+pub mod relative_pointer;
 pub mod touch;
 
 use std::{

--- a/src/seat/relative_pointer.rs
+++ b/src/seat/relative_pointer.rs
@@ -1,0 +1,135 @@
+use wayland_client::{
+    globals::GlobalList, protocol::wl_pointer, Connection, Dispatch, QueueHandle,
+};
+use wayland_protocols::wp::relative_pointer::zv1::client::{
+    zwp_relative_pointer_manager_v1, zwp_relative_pointer_v1,
+};
+
+use crate::{error::GlobalError, globals::GlobalData, registry::GlobalProxy};
+
+#[derive(Debug)]
+pub struct RelativePointerState {
+    relative_pointer_manager:
+        GlobalProxy<zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1>,
+}
+
+impl RelativePointerState {
+    /// Bind `zwp_relative_pointer_manager_v1` global, if it exists
+    pub fn bind<D>(globals: &GlobalList, qh: &QueueHandle<D>) -> Self
+    where
+        D: Dispatch<zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1, GlobalData>
+            + 'static,
+    {
+        let relative_pointer_manager = GlobalProxy::from(globals.bind(qh, 1..=1, GlobalData));
+        Self { relative_pointer_manager }
+    }
+
+    pub fn get_relative_pointer<D>(
+        &self,
+        pointer: &wl_pointer::WlPointer,
+        qh: &QueueHandle<D>,
+    ) -> Result<zwp_relative_pointer_v1::ZwpRelativePointerV1, GlobalError>
+    where
+        D: Dispatch<zwp_relative_pointer_v1::ZwpRelativePointerV1, RelativePointerData> + 'static,
+    {
+        let udata = RelativePointerData { wl_pointer: pointer.clone() };
+        Ok(self.relative_pointer_manager.get()?.get_relative_pointer(pointer, qh, udata))
+    }
+}
+
+#[derive(Debug)]
+pub struct RelativeMotionEvent {
+    /// (x, y) motion vector
+    pub delta: (f64, f64),
+    /// Unaccelerated (x, y) motion vector
+    pub delta_unaccel: (f64, f64),
+    /// Timestamp in microseconds
+    pub utime: u64,
+}
+
+pub trait RelativePointerHandler: Sized {
+    fn relative_pointer_motion(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        relative_pointer: &zwp_relative_pointer_v1::ZwpRelativePointerV1,
+        pointer: &wl_pointer::WlPointer,
+        event: RelativeMotionEvent,
+    );
+}
+
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct RelativePointerData {
+    wl_pointer: wl_pointer::WlPointer,
+}
+
+impl<D> Dispatch<zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1, GlobalData, D>
+    for RelativePointerState
+where
+    D: Dispatch<zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1, GlobalData>
+        + RelativePointerHandler,
+{
+    fn event(
+        _data: &mut D,
+        _manager: &zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
+        _event: zwp_relative_pointer_manager_v1::Event,
+        _: &GlobalData,
+        _conn: &Connection,
+        _qh: &QueueHandle<D>,
+    ) {
+        unreachable!()
+    }
+}
+
+impl<D> Dispatch<zwp_relative_pointer_v1::ZwpRelativePointerV1, RelativePointerData, D>
+    for RelativePointerState
+where
+    D: Dispatch<zwp_relative_pointer_v1::ZwpRelativePointerV1, RelativePointerData>
+        + RelativePointerHandler,
+{
+    fn event(
+        data: &mut D,
+        relative_pointer: &zwp_relative_pointer_v1::ZwpRelativePointerV1,
+        event: zwp_relative_pointer_v1::Event,
+        udata: &RelativePointerData,
+        conn: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        match event {
+            zwp_relative_pointer_v1::Event::RelativeMotion {
+                utime_hi,
+                utime_lo,
+                dx,
+                dy,
+                dx_unaccel,
+                dy_unaccel,
+            } => {
+                data.relative_pointer_motion(
+                    conn,
+                    qh,
+                    relative_pointer,
+                    &udata.wl_pointer,
+                    RelativeMotionEvent {
+                        utime: ((utime_hi as u64) << 32) | (utime_lo as u64),
+                        delta: (dx, dy),
+                        delta_unaccel: (dx_unaccel, dy_unaccel),
+                    },
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_relative_pointer {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::protocols::wp::relative_pointer::zv1::client::zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1: $crate::globals::GlobalData
+        ] => $crate::seat::relative_pointer::RelativePointerState);
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::reexports::protocols::wp::relative_pointer::zv1::client::zwp_relative_pointer_v1::ZwpRelativePointerV1: $crate::seat::relative_pointer::RelativePointerData
+        ] => $crate::seat::relative_pointer::RelativePointerState);
+    };
+}


### PR DESCRIPTION
In a future PR adding pointer constraints, the example could be updated to demonstrate relative motion in combination with pointer locks and confinement. But here it just prints motion events a window receives.