### PR TITLE
seat/pointer: simplify ThemedPointer handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+#### Breaking Changes
+
+- `ThemedPointer::set_cursor` now takes only `Connection` and `&str`.
+- `SeatState:get_pointer_with_them*` now takes `Shm` and `WlSurface` for the themed cursor.
+- `ThemedPointer` now automatically releases the associated `WlPointer`.
+- `CursorIcon` from `cursor-icon` crate is now used for `set_cursor` and `Frame`.
+
 ## 0.17.0 - 2023-03-28
 
 #### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,18 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bitflags = "1.0"
-nix = { version = "0.26.1", default-features = false, features = ["fs", "mman"] }
+cursor-icon = "1.0.0"
 dlib = "0.5"
 lazy_static = "1.0"
-memmap2 = "0.5.0"
 log = "0.4"
+memmap2 = "0.5.0"
+nix = { version = "0.26.1", default-features = false, features = ["fs", "mman"] }
 thiserror = "1.0.30"
 wayland-backend = "0.1.0"
 wayland-client = "0.30.1"
+wayland-cursor = "0.30.0"
 wayland-protocols = { version = "0.30.0", features = ["client", "unstable"] }
 wayland-protocols-wlr = { version = "0.1.0", features = ["client"] }
-wayland-cursor = "0.30.0"
 wayland-scanner = "0.30.0"
 
 xkbcommon = { version = "0.5", optional = true, features = ["wayland"] }

--- a/src/shell/xdg/frame/fallback_frame.rs
+++ b/src/shell/xdg/frame/fallback_frame.rs
@@ -11,6 +11,7 @@ use crate::reexports::protocols::xdg::shell::client::xdg_toplevel::ResizeEdge;
 
 use crate::{
     compositor::SurfaceData,
+    seat::pointer::CursorIcon,
     shell::xdg::{WindowManagerCapabilities, WindowState},
     shell::WaylandSurface,
     shm::{slot::SlotPool, Shm},
@@ -357,7 +358,7 @@ where
         }
     }
 
-    fn click_point_moved(&mut self, surface: &WlSurface, x: f64, y: f64) -> Option<&str> {
+    fn click_point_moved(&mut self, surface: &WlSurface, x: f64, y: f64) -> Option<CursorIcon> {
         let part_index = self.part_index_for_surface(surface)?;
         let location = match part_index {
             LEFT_BORDER => Location::Left,
@@ -383,15 +384,15 @@ where
             && old_location != self.mouse_location;
 
         Some(match self.mouse_location {
-            Location::Top => "top_side",
-            Location::TopRight => "top_right_corner",
-            Location::Right => "right_side",
-            Location::BottomRight => "bottom_right_corner",
-            Location::Bottom => "bottom_side",
-            Location::BottomLeft => "bottom_left_corner",
-            Location::Left => "left_side",
-            Location::TopLeft => "top_left_corner",
-            _ => "left_ptr",
+            Location::Top => CursorIcon::NResize,
+            Location::TopRight => CursorIcon::NeResize,
+            Location::Right => CursorIcon::EResize,
+            Location::BottomRight => CursorIcon::SeResize,
+            Location::Bottom => CursorIcon::SResize,
+            Location::BottomLeft => CursorIcon::SwResize,
+            Location::Left => CursorIcon::WResize,
+            Location::TopLeft => CursorIcon::NwResize,
+            _ => CursorIcon::Default,
         })
     }
 

--- a/src/shell/xdg/frame/mod.rs
+++ b/src/shell/xdg/frame/mod.rs
@@ -5,6 +5,7 @@ use std::num::NonZeroU32;
 use crate::reexports::client::protocol::wl_surface::WlSurface;
 use crate::reexports::protocols::xdg::shell::client::xdg_toplevel::ResizeEdge;
 
+use crate::seat::pointer::CursorIcon;
 use crate::shell::xdg::window::{WindowManagerCapabilities, WindowState};
 
 pub mod fallback_frame;
@@ -28,7 +29,7 @@ pub trait DecorationsFrame: Sized {
     /// The return value is the new cursor icon you should apply to provide better visual
     /// feedback for the user. However, you might want to ignore it, if you're using touch events
     /// to drive the movements.
-    fn click_point_moved(&mut self, surface: &WlSurface, x: f64, y: f64) -> Option<&str>;
+    fn click_point_moved(&mut self, surface: &WlSurface, x: f64, y: f64) -> Option<CursorIcon>;
 
     /// All clicks left the decorations.
     ///


### PR DESCRIPTION
This should simplify the handling of custom cursors in the user applications by incapsulating all the necessary state in the ThemedPointer.

In the future we can automatically handle the `wp_cursor_shape` under the hood.