### PR TITLE
window: add client side decorations interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,3 +23,4 @@ pub mod registry;
 pub mod seat;
 pub mod shell;
 pub mod shm;
+pub mod subcompositor;

--- a/src/shell/xdg/frame/fallback_frame.rs
+++ b/src/shell/xdg/frame/fallback_frame.rs
@@ -1,0 +1,696 @@
+//! The default fallback frame which is intended to show some very basic derocations.
+
+use std::sync::Arc;
+use std::{error::Error, num::NonZeroU32};
+
+use crate::reexports::client::{
+    protocol::{wl_shm, wl_subsurface::WlSubsurface, wl_surface::WlSurface},
+    Dispatch, Proxy, QueueHandle,
+};
+use crate::reexports::protocols::xdg::shell::client::xdg_toplevel::ResizeEdge;
+
+use crate::{
+    compositor::SurfaceData,
+    shell::xdg::{WindowManagerCapabilities, WindowState},
+    shell::WaylandSurface,
+    shm::{slot::SlotPool, Shm},
+    subcompositor::{SubcompositorState, SubsurfaceData},
+};
+
+use super::{DecorationsFrame, FrameAction, FrameClick};
+
+/// The size of the header bar.
+const HEADER_SIZE: u32 = 24;
+
+/// The size of the border.
+const BORDER_SIZE: u32 = 4;
+
+const HEADER: usize = 0;
+const TOP_BORDER: usize = 1;
+const RIGHT_BORDER: usize = 2;
+const BOTTOM_BORDER: usize = 3;
+const LEFT_BORDER: usize = 4;
+
+const BTN_ICON_COLOR: u32 = 0xFFCCCCCC;
+const BTN_HOVER_BG: u32 = 0xFF808080;
+
+const PRIMARY_COLOR_ACTIVE: u32 = 0xFF3A3A3A;
+const PRIMARY_COLOR_INACTIVE: u32 = 0xFF242424;
+
+/// The default ugly frame.
+#[derive(Debug)]
+pub struct FallbackFrame<State> {
+    /// The parent surface.
+    parent: WlSurface,
+
+    /// The latest window state.
+    state: WindowState,
+
+    /// The wm capabilities.
+    wm_capabilities: WindowManagerCapabilities,
+
+    /// Whether the frame is resizable.
+    resizable: bool,
+
+    /// Whether the frame is waiting for redraw.
+    dirty: bool,
+
+    /// The location of the mouse.
+    mouse_location: Location,
+
+    /// The location of the mouse.
+    mouse_coords: (i32, i32),
+
+    /// The frame rendering data. When `None` the frame is hidden.
+    render_data: Option<FrameRenderData>,
+
+    /// The frame queue handle.
+    queue_handle: QueueHandle<State>,
+
+    /// The memory pool to use for drawing.
+    pool: SlotPool,
+
+    /// The subcompositor.
+    subcompositor: Arc<SubcompositorState>,
+
+    /// Buttons state.
+    buttons: [Option<UIButton>; 3],
+}
+
+impl<State> FallbackFrame<State>
+where
+    State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+{
+    pub fn new(
+        parent: &impl WaylandSurface,
+        shm: &Shm,
+        subcompositor: Arc<SubcompositorState>,
+        queue_handle: QueueHandle<State>,
+    ) -> Result<Self, Box<dyn Error>> {
+        let parent = parent.wl_surface().clone();
+        let pool = SlotPool::new(1, shm)?;
+        let render_data = Some(FrameRenderData::new(&parent, &subcompositor, &queue_handle));
+
+        let wm_capabilities = WindowManagerCapabilities::all();
+        Ok(Self {
+            parent,
+            resizable: true,
+            state: WindowState::empty(),
+            wm_capabilities,
+            dirty: true,
+            pool,
+            queue_handle,
+            subcompositor,
+            render_data,
+            mouse_location: Location::None,
+            mouse_coords: (0, 0),
+            buttons: Self::supported_buttons(wm_capabilities),
+        })
+    }
+
+    fn supported_buttons(wm_capabilities: WindowManagerCapabilities) -> [Option<UIButton>; 3] {
+        let maximize = wm_capabilities
+            .contains(WindowManagerCapabilities::MAXIMIZE)
+            .then_some(UIButton::Maximize);
+        let minimize = wm_capabilities
+            .contains(WindowManagerCapabilities::MINIMIZE)
+            .then_some(UIButton::Minimize);
+        [Some(UIButton::Close), maximize, minimize]
+    }
+
+    fn precise_location(
+        buttons: &[Option<UIButton>],
+        old: Location,
+        width: u32,
+        x: f64,
+        y: f64,
+    ) -> Location {
+        match old {
+            Location::Head | Location::Button(_) => Self::find_button(buttons, x, y, width),
+
+            Location::Top | Location::TopLeft | Location::TopRight => {
+                if x <= f64::from(BORDER_SIZE) {
+                    Location::TopLeft
+                } else if x >= f64::from(width - BORDER_SIZE) {
+                    Location::TopRight
+                } else {
+                    Location::Top
+                }
+            }
+
+            Location::Bottom | Location::BottomLeft | Location::BottomRight => {
+                if x <= f64::from(BORDER_SIZE) {
+                    Location::BottomLeft
+                } else if x >= f64::from(width - BORDER_SIZE) {
+                    Location::BottomRight
+                } else {
+                    Location::Bottom
+                }
+            }
+
+            other => other,
+        }
+    }
+
+    fn find_button(buttons: &[Option<UIButton>], x: f64, y: f64, w: u32) -> Location {
+        for (idx, &button) in buttons.iter().flatten().enumerate() {
+            let idx = idx as u32;
+            if w >= (idx + 1) * HEADER_SIZE
+                && x >= f64::from(w - (idx + 1) * HEADER_SIZE)
+                && x <= f64::from(w - idx * HEADER_SIZE)
+                && y <= f64::from(HEADER_SIZE)
+                && y >= f64::from(0)
+            {
+                return Location::Button(button);
+            }
+        }
+
+        Location::Head
+    }
+
+    #[inline]
+    fn part_index_for_surface(&mut self, surface: &WlSurface) -> Option<usize> {
+        self.render_data.as_ref()?.parts.iter().position(|part| &part.surface == surface)
+    }
+
+    fn draw_buttons(
+        buttons: &[Option<UIButton>],
+        canvas: &mut [u8],
+        width: u32,
+        scale: u32,
+        is_active: bool,
+        mouse_location: &Location,
+    ) {
+        let scale = scale as usize;
+        for (idx, &button) in buttons.iter().flatten().enumerate() {
+            if width >= (idx + 1) as u32 * HEADER_SIZE {
+                if is_active && mouse_location == &Location::Button(button) {
+                    Self::draw_button(
+                        canvas,
+                        idx * HEADER_SIZE as usize,
+                        scale,
+                        width as usize,
+                        BTN_HOVER_BG.to_le_bytes(),
+                    );
+                }
+                Self::draw_icon(
+                    canvas,
+                    width as usize,
+                    idx * HEADER_SIZE as usize,
+                    scale,
+                    BTN_ICON_COLOR.to_le_bytes(),
+                    button,
+                );
+            }
+        }
+    }
+
+    fn draw_button(
+        canvas: &mut [u8],
+        x_offset: usize,
+        scale: usize,
+        width: usize,
+        btn_color: [u8; 4],
+    ) {
+        let h = HEADER_SIZE as usize;
+        let x_start = width - h - x_offset;
+        // main square
+        for y in 0..h * scale {
+            let canvas = &mut canvas
+                [(x_start + y * width) * 4 * scale..(x_start + y * width + h) * scale * 4];
+            for pixel in canvas.chunks_exact_mut(4) {
+                pixel[0] = btn_color[0];
+                pixel[1] = btn_color[1];
+                pixel[2] = btn_color[2];
+                pixel[3] = btn_color[3];
+            }
+        }
+    }
+
+    fn draw_icon(
+        canvas: &mut [u8],
+        width: usize,
+        x_offset: usize,
+        scale: usize,
+        icon_color: [u8; 4],
+        icon: UIButton,
+    ) {
+        let h = HEADER_SIZE as usize;
+        let sh = scale * h;
+        let x_start = width - h - x_offset;
+
+        match icon {
+            UIButton::Close => {
+                // Draw black rectangle
+                for y in sh / 4..3 * sh / 4 {
+                    let line = &mut canvas[(x_start + y * width + h / 4) * 4 * scale
+                        ..(x_start + y * width + 3 * h / 4) * 4 * scale];
+                    for pixel in line.chunks_exact_mut(4) {
+                        pixel[0] = icon_color[0];
+                        pixel[1] = icon_color[1];
+                        pixel[2] = icon_color[2];
+                        pixel[3] = icon_color[3];
+                    }
+                }
+            }
+            UIButton::Maximize => {
+                // Draw an empty rectangle
+                for y in 2 * sh / 8..3 * sh / 8 {
+                    let line = &mut canvas[(x_start + y * width + h / 4) * 4 * scale
+                        ..(x_start + y * width + 3 * h / 4) * 4 * scale];
+                    for pixel in line.chunks_exact_mut(4) {
+                        pixel[0] = icon_color[0];
+                        pixel[1] = icon_color[1];
+                        pixel[2] = icon_color[2];
+                        pixel[3] = icon_color[3];
+                    }
+                }
+                for y in 3 * sh / 8..5 * sh / 8 {
+                    let line = &mut canvas[(x_start + y * width + 2 * h / 8) * 4 * scale
+                        ..(x_start + y * width + 3 * h / 8) * 4 * scale];
+                    for pixel in line.chunks_exact_mut(4) {
+                        pixel[0] = icon_color[0];
+                        pixel[1] = icon_color[1];
+                        pixel[2] = icon_color[2];
+                        pixel[3] = icon_color[3];
+                    }
+                    let line = &mut canvas[(x_start + y * width + 5 * h / 8) * 4 * scale
+                        ..(x_start + y * width + 6 * h / 8) * 4 * scale];
+                    for pixel in line.chunks_exact_mut(4) {
+                        pixel[0] = icon_color[0];
+                        pixel[1] = icon_color[1];
+                        pixel[2] = icon_color[2];
+                        pixel[3] = icon_color[3];
+                    }
+                }
+                for y in 5 * sh / 8..6 * sh / 8 {
+                    let line = &mut canvas[(x_start + y * width + h / 4) * 4 * scale
+                        ..(x_start + y * width + 3 * h / 4) * 4 * scale];
+                    for pixel in line.chunks_exact_mut(4) {
+                        pixel[0] = icon_color[0];
+                        pixel[1] = icon_color[1];
+                        pixel[2] = icon_color[2];
+                        pixel[3] = icon_color[3];
+                    }
+                }
+            }
+            UIButton::Minimize => {
+                // Draw an underline
+                for y in 5 * sh / 8..3 * sh / 4 {
+                    let line = &mut canvas[(x_start + y * width + h / 4) * 4 * scale
+                        ..(x_start + y * width + 3 * h / 4) * 4 * scale];
+                    for pixel in line.chunks_exact_mut(4) {
+                        pixel[0] = icon_color[0];
+                        pixel[1] = icon_color[1];
+                        pixel[2] = icon_color[2];
+                        pixel[3] = icon_color[3];
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<State> DecorationsFrame for FallbackFrame<State>
+where
+    State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+{
+    fn on_click(&mut self, click: FrameClick, pressed: bool) -> Option<super::FrameAction> {
+        // Handle alternate click before everything else.
+        if click == FrameClick::Alternate {
+            return if Location::Head != self.mouse_location
+                || !self.wm_capabilities.contains(WindowManagerCapabilities::WINDOW_MENU)
+            {
+                None
+            } else {
+                Some(FrameAction::ShowMenu(
+                    self.mouse_coords.0,
+                    self.mouse_coords.1 - HEADER_SIZE as i32,
+                ))
+            };
+        }
+
+        let resize = pressed && self.resizable;
+        match self.mouse_location {
+            Location::Head if pressed => Some(FrameAction::Move),
+            Location::Button(UIButton::Close) if !pressed => Some(FrameAction::Close),
+            Location::Button(UIButton::Minimize) if !pressed => Some(FrameAction::Minimize),
+            Location::Button(UIButton::Maximize)
+                if !pressed && !self.state.contains(WindowState::MAXIMIZED) =>
+            {
+                Some(FrameAction::Maximize)
+            }
+            Location::Button(UIButton::Maximize)
+                if !pressed && self.state.contains(WindowState::MAXIMIZED) =>
+            {
+                Some(FrameAction::UnMaximize)
+            }
+            Location::Top if resize => Some(FrameAction::Resize(ResizeEdge::Top)),
+            Location::TopLeft if resize => Some(FrameAction::Resize(ResizeEdge::TopLeft)),
+            Location::Left if resize => Some(FrameAction::Resize(ResizeEdge::Left)),
+            Location::BottomLeft if resize => Some(FrameAction::Resize(ResizeEdge::BottomLeft)),
+            Location::Bottom if resize => Some(FrameAction::Resize(ResizeEdge::Bottom)),
+            Location::BottomRight if resize => Some(FrameAction::Resize(ResizeEdge::BottomRight)),
+            Location::Right if resize => Some(FrameAction::Resize(ResizeEdge::Right)),
+            Location::TopRight if resize => Some(FrameAction::Resize(ResizeEdge::TopRight)),
+            _ => None,
+        }
+    }
+
+    fn click_point_moved(&mut self, surface: &WlSurface, x: f64, y: f64) -> Option<&str> {
+        let part_index = self.part_index_for_surface(surface)?;
+        let location = match part_index {
+            LEFT_BORDER => Location::Left,
+            RIGHT_BORDER => Location::Right,
+            BOTTOM_BORDER => Location::Bottom,
+            TOP_BORDER => Location::Top,
+            _ => Location::Head,
+        };
+
+        let old_location = self.mouse_location;
+        self.mouse_coords = (x as i32, y as i32);
+        self.mouse_location = Self::precise_location(
+            &self.buttons,
+            location,
+            self.render_data.as_ref().unwrap().parts[part_index].width,
+            x,
+            y,
+        );
+
+        // Set dirty if we moved the cursor between the buttons.
+        self.dirty |= (matches!(old_location, Location::Button(_))
+            || matches!(self.mouse_location, Location::Button(_)))
+            && old_location != self.mouse_location;
+
+        Some(match self.mouse_location {
+            Location::Top => "top_side",
+            Location::TopRight => "top_right_corner",
+            Location::Right => "right_side",
+            Location::BottomRight => "bottom_right_corner",
+            Location::Bottom => "bottom_side",
+            Location::BottomLeft => "bottom_left_corner",
+            Location::Left => "left_side",
+            Location::TopLeft => "top_left_corner",
+            _ => "left_ptr",
+        })
+    }
+
+    fn click_point_left(&mut self) {
+        self.mouse_location = Location::None;
+        self.dirty = true;
+    }
+
+    fn set_hidden(&mut self, hidden: bool) {
+        if self.is_hidden() == hidden {
+            return;
+        }
+
+        if hidden {
+            self.render_data = None;
+        } else {
+            let _ = self.pool.resize(1);
+            self.render_data =
+                Some(FrameRenderData::new(&self.parent, &self.subcompositor, &self.queue_handle));
+        }
+    }
+
+    fn set_resizable(&mut self, resizable: bool) {
+        self.resizable = resizable;
+    }
+
+    fn update_state(&mut self, state: WindowState) {
+        let difference = self.state.symmetric_difference(state);
+        self.state = state;
+        self.dirty |= !difference
+            .intersection(WindowState::ACTIVATED | WindowState::FULLSCREEN | WindowState::MAXIMIZED)
+            .is_empty();
+    }
+
+    fn resize(&mut self, width: NonZeroU32, height: NonZeroU32) {
+        let parts = &mut self.render_data.as_mut().expect("trying to resize hidden frame").parts;
+
+        let width = width.get();
+        let height = height.get();
+
+        parts[HEADER].width = width;
+
+        parts[TOP_BORDER].width = width + 2 * BORDER_SIZE;
+
+        parts[BOTTOM_BORDER].width = width + 2 * BORDER_SIZE;
+        parts[BOTTOM_BORDER].pos.1 = height as i32;
+
+        parts[LEFT_BORDER].height = height + HEADER_SIZE;
+
+        parts[RIGHT_BORDER].height = parts[LEFT_BORDER].height;
+        parts[RIGHT_BORDER].pos.0 = width as i32;
+
+        self.dirty = true;
+    }
+
+    fn subtract_borders(
+        &self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+    ) -> (Option<NonZeroU32>, Option<NonZeroU32>) {
+        if self.state.contains(WindowState::FULLSCREEN) || self.render_data.is_none() {
+            (Some(width), Some(height))
+        } else {
+            (
+                NonZeroU32::new(width.get().saturating_sub(2 * BORDER_SIZE)),
+                NonZeroU32::new(height.get().saturating_sub(HEADER_SIZE + 2 * BORDER_SIZE)),
+            )
+        }
+    }
+
+    fn add_borders(&self, width: u32, height: u32) -> (u32, u32) {
+        if self.state.contains(WindowState::FULLSCREEN) || self.render_data.is_none() {
+            (width, height)
+        } else {
+            (width + 2 * BORDER_SIZE, height + (HEADER_SIZE + 2 * BORDER_SIZE))
+        }
+    }
+
+    fn is_hidden(&self) -> bool {
+        self.render_data.is_none()
+    }
+
+    fn location(&self) -> (i32, i32) {
+        if self.state.contains(WindowState::FULLSCREEN) || self.is_hidden() {
+            (0, 0)
+        } else {
+            self.render_data.as_ref().unwrap().parts[TOP_BORDER].pos
+        }
+    }
+
+    fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    fn draw(&mut self) {
+        let render_data = match self.render_data.as_mut() {
+            Some(render_data) => render_data,
+            None => return,
+        };
+
+        // Reset the dirty bit.
+        self.dirty = false;
+
+        if self.state.contains(WindowState::FULLSCREEN) {
+            // Don't draw the decorations for the full screen surface.
+            for part in &render_data.parts {
+                part.surface.attach(None, 0, 0);
+                part.surface.commit();
+            }
+            return;
+        }
+
+        let is_active = self.state.contains(WindowState::ACTIVATED);
+        let fill_color =
+            if is_active { PRIMARY_COLOR_ACTIVE } else { PRIMARY_COLOR_INACTIVE }.to_le_bytes();
+
+        for (idx, part) in render_data.parts.iter().enumerate() {
+            let scale = part.surface.data::<SurfaceData>().unwrap().scale_factor();
+            let (buffer, canvas) = match self.pool.create_buffer(
+                part.width as i32 * scale,
+                part.height as i32 * scale,
+                part.width as i32 * 4 * scale,
+                wl_shm::Format::Argb8888,
+            ) {
+                Ok((buffer, canvas)) => (buffer, canvas),
+                Err(_) => continue,
+            };
+
+            // Fill the canvas.
+            for pixel in canvas.chunks_exact_mut(4) {
+                pixel[0] = fill_color[0];
+                pixel[1] = fill_color[1];
+                pixel[2] = fill_color[2];
+                pixel[3] = fill_color[3];
+            }
+
+            // Draw the buttons for the header.
+            if idx == HEADER {
+                Self::draw_buttons(
+                    &self.buttons,
+                    canvas,
+                    part.width,
+                    scale as u32,
+                    is_active,
+                    &self.mouse_location,
+                );
+            }
+
+            part.surface.set_buffer_scale(scale);
+
+            // Update the subsurface position.
+            part.subsurface.set_position(part.pos.0, part.pos.1);
+
+            buffer.attach_to(&part.surface).expect("failed to attach the buffer");
+            if part.surface.version() >= 4 {
+                part.surface.damage_buffer(0, 0, i32::MAX, i32::MAX);
+            } else {
+                part.surface.damage(0, 0, i32::MAX, i32::MAX);
+            }
+
+            part.surface.commit();
+        }
+    }
+
+    fn update_wm_capabilities(&mut self, capabilities: WindowManagerCapabilities) {
+        self.dirty |= self.wm_capabilities != capabilities;
+        self.wm_capabilities = capabilities;
+        self.buttons = Self::supported_buttons(capabilities);
+    }
+
+    fn set_title(&mut self, _: impl Into<String>) {}
+}
+
+/// Inner state to simplify dropping.
+#[derive(Debug)]
+struct FrameRenderData {
+    /// The header subsurface.
+    parts: [FramePart; 5],
+}
+
+impl FrameRenderData {
+    fn new<State>(
+        parent: &WlSurface,
+        subcompositor: &SubcompositorState,
+        queue_handle: &QueueHandle<State>,
+    ) -> Self
+    where
+        State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+    {
+        let parts = [
+            // Header.
+            FramePart::new(
+                subcompositor.create_subsurface(parent.clone(), queue_handle),
+                0,
+                HEADER_SIZE,
+                (0, -(HEADER_SIZE as i32)),
+            ),
+            // Top border.
+            FramePart::new(
+                subcompositor.create_subsurface(parent.clone(), queue_handle),
+                0,
+                BORDER_SIZE,
+                (-(BORDER_SIZE as i32), -(HEADER_SIZE as i32 + BORDER_SIZE as i32)),
+            ),
+            // Right border.
+            FramePart::new(
+                subcompositor.create_subsurface(parent.clone(), queue_handle),
+                BORDER_SIZE,
+                0,
+                (0, -(HEADER_SIZE as i32)),
+            ),
+            // Bottom border.
+            FramePart::new(
+                subcompositor.create_subsurface(parent.clone(), queue_handle),
+                0,
+                BORDER_SIZE,
+                (-(BORDER_SIZE as i32), 0),
+            ),
+            // Left border.
+            FramePart::new(
+                subcompositor.create_subsurface(parent.clone(), queue_handle),
+                BORDER_SIZE,
+                0,
+                (-(BORDER_SIZE as i32), -(HEADER_SIZE as i32)),
+            ),
+        ];
+
+        Self { parts }
+    }
+}
+
+#[derive(Debug)]
+struct FramePart {
+    /// The surface used for the frame part.
+    subsurface: WlSubsurface,
+
+    /// The surface used for this part.
+    surface: WlSurface,
+
+    /// The width of the Frame part in logical pixels.
+    width: u32,
+
+    /// The height of the Frame part in logical pixels.
+    height: u32,
+
+    /// The position for the subsurface.
+    pos: (i32, i32),
+}
+
+impl FramePart {
+    fn new(surfaces: (WlSubsurface, WlSurface), width: u32, height: u32, pos: (i32, i32)) -> Self {
+        let (subsurface, surface) = surfaces;
+        // XXX sync subsurfaces with the main surface.
+        subsurface.set_sync();
+        Self { surface, subsurface, width, height, pos }
+    }
+}
+
+impl Drop for FramePart {
+    fn drop(&mut self) {
+        self.subsurface.destroy();
+        self.surface.destroy();
+    }
+}
+
+/// The location inside the
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum Location {
+    /// The location doesn't belong to the frame.
+    None,
+    /// Header bar.
+    Head,
+    /// Top border.
+    Top,
+    /// Top right corner.
+    TopRight,
+    /// Right border.
+    Right,
+    /// Bottom right corner.
+    BottomRight,
+    /// Bottom border.
+    Bottom,
+    /// Bottom left corner.
+    BottomLeft,
+    /// Left border.
+    Left,
+    /// Top left corner.
+    TopLeft,
+    /// One of the buttons.
+    Button(UIButton),
+}
+
+/// The frame button.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum UIButton {
+    /// The minimize button, the left most.
+    Minimize,
+    /// The maximize button, in the middle.
+    Maximize,
+    /// The close botton, the right most.
+    Close,
+}

--- a/src/shell/xdg/frame/mod.rs
+++ b/src/shell/xdg/frame/mod.rs
@@ -1,0 +1,145 @@
+//! The frame to use with XDG shell window.
+
+use std::num::NonZeroU32;
+
+use crate::reexports::client::protocol::wl_surface::WlSurface;
+use crate::reexports::protocols::xdg::shell::client::xdg_toplevel::ResizeEdge;
+
+use crate::shell::xdg::window::{WindowManagerCapabilities, WindowState};
+
+pub mod fallback_frame;
+
+/// The interface for the client side decorations.
+pub trait DecorationsFrame: Sized {
+    /// Emulate click on the decorations.
+    ///
+    /// The `click` is a variant of click to use, see [`FrameClick`] for more information.
+    ///
+    /// The return value is a [`FrameAction`] you should apply, this action could be
+    /// ignored.
+    ///
+    /// The location of the click is the one passed to [`Self::click_point_moved`].
+    fn on_click(&mut self, click: FrameClick, pressed: bool) -> Option<FrameAction>;
+
+    /// Emulate pointer moved event on the decorations frame.
+    ///
+    /// The `x` and `y` are location in the surface local coordinates relative to the `surface`.
+    ///
+    /// The return value is the new cursor icon you should apply to provide better visual
+    /// feedback for the user. However, you might want to ignore it, if you're using touch events
+    /// to drive the movements.
+    fn click_point_moved(&mut self, surface: &WlSurface, x: f64, y: f64) -> Option<&str>;
+
+    /// All clicks left the decorations.
+    ///
+    /// This function should be called when input leaves the decorations.
+    fn click_point_left(&mut self);
+
+    /// Update the state of the frame.
+    ///
+    /// The state is usually obtained from the [`WindowConfigure`] event.
+    ///
+    /// [`WindowConfigure`]: crate::shell::window::WindowConfigure
+    fn update_state(&mut self, state: WindowState);
+
+    /// Update the window manager capabilites.
+    ///
+    /// The capabilites are usually obtained from the [`WindowConfigure`] event.
+    ///
+    /// [`WindowConfigure`]: crate::shell::window::WindowConfigure
+    fn update_wm_capabilities(&mut self, wm_capabilities: WindowManagerCapabilities);
+
+    /// Resize the window to the new size.
+    ///
+    /// The size must be without the borders, as in [`Self::subtract_borders]` were used on it.
+    ///
+    /// **Note:** The [`Self::update_state`] and [`Self::update_wm_capabilities`] **must be**
+    /// applied before calling this function.
+    ///
+    /// # Panics
+    ///
+    /// Panics when resizing the hidden frame.
+    fn resize(&mut self, width: NonZeroU32, height: NonZeroU32);
+
+    /// Return the coordinates of the top-left corner of the borders relative to the content.
+    ///
+    /// Values **must** thus be negative.
+    fn location(&self) -> (i32, i32);
+
+    /// Subtract the borders from the given `width` and `height`.
+    ///
+    /// `None` will be returned for the particular dimension when the given
+    /// value for it was too small.
+    fn subtract_borders(
+        &self,
+        width: NonZeroU32,
+        height: NonZeroU32,
+    ) -> (Option<NonZeroU32>, Option<NonZeroU32>);
+
+    /// Add the borders to the given `width` and `height`.
+    ///
+    /// Passing zero for both width and height could be used to get the size
+    /// of the decorations frame.
+    fn add_borders(&self, width: u32, height: u32) -> (u32, u32);
+
+    /// Whether the given frame is dirty and should be redrawn.
+    fn is_dirty(&self) -> bool;
+
+    /// Set the frame as hidden.
+    ///
+    /// The frame **must be** visible by default.
+    fn set_hidden(&mut self, hidden: bool);
+
+    /// Get the frame hidden state.
+    ///
+    /// Get the state of the last [`DecorationsFrame::set_hidden`].
+    fn is_hidden(&self) -> bool;
+
+    /// Mark the frame as resizable.
+    ///
+    /// By default the frame is resizable.
+    fn set_resizable(&mut self, resizable: bool);
+
+    /// Draw the decorations frame.
+    ///
+    /// The user of the frame **must** commit the base surface afterwards.
+    fn draw(&mut self);
+
+    /// Set the frames title.
+    fn set_title(&mut self, title: impl Into<String>);
+}
+
+/// The Frame action user should perform in responce to mouse click events.
+#[derive(Debug, Clone, Copy)]
+pub enum FrameAction {
+    /// The window should be minimized.
+    Minimize,
+    /// The window should be maximized.
+    Maximize,
+    /// The window should be unmaximized.
+    UnMaximize,
+    /// The window should be closed.
+    Close,
+    /// An interactive move should be started.
+    Move,
+    /// An interactive resize should be started with the provided edge.
+    Resize(ResizeEdge),
+    /// Show window menu.
+    ///
+    /// The coordinates are relative to the base surface, as in should be directly passed
+    /// to the `xdg_toplevel::show_window_menu`.
+    ShowMenu(i32, i32),
+}
+
+/// The user clicked or touched the decoractions frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameClick {
+    /// The user done normal click, likely with left mouse button or single finger touch.
+    Normal,
+
+    /// The user done right mouse click or some touch sequence that was treated as alternate click.
+    ///
+    /// The alternate click exists solely to provide alternative action, like show window
+    /// menu when doing right mouse button cilck on the header decorations, nothing more.
+    Alternate,
+}

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -26,6 +26,7 @@ use self::window::{
 
 use super::WaylandSurface;
 
+pub mod frame;
 pub mod popup;
 pub mod window;
 

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -258,8 +258,8 @@ impl Window {
         decoration.data::<WindowData>().and_then(|data| data.0.upgrade()).map(Window)
     }
 
-    pub fn show_window_menu(&self, seat: &wl_seat::WlSeat, serial: u32, position: (u32, u32)) {
-        self.xdg_toplevel().show_window_menu(seat, serial, position.0 as i32, position.1 as i32);
+    pub fn show_window_menu(&self, seat: &wl_seat::WlSeat, serial: u32, position: (i32, i32)) {
+        self.xdg_toplevel().show_window_menu(seat, serial, position.0, position.1);
     }
 
     pub fn set_title(&self, title: impl Into<String>) {

--- a/src/subcompositor.rs
+++ b/src/subcompositor.rs
@@ -1,0 +1,125 @@
+use crate::reexports::client::globals::{BindError, GlobalList};
+use crate::reexports::client::protocol::wl_compositor::WlCompositor;
+use crate::reexports::client::protocol::wl_subcompositor::WlSubcompositor;
+use crate::reexports::client::protocol::wl_subsurface::WlSubsurface;
+use crate::reexports::client::protocol::wl_surface::WlSurface;
+use crate::reexports::client::{Connection, Dispatch, Proxy, QueueHandle};
+
+use crate::compositor::SurfaceData;
+use crate::globals::GlobalData;
+
+#[derive(Debug)]
+pub struct SubcompositorState {
+    compositor: WlCompositor,
+    subcompositor: WlSubcompositor,
+}
+
+impl SubcompositorState {
+    pub fn bind<State>(
+        compositor: WlCompositor,
+        globals: &GlobalList,
+        queue_handle: &QueueHandle<State>,
+    ) -> Result<Self, BindError>
+    where
+        State: Dispatch<WlSubcompositor, GlobalData, State> + 'static,
+    {
+        let subcompositor = globals.bind(queue_handle, 1..=1, GlobalData)?;
+        Ok(SubcompositorState { compositor, subcompositor })
+    }
+
+    pub fn create_subsurface<State>(
+        &self,
+        parent: WlSurface,
+        queue_handle: &QueueHandle<State>,
+    ) -> (WlSubsurface, WlSurface)
+    where
+        State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+    {
+        let surface_data = SurfaceData::new(Some(parent.clone()), 1);
+        let surface = self.compositor.create_surface(queue_handle, surface_data);
+        let subsurface_data = SubsurfaceData::new(surface.clone());
+        let subsurface =
+            self.subcompositor.get_subsurface(&surface, &parent, queue_handle, subsurface_data);
+        (subsurface, surface)
+    }
+}
+
+impl<D> Dispatch<WlSubsurface, SubsurfaceData, D> for SubcompositorState
+where
+    D: Dispatch<WlSubsurface, SubsurfaceData>,
+{
+    fn event(
+        _: &mut D,
+        _: &WlSubsurface,
+        _: <WlSubsurface as Proxy>::Event,
+        _: &SubsurfaceData,
+        _: &Connection,
+        _: &QueueHandle<D>,
+    ) {
+        unreachable!("wl_subsurface has no events")
+    }
+}
+
+impl<D> Dispatch<WlSubcompositor, GlobalData, D> for SubcompositorState
+where
+    D: Dispatch<WlSubcompositor, GlobalData>,
+{
+    fn event(
+        _: &mut D,
+        _: &WlSubcompositor,
+        _: <WlSubcompositor as Proxy>::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<D>,
+    ) {
+        unreachable!("wl_subcompositor has no events")
+    }
+}
+
+/// The data assoctiated with the subsurface.
+#[derive(Debug)]
+pub struct SubsurfaceData {
+    /// The surface used when creating this subsurface.
+    surface: WlSurface,
+}
+
+impl SubsurfaceData {
+    pub(crate) fn new(surface: WlSurface) -> Self {
+        Self { surface }
+    }
+
+    /// Get the surface used when creating the given subsurface.
+    pub fn surface(&self) -> &WlSurface {
+        &self.surface
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_subcompositor {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $crate::reexports::client::protocol::wl_subcompositor::WlSubcompositor: $crate::globals::GlobalData
+            ] => $crate::subcompositor::SubcompositorState
+        );
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+        [
+            $crate::reexports::client::protocol::wl_subsurface::WlSubsurface: $crate::subcompositor::SubsurfaceData
+        ] => $crate::subcompositor::SubcompositorState
+        );
+    };
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, subsurface: [$($subsurface: ty),*$(,)?]) => {
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $crate::reexports::client::protocol::wl_subcompositor::WlSubcompositor: $crate::globals::GlobalData
+            ] => $crate::subcompositor::SubcompositorState
+        );
+        $(
+            $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                    $crate::reexports::client::protocol::wl_subsurface::WlSubsurface: $subsurface
+            ] => $crate::subcompositor::SubcompositorState
+            );
+        )*
+    };
+}


### PR DESCRIPTION
While the new decorations look the same as the ones before, the
approach in drawing them was changed, and now decorations are more
instant mode, meaning that you create and drop them when needed.

Fixes #273.

--

This series also adds subcompositor and subsurface handlers. The parent surface stuff is
intended to be used from inside winit, yet, I haven't added it into it.

The example which is using CSD decorations is `themed_window`.

All the drawing was ported from before.

cc @PolyMeilex 