### PR TITLE
seat: store seat in udata

### DIFF
--- a/src/seat/keyboard/repeat.rs
+++ b/src/seat/keyboard/repeat.rs
@@ -66,8 +66,8 @@ impl SeatState {
         D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData> + KeyboardHandler + 'static,
     {
         let udata = match rmlvo {
-            Some(rmlvo) => KeyboardData::from_rmlvo(rmlvo)?,
-            None => KeyboardData::default(),
+            Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo)?,
+            None => KeyboardData::new(seat.clone()),
         };
 
         self.get_keyboard_with_repeat_with_data(qh, seat, udata)

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -121,7 +121,7 @@ impl SeatState {
     where
         D: Dispatch<wl_pointer::WlPointer, PointerData> + PointerHandler + 'static,
     {
-        self.get_pointer_with_data(qh, seat, PointerData::default())
+        self.get_pointer_with_data(qh, seat, PointerData::new(seat.clone()))
     }
 
     /// Creates a pointer from a seat with the provided theme.
@@ -139,7 +139,7 @@ impl SeatState {
     where
         D: Dispatch<wl_pointer::WlPointer, PointerData> + PointerHandler + 'static,
     {
-        self.get_pointer_with_theme_and_data(qh, seat, theme, scale, Default::default())
+        self.get_pointer_with_theme_and_data(qh, seat, theme, scale, PointerData::new(seat.clone()))
     }
 
     /// Creates a pointer from a seat.
@@ -216,7 +216,7 @@ impl SeatState {
     where
         D: Dispatch<wl_touch::WlTouch, TouchData> + TouchHandler + 'static,
     {
-        self.get_touch_with_data(qh, seat, TouchData::default())
+        self.get_touch_with_data(qh, seat, TouchData::new(seat.clone()))
     }
 
     /// Creates a touch handle from a seat.

--- a/src/seat/pointer/mod.rs
+++ b/src/seat/pointer/mod.rs
@@ -6,7 +6,7 @@ use std::{
 use wayland_backend::{client::InvalidId, smallvec::SmallVec};
 
 use wayland_client::{
-    protocol::{wl_pointer, wl_shm, wl_surface},
+    protocol::{wl_pointer, wl_seat::WlSeat, wl_shm, wl_surface},
     Connection, Dispatch, Proxy, QueueHandle, WEnum,
 };
 use wayland_cursor::{Cursor, CursorTheme};
@@ -114,12 +114,22 @@ pub trait PointerHandler: Sized {
     );
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PointerData {
+    seat: WlSeat,
     pub(crate) inner: Mutex<PointerDataInner>,
 }
 
 impl PointerData {
+    pub fn new(seat: WlSeat) -> Self {
+        Self { seat, inner: Default::default() }
+    }
+
+    /// The seat associated with this pointer.
+    pub fn seat(&self) -> &WlSeat {
+        &self.seat
+    }
+
     /// The latest serial from the `Enter` event.
     pub fn latest_enter_serial(&self) -> Option<u32> {
         self.inner.lock().unwrap().latest_enter

--- a/src/seat/touch.rs
+++ b/src/seat/touch.rs
@@ -1,14 +1,30 @@
 use std::sync::Mutex;
 
+use wayland_client::protocol::wl_seat::WlSeat;
+
 use wayland_client::protocol::wl_surface::WlSurface;
 use wayland_client::protocol::wl_touch::{Event as TouchEvent, WlTouch};
 use wayland_client::{Connection, Dispatch, QueueHandle};
 
 use crate::seat::SeatState;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct TouchData {
+    seat: WlSeat,
+
     inner: Mutex<TouchDataInner>,
+}
+
+impl TouchData {
+    /// Create the new touch data associated with the given seat.
+    pub fn new(seat: WlSeat) -> Self {
+        Self { seat, inner: Default::default() }
+    }
+
+    /// Get the associated seat from the data.
+    pub fn seat(&self) -> &WlSeat {
+        &self.seat
+    }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
This should help with handling of multi-seat given that all input must be associated with the seat, but right now it'll require manually finding the right seat on each input of the event.
