### PR TITLE
window: use bitflags for window state

### DIFF
--- a/examples/generic_simple_window.rs
+++ b/examples/generic_simple_window.rs
@@ -279,7 +279,7 @@ impl<T: Test + 'static> KeyboardHandler for SimpleWindow<T> {
         keysyms: &[u32],
     ) {
         if self.window.wl_surface() == surface {
-            println!("Keyboard focus on window with pressed syms: {:?}", keysyms);
+            println!("Keyboard focus on window with pressed syms: {keysyms:?}");
             self.keyboard_focus = true;
         }
     }

--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -263,7 +263,7 @@ impl KeyboardHandler for SimpleLayer {
         keysyms: &[u32],
     ) {
         if self.layer.wl_surface() == surface {
-            println!("Keyboard focus on window with pressed syms: {:?}", keysyms);
+            println!("Keyboard focus on window with pressed syms: {keysyms:?}");
             self.keyboard_focus = true;
         }
     }

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -194,6 +194,8 @@ impl WindowHandler for SimpleWindow {
         configure: WindowConfigure,
         _serial: u32,
     ) {
+        println!("Window configured to: {:?}", configure);
+
         match configure.new_size {
             Some(size) => {
                 self.width = size.0;

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -283,7 +283,7 @@ impl KeyboardHandler for SimpleWindow {
         keysyms: &[u32],
     ) {
         if self.window.wl_surface() == surface {
-            println!("Keyboard focus on window with pressed syms: {:?}", keysyms);
+            println!("Keyboard focus on window with pressed syms: {keysyms:?}");
             self.keyboard_focus = true;
         }
     }

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -21,6 +21,7 @@ use crate::registry::GlobalProxy;
 use self::window::inner::WindowInner;
 use self::window::{
     DecorationMode, Window, WindowConfigure, WindowData, WindowDecorations, WindowHandler,
+    WindowState,
 };
 
 use super::WaylandSurface;
@@ -137,7 +138,7 @@ impl XdgShell {
                     suggested_bounds: None,
                     // Initial configure will indicate whether there are server side decorations.
                     decoration_mode: DecorationMode::Client,
-                    states: Vec::new(),
+                    state: WindowState::empty(),
                 }),
             }
         });

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -21,7 +21,7 @@ use crate::registry::GlobalProxy;
 use self::window::inner::WindowInner;
 use self::window::{
     DecorationMode, Window, WindowConfigure, WindowData, WindowDecorations, WindowHandler,
-    WindowState,
+    WindowManagerCapabilities, WindowState,
 };
 
 use super::WaylandSurface;
@@ -51,7 +51,7 @@ impl XdgShell {
             + Dispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, GlobalData, State>
             + 'static,
     {
-        let xdg_wm_base = globals.bind(qh, 1..=4, GlobalData)?;
+        let xdg_wm_base = globals.bind(qh, 1..=5, GlobalData)?;
         let xdg_decoration_manager = GlobalProxy::from(globals.bind(qh, 1..=1, GlobalData));
         Ok(Self { xdg_wm_base, xdg_decoration_manager })
     }
@@ -139,6 +139,8 @@ impl XdgShell {
                     // Initial configure will indicate whether there are server side decorations.
                     decoration_mode: DecorationMode::Client,
                     state: WindowState::empty(),
+                    // XXX by default we assume that everything is supported.
+                    capabilities: WindowManagerCapabilities::all(),
                 }),
             }
         });

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -89,7 +89,11 @@ pub struct WindowConfigure {
     ///
     /// For more see [`WindowState`] documentation on the flag values.
     pub state: WindowState,
-    // TODO: wm capabilities added in version 5.
+
+    /// The capabilities supported by the compositor.
+    ///
+    /// For more see [`WindowManagerCapabilites`] documentation on the flag values.
+    pub capabilities: WindowManagerCapabilities,
 }
 
 impl WindowConfigure {
@@ -214,6 +218,23 @@ pub enum WindowDecorations {
 
     /// The window should use server side decorations or draw any client side decorations.
     None,
+}
+
+bitflags! {
+    /// The capabilities of the window manager.
+    ///
+    /// This is a hint to hide UI elements which provide functionality
+    /// not supported by compositor.
+    pub struct WindowManagerCapabilities : u16 {
+        /// `show_window_menu` is available.
+        const WINDOW_MENU = 0b0000_0000_0000_0001;
+        /// Window can be maximized and unmaximized.
+        const MAXIMIZE = 0b0000_0000_0000_0010;
+        /// Window can be fullscreened and unfullscreened.
+        const FULLSCREEN = 0b0000_0000_0000_0100;
+        /// Window could be minimized.
+        const MINIMIZE = 0b0000_0000_0000_1000;
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This should simplify handling and storing the state downstream.