### PR TITLE
Remove unused `lazy_static` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 bitflags = "1.0"
 cursor-icon = "1.0.0"
 dlib = "0.5"
-lazy_static = "1.0"
 log = "0.4"
 memmap2 = "0.5.0"
 nix = { version = "0.26.1", default-features = false, features = ["fs", "mman"] }


### PR DESCRIPTION
Not sure when this happened, but apparently the `lazy_static` dependency is entirely unused.

Would play nice with https://github.com/Smithay/wayland-rs/pull/627.