### PR TITLE
Don't use raw identifier in method name

### DIFF
--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -264,7 +264,7 @@ impl Window {
         }
     }
 
-    pub fn r#move(&self, seat: &wl_seat::WlSeat, serial: u32) {
+    pub fn move_(&self, seat: &wl_seat::WlSeat, serial: u32) {
         self.xdg_toplevel()._move(seat, serial)
     }
 


### PR DESCRIPTION
Raw identifiers are really only meant for cases where it's technically necessary to use a particular identifier (like when a keyword was added by an edition, but an API currently uses that as an identifier).

I this an `_` suffix is the most idiomatic solution.