### PR TITLE
seat: explicitly pass scale each time for pointer

### DIFF
--- a/examples/pointer_theme_window.rs
+++ b/examples/pointer_theme_window.rs
@@ -231,7 +231,7 @@ impl SeatHandler for SimpleWindow {
             println!("Creating pointer theme");
             let themed_pointer = self
                 .seat_state
-                .get_pointer_with_theme(qh, &seat, ThemeSpec::default(), 1)
+                .get_pointer_with_theme(qh, &seat, ThemeSpec::default())
                 .expect("Failed to create pointer");
             self.themed_pointer.replace(themed_pointer);
         }
@@ -375,6 +375,7 @@ impl SimpleWindow {
                 "diamond_cross",
                 self.shm_state.wl_shm(),
                 &self.pointer_surface,
+                1,
             );
             self.set_cursor = false;
         }

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -134,12 +134,11 @@ impl SeatState {
         qh: &QueueHandle<D>,
         seat: &wl_seat::WlSeat,
         theme: ThemeSpec,
-        scale: i32,
     ) -> Result<ThemedPointer<PointerData>, SeatError>
     where
         D: Dispatch<wl_pointer::WlPointer, PointerData> + PointerHandler + 'static,
     {
-        self.get_pointer_with_theme_and_data(qh, seat, theme, scale, PointerData::new(seat.clone()))
+        self.get_pointer_with_theme_and_data(qh, seat, theme, PointerData::new(seat.clone()))
     }
 
     /// Creates a pointer from a seat.
@@ -177,7 +176,6 @@ impl SeatState {
         qh: &QueueHandle<D>,
         seat: &wl_seat::WlSeat,
         theme: ThemeSpec,
-        scale: i32,
         pointer_data: U,
     ) -> Result<ThemedPointer<U>, SeatError>
     where
@@ -195,7 +193,6 @@ impl SeatState {
         Ok(ThemedPointer {
             themes: Arc::new(Mutex::new(Themes::new(theme))),
             pointer: wl_ptr,
-            scale,
             _marker: std::marker::PhantomData,
         })
     }


### PR DESCRIPTION
Previous API flow was to recreate a `ThemedPointer` each time you want to change scale, which is counterintuitive, given that the inner wl_pointer, shouldn't be dropped.