### PR TITLE
build: don't look for libxkbcommon without feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,10 @@ calloop = { version = "0.10.5", optional = true }
 [features]
 default = ["calloop", "xkbcommon"]
 calloop = ["dep:calloop", "wayland-client/calloop"]
+xkbcommon = ["dep:xkbcommon", "pkg-config"]
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = { version = "0.3", optional = true }
 
 [dev-dependencies]
 bytemuck = "1.13.0"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,4 @@
-extern crate pkg_config;
-
 fn main() {
-    #[cfg(not(feature = "dlopen"))]
+    #[cfg(feature = "xkbcommon")]
     pkg_config::Config::new().find("xkbcommon").unwrap();
 }


### PR DESCRIPTION
--

Not sure whether the `dlopen` is needed for `xkbcommon`, but I can say for sure that it's not used right now. This commit should fix the build failure when libxkbcommon-dev is not present on the system.