### PR TITLE
window: use NonZeroU32 for WindowConfigure::new_size

### DIFF
--- a/examples/generic_simple_window.rs
+++ b/examples/generic_simple_window.rs
@@ -197,18 +197,9 @@ impl<T: Test + 'static> WindowHandler for SimpleWindow<T> {
         configure: WindowConfigure,
         _serial: u32,
     ) {
-        match configure.new_size {
-            Some(size) => {
-                self.width = size.0;
-                self.height = size.1;
-                self.buffer = None;
-            }
-            None => {
-                self.width = 256;
-                self.height = 256;
-                self.buffer = None;
-            }
-        }
+        self.buffer = None;
+        self.width = configure.new_size.0.map(|v| v.get()).unwrap_or(256);
+        self.height = configure.new_size.1.map(|v| v.get()).unwrap_or(256);
 
         // Initiate the first draw.
         if self.first_configure {

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -198,12 +198,11 @@ impl WindowHandler for State {
             if viewer.window != *window {
                 continue;
             }
-            if let Some(size) = configure.new_size {
-                viewer.width = size.0;
-                viewer.height = size.1;
-                viewer.buffer = None;
-                viewer.damaged = true;
-            }
+
+            viewer.buffer = None;
+            viewer.width = configure.new_size.0.map(|v| v.get()).unwrap_or(256);
+            viewer.height = configure.new_size.1.map(|v| v.get()).unwrap_or(256);
+            viewer.damaged = true;
 
             // Initiate the first draw.
             viewer.first_configure = false;

--- a/examples/image_viewporter.rs
+++ b/examples/image_viewporter.rs
@@ -223,10 +223,10 @@ impl WindowHandler for State {
             if viewer.window != *window {
                 continue;
             }
-            if let Some(size) = configure.new_size {
-                viewer.width = size.0;
-                viewer.height = size.1;
-                viewer.viewport.set_destination(size.0 as _, size.1 as _);
+            if let (Some(width), Some(height)) = configure.new_size {
+                viewer.width = width.get();
+                viewer.height = height.get();
+                viewer.viewport.set_destination(width.get() as _, height.get() as _);
                 if !viewer.first_configure {
                     viewer.window.commit();
                 }

--- a/examples/pointer_theme_window.rs
+++ b/examples/pointer_theme_window.rs
@@ -190,18 +190,9 @@ impl WindowHandler for SimpleWindow {
         configure: WindowConfigure,
         _serial: u32,
     ) {
-        match configure.new_size {
-            Some(size) => {
-                self.width = size.0;
-                self.height = size.1;
-                self.buffer = None;
-            }
-            None => {
-                self.width = 256;
-                self.height = 256;
-                self.buffer = None;
-            }
-        }
+        self.buffer = None;
+        self.width = configure.new_size.0.map(|v| v.get()).unwrap_or(256);
+        self.height = configure.new_size.1.map(|v| v.get()).unwrap_or(256);
 
         // Initiate the first draw.
         if self.first_configure {

--- a/examples/relative_pointer.rs
+++ b/examples/relative_pointer.rs
@@ -191,16 +191,8 @@ impl WindowHandler for SimpleWindow {
         configure: WindowConfigure,
         _serial: u32,
     ) {
-        match configure.new_size {
-            Some(size) => {
-                self.width = size.0;
-                self.height = size.1;
-            }
-            None => {
-                self.width = 256;
-                self.height = 256;
-            }
-        }
+        self.width = configure.new_size.0.map(|v| v.get()).unwrap_or(256);
+        self.height = configure.new_size.1.map(|v| v.get()).unwrap_or(256);
 
         self.draw(conn, qh);
     }

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -196,18 +196,9 @@ impl WindowHandler for SimpleWindow {
     ) {
         println!("Window configured to: {:?}", configure);
 
-        match configure.new_size {
-            Some(size) => {
-                self.width = size.0;
-                self.height = size.1;
-                self.buffer = None;
-            }
-            None => {
-                self.width = 256;
-                self.height = 256;
-                self.buffer = None;
-            }
-        }
+        self.buffer = None;
+        self.width = configure.new_size.0.map(|v| v.get()).unwrap_or(256);
+        self.height = configure.new_size.1.map(|v| v.get()).unwrap_or(256);
 
         // Initiate the first draw.
         if self.first_configure {

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -134,7 +134,7 @@ impl XdgShell {
                 xdg_toplevel,
                 toplevel_decoration,
                 pending_configure: Mutex::new(WindowConfigure {
-                    new_size: None,
+                    new_size: (None, None),
                     suggested_bounds: None,
                     // Initial configure will indicate whether there are server side decorations.
                     decoration_mode: DecorationMode::Client,

--- a/src/shell/xdg/window/inner.rs
+++ b/src/shell/xdg/window/inner.rs
@@ -1,5 +1,6 @@
 use std::{
     convert::{TryFrom, TryInto},
+    num::NonZeroU32,
     sync::Mutex,
 };
 
@@ -121,14 +122,13 @@ where
                             acc
                         });
 
-                    let new_size = if width == 0 && height == 0 {
-                        None
-                    } else {
-                        Some((width as u32, height as u32))
-                    };
+                    // XXX we do explicit convertion and sanity checking because compositor
+                    // could pass negative values which we should ignore all together.
+                    let width = u32::try_from(width).ok().and_then(NonZeroU32::new);
+                    let height = u32::try_from(height).ok().and_then(NonZeroU32::new);
 
                     let pending_configure = &mut window.0.pending_configure.lock().unwrap();
-                    pending_configure.new_size = new_size;
+                    pending_configure.new_size = (width, height);
                     pending_configure.state = new_state;
                 }
 

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -1,6 +1,9 @@
 //! XDG shell windows.
 
-use std::sync::{Arc, Weak};
+use std::{
+    num::NonZeroU32,
+    sync::{Arc, Weak},
+};
 
 use bitflags::bitflags;
 
@@ -70,7 +73,7 @@ pub struct WindowConfigure {
     /// The compositor suggested new size of the window in window geometry coordinates.
     ///
     /// If this value is [`None`], you may set the size of the window as you wish.
-    pub new_size: Option<(u32, u32)>,
+    pub new_size: (Option<NonZeroU32>, Option<NonZeroU32>),
 
     /// Compositor suggested maximum bounds for a window.
     ///


### PR DESCRIPTION
The protocol states:

>If the width or height arguments are zero, it means the client should
>decide its own window dimension.

Meaning that either could be zero, though it's not clear whether all dimensions should be picked, or just the one with zero.

It was also observed in the wild that some compositors could send negative values for the configure, in which we should protect and pick our own sizes to not cause overflow on casting.

--

We could rollback to tuple and then if some of them is zero, meaning that both dimensions should be picked.