### PR TITLE
seat: return just `ThemedPointer` when creating it

### DIFF
--- a/examples/pointer_theme_window.rs
+++ b/examples/pointer_theme_window.rs
@@ -79,7 +79,6 @@ fn main() {
         pointer_surface,
         keyboard: None,
         keyboard_focus: false,
-        pointer: None,
         themed_pointer: None,
         set_cursor: false,
     };
@@ -116,7 +115,6 @@ struct SimpleWindow {
     pointer_surface: wl_surface::WlSurface,
     keyboard: Option<wl_keyboard::WlKeyboard>,
     keyboard_focus: bool,
-    pointer: Option<wl_pointer::WlPointer>,
     themed_pointer: Option<ThemedPointer>,
     set_cursor: bool,
 }
@@ -228,14 +226,13 @@ impl SeatHandler for SimpleWindow {
             self.keyboard = Some(keyboard);
         }
 
-        if capability == Capability::Pointer && self.pointer.is_none() {
+        if capability == Capability::Pointer && self.themed_pointer.is_none() {
             println!("Set pointer capability");
             println!("Creating pointer theme");
-            let (pointer, themed_pointer) = self
+            let themed_pointer = self
                 .seat_state
                 .get_pointer_with_theme(qh, &seat, ThemeSpec::default(), 1)
                 .expect("Failed to create pointer");
-            self.pointer = Some(pointer);
             self.themed_pointer.replace(themed_pointer);
         }
     }
@@ -252,9 +249,9 @@ impl SeatHandler for SimpleWindow {
             self.keyboard.take().unwrap().release();
         }
 
-        if capability == Capability::Pointer && self.pointer.is_some() {
+        if capability == Capability::Pointer && self.themed_pointer.is_some() {
             println!("Unset pointer capability");
-            self.pointer.take().unwrap().release();
+            self.themed_pointer.take().unwrap().pointer().release();
         }
     }
 

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -135,7 +135,7 @@ impl SeatState {
         seat: &wl_seat::WlSeat,
         theme: ThemeSpec,
         scale: i32,
-    ) -> Result<(wl_pointer::WlPointer, ThemedPointer<PointerData>), SeatError>
+    ) -> Result<ThemedPointer<PointerData>, SeatError>
     where
         D: Dispatch<wl_pointer::WlPointer, PointerData> + PointerHandler + 'static,
     {
@@ -179,7 +179,7 @@ impl SeatState {
         theme: ThemeSpec,
         scale: i32,
         pointer_data: U,
-    ) -> Result<(wl_pointer::WlPointer, ThemedPointer<U>), SeatError>
+    ) -> Result<ThemedPointer<U>, SeatError>
     where
         D: Dispatch<wl_pointer::WlPointer, U> + PointerHandler + 'static,
         U: PointerDataExt + 'static,
@@ -192,15 +192,12 @@ impl SeatState {
         }
 
         let wl_ptr = seat.get_pointer(qh, pointer_data);
-        Ok((
-            wl_ptr.clone(),
-            ThemedPointer {
-                themes: Arc::new(Mutex::new(Themes::new(theme))),
-                pointer: wl_ptr,
-                scale,
-                _marker: std::marker::PhantomData,
-            },
-        ))
+        Ok(ThemedPointer {
+            themes: Arc::new(Mutex::new(Themes::new(theme))),
+            pointer: wl_ptr,
+            scale,
+            _marker: std::marker::PhantomData,
+        })
     }
 
     /// Creates a touch handle from a seat.


### PR DESCRIPTION
The `WlPointer` is already stored on the `ThemedPointer`, so you can get it from it without the need to return a tuple of `(WlPointer, ThemedPointer)`.