### PR TITLE
fix wgpu example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ image = "0.23"
 env_logger = "0.9"
 wgpu = "0.15.0"
 raqote = "0.8.2"
-raw-window-handle = "0.4.3"
+raw-window-handle = "0.5.2"
 pollster = "0.2.5"
 
 [[example]]

--- a/examples/wgpu.rs
+++ b/examples/wgpu.rs
@@ -204,16 +204,9 @@ impl WindowHandler for Wgpu {
         configure: WindowConfigure,
         _serial: u32,
     ) {
-        match configure.new_size {
-            Some(size) => {
-                self.width = size.0;
-                self.height = size.1;
-            }
-            None => {
-                self.width = 256;
-                self.height = 256;
-            }
-        }
+        let (new_width, new_height) = configure.new_size;
+        self.width = new_width.map_or(256, |v| v.get());
+        self.height = new_height.map_or(256, |v| v.get());
 
         let adapter = &self.adapter;
         let surface = &self.surface;


### PR DESCRIPTION
The wgpu example wasn't building, I noticed [Has]RawDisplayHandle wasn't available until v0.5 so I bumped it up
`WindowConfigure.new_size` had also changed into a tuple of options so I fixed that too.

running `cargo run --example wgpu --features="wayland-backend/client_system"` now shows a big blue window, and resizing and toggling fullscreen seems to work fine