### PR TITLE
Data offer source actions

### DIFF
--- a/examples/data_device.rs
+++ b/examples/data_device.rs
@@ -500,7 +500,7 @@ impl DataDeviceWindow {
 
 impl DataDeviceHandler for DataDeviceWindow {
     fn enter(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, data_device: DataDevice) {
-        let mut drag_offer = data_device.drag_offer().unwrap();
+        let drag_offer = data_device.drag_offer().unwrap();
         println!("data offer entered x: {:.2} y: {:.2}", drag_offer.x, drag_offer.y);
 
         // accept the first mime type we support

--- a/src/data_device_manager/data_offer.rs
+++ b/src/data_device_manager/data_offer.rs
@@ -61,8 +61,6 @@ pub struct DragOffer {
     pub y: f64,
     /// the timestamp a motion event was received in millisecond granularity
     pub time: Option<u32>,
-    /// accepted mime type
-    pub accepted_mime_type: Option<String>,
     /// the advertised drag actions
     pub source_actions: DndAction,
     /// the compositor selected drag action
@@ -101,8 +99,7 @@ impl DragOffer {
     /// Accept the given mime type, or None to reject the offer.
     /// In version 2, this request is used for feedback, but doesn't affect the final result of the drag-and-drop operation.
     /// In version 3, this request determines the final result of the drag-and-drop operation.
-    pub fn accept_mime_type(&mut self, serial: u32, mime_type: Option<String>) {
-        self.accepted_mime_type = mime_type.clone();
+    pub fn accept_mime_type(&self, serial: u32, mime_type: Option<String>) {
         self.data_offer.accept(serial, mime_type);
     }
 
@@ -163,7 +160,10 @@ pub enum DataDeviceOffer {
 
 impl Default for DataDeviceOffer {
     fn default() -> Self {
-        DataDeviceOffer::Undetermined(UndeterminedOffer { data_offer: None, actions: DndAction::empty() })
+        DataDeviceOffer::Undetermined(UndeterminedOffer {
+            data_offer: None,
+            actions: DndAction::empty(),
+        })
     }
 }
 
@@ -197,7 +197,7 @@ impl DataDeviceOffer {
         receive(inner, mime_type).map_err(DataOfferError::Io)
     }
 
-    pub fn accept_mime_type(&mut self, serial: u32, mime_type: Option<String>) {
+    pub fn accept_mime_type(&self, serial: u32, mime_type: Option<String>) {
         match self {
             DataDeviceOffer::Drag(o) => o.accept_mime_type(serial, mime_type),
             DataDeviceOffer::Selection(_) => {}
@@ -205,7 +205,7 @@ impl DataDeviceOffer {
         };
     }
 
-    pub fn set_actions(&mut self, actions: DndAction, preferred_action: DndAction) {
+    pub fn set_actions(&self, actions: DndAction, preferred_action: DndAction) {
         match self {
             DataDeviceOffer::Drag(o) => o.set_actions(actions, preferred_action),
             DataDeviceOffer::Selection(_) => {}
@@ -299,7 +299,6 @@ impl DataOfferData {
             DataDeviceOffer::Selection(o) => {
                 inner.offer = DataDeviceOffer::Drag(DragOffer {
                     data_offer: o.data_offer.clone(),
-                    accepted_mime_type: None,
                     source_actions: DndAction::empty(),
                     selected_action: DndAction::empty(),
                     serial,
@@ -312,7 +311,6 @@ impl DataOfferData {
             DataDeviceOffer::Undetermined(o) => {
                 inner.offer = DataDeviceOffer::Drag(DragOffer {
                     data_offer: o.data_offer.clone().unwrap(),
-                    accepted_mime_type: None,
                     source_actions: o.actions,
                     selected_action: DndAction::empty(),
                     serial,


### PR DESCRIPTION
While the description at https://wayland.app/protocols/wayland#wl_data_offer:event:source_actions is confusing to me, the way I read it implies that enter event should be sent before source actions for DnD offers. In practice, I've only ever seen the source actions sent before the enter event :sweat:.

This PR fixes the implementation so that an undetermined offer also tracks advertised source actions. When the enter event is being handled, source actions can be checked and handled as well at the same time. It doesn't call the source_actions method though, because the method expects a drag offer. It also cleans up an unused variable and makes a couple methods take `&self` instead of `&mut self`.

Ultimately I don't think this event matters so much because clients can still set their preferred action and accepted actions regardless, but the info from the source actions should be available if it is received.