### PR TITLE
Remove workaround depending on `wayland-client/log`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ memmap2 = "0.5.0"
 log = "0.4"
 thiserror = "1.0.30"
 wayland-backend = "0.1.0"
-wayland-client = "0.30.0"
+wayland-client = "0.30.1"
 wayland-protocols = { version = "0.30.0", features = ["client", "unstable"] }
 wayland-protocols-wlr = { version = "0.1.0", features = ["client"] }
 wayland-cursor = "0.30.0"
@@ -35,8 +35,7 @@ calloop = { version = "0.10.5", optional = true }
 
 [features]
 default = ["calloop", "xkbcommon"]
-# TODO remove `log` once wayland-client fixed
-calloop = ["dep:calloop", "wayland-client/calloop", "wayland-client/log"]
+calloop = ["dep:calloop", "wayland-client/calloop"]
 
 [build-dependencies]
 pkg-config = "0.3"


### PR DESCRIPTION
Looks like the fix for this is in `wayland-client` 0.30.1 now.