### PR TITLE
Use map_copy_read_only() to map the keymap file

### DIFF
--- a/src/seat/keyboard/state.rs
+++ b/src/seat/keyboard/state.rs
@@ -361,7 +361,7 @@ impl KbState {
     }
 
     pub(crate) unsafe fn init_with_fd(&mut self, fd: File, size: usize) {
-        let map = MmapOptions::new().len(size).map(&fd).unwrap();
+        let map = MmapOptions::new().len(size).map_copy_read_only(&fd).unwrap();
 
         let keymap = ffi_dispatch!(
             XKBH,


### PR DESCRIPTION
map() creates a shared, read-only map. Unfortunately there's a quirk in Linux that prevents the creation of such maps if the file is sealed for write. (which is a reasonable thing the compositor might want to do).

map_copy_read_only() creates a private, read-only map which doesn't have this problem.