### PR TITLE
api: add zwp_primary_selection_v1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### Additions
 
 - Make `DataDeviceManagerState`'s `create_{copy_paste,drag_and_drop}_source` accept `IntoIterator<Item = T: ToString>`.
+- Add support for `zwp_primary_selection_v1`.
 
 ## 0.17.0 - 2023-03-28
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod data_device_manager;
 pub mod error;
 pub mod globals;
 pub mod output;
+pub mod primary_selection;
 pub mod registry;
 pub mod seat;
 pub mod shell;

--- a/src/primary_selection/device.rs
+++ b/src/primary_selection/device.rs
@@ -1,0 +1,148 @@
+use std::sync::{Arc, Mutex};
+
+use crate::reexports::client::{
+    event_created_child, protocol::wl_seat::WlSeat, Connection, Dispatch, Proxy, QueueHandle,
+};
+use crate::reexports::protocols::wp::primary_selection::zv1::client::{
+    zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1,
+    zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1,
+};
+
+use super::{
+    offer::{PrimarySelectionOffer, PrimarySelectionOfferData},
+    PrimarySelectionManagerState,
+};
+
+pub trait PrimarySelectionDeviceHandler: Sized {
+    /// The new selection is received.
+    ///
+    /// The given primary selection device could be used to identify [`PrimarySelectionDevice`].
+    fn selection(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        primary_selection_device: &ZwpPrimarySelectionDeviceV1,
+    );
+}
+
+#[derive(Debug)]
+pub struct PrimarySelectionDevice {
+    pub(crate) device: ZwpPrimarySelectionDeviceV1,
+}
+
+impl PrimarySelectionDevice {
+    /// Remove the currently active selection.
+    ///
+    /// The passed `serial` is the serial of the input event.
+    pub fn unset_selection(&self, serial: u32) {
+        self.device.set_selection(None, serial);
+    }
+
+    /// Get the underlying data.
+    pub fn data(&self) -> &PrimarySelectionDeviceData {
+        self.device.data::<PrimarySelectionDeviceData>().unwrap()
+    }
+}
+
+impl Drop for PrimarySelectionDevice {
+    fn drop(&mut self) {
+        self.device.destroy();
+    }
+}
+
+impl<State> Dispatch<ZwpPrimarySelectionDeviceV1, PrimarySelectionDeviceData, State>
+    for PrimarySelectionManagerState
+where
+    State: Dispatch<ZwpPrimarySelectionDeviceV1, PrimarySelectionDeviceData>
+        + Dispatch<ZwpPrimarySelectionOfferV1, PrimarySelectionOfferData>
+        + PrimarySelectionDeviceHandler
+        + 'static,
+{
+    event_created_child!(State, ZwpPrimarySelectionDeviceV1, [
+        0 => (ZwpPrimarySelectionOfferV1, PrimarySelectionOfferData::default())
+    ]);
+
+    fn event(
+        state: &mut State,
+        proxy: &ZwpPrimarySelectionDeviceV1,
+        event: <ZwpPrimarySelectionDeviceV1 as wayland_client::Proxy>::Event,
+        data: &PrimarySelectionDeviceData,
+        conn: &Connection,
+        qhandle: &QueueHandle<State>,
+    ) {
+        use wayland_protocols::wp::primary_selection::zv1::client::zwp_primary_selection_device_v1::Event;
+        let mut data = data.inner.lock().unwrap();
+        match event {
+            Event::DataOffer { offer } => {
+                // Try to resist faulty compositors.
+                if let Some(pending_offer) = data.pending_offer.take() {
+                    pending_offer.destroy();
+                }
+
+                data.pending_offer = Some(offer);
+            }
+            Event::Selection { id } => {
+                // We must drop the current offer regardless.
+                if let Some(offer) = data.offer.take() {
+                    offer.destroy();
+                }
+
+                if id == data.pending_offer {
+                    data.offer = data.pending_offer.take();
+                } else {
+                    // Remove the pending offer, assign the new delivered one.
+                    if let Some(offer) = data.pending_offer.take() {
+                        offer.destroy()
+                    }
+
+                    data.offer = id;
+                }
+
+                // Release the user data lock before calling into user.
+                drop(data);
+
+                state.selection(conn, qhandle, proxy);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// The user data associated with the [`ZwpPrimarySelectionDeviceV1`].
+#[derive(Debug)]
+pub struct PrimarySelectionDeviceData {
+    /// The seat associated with this device.
+    seat: WlSeat,
+    /// The inner mutable storage.
+    inner: Arc<Mutex<PrimarySelectionDeviceDataInner>>,
+}
+
+impl PrimarySelectionDeviceData {
+    pub(crate) fn new(seat: WlSeat) -> Self {
+        Self { seat, inner: Default::default() }
+    }
+
+    /// The seat used to create this primary selection device.
+    pub fn seat(&self) -> &WlSeat {
+        &self.seat
+    }
+
+    /// The active selection offer.
+    pub fn selection_offer(&self) -> Option<PrimarySelectionOffer> {
+        self.inner
+            .lock()
+            .unwrap()
+            .offer
+            .as_ref()
+            .map(|offer| PrimarySelectionOffer { offer: offer.clone() })
+    }
+}
+
+#[derive(Debug, Default)]
+struct PrimarySelectionDeviceDataInner {
+    /// The offer is valid until either `NULL` or new selection is received via the
+    /// `selection` event.
+    offer: Option<ZwpPrimarySelectionOfferV1>,
+    /// The offer we've got in `offer` event, but not finished it in `selection`.
+    pending_offer: Option<ZwpPrimarySelectionOfferV1>,
+}

--- a/src/primary_selection/mod.rs
+++ b/src/primary_selection/mod.rs
@@ -1,0 +1,120 @@
+use crate::globals::GlobalData;
+use crate::reexports::client::{
+    globals::{BindError, GlobalList},
+    protocol::wl_seat::WlSeat,
+    Dispatch, QueueHandle,
+};
+use crate::reexports::protocols::wp::primary_selection::zv1::client::{
+    zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1,
+    zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1,
+    zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1,
+};
+
+pub mod device;
+pub mod offer;
+pub mod selection;
+
+use self::device::{PrimarySelectionDevice, PrimarySelectionDeviceData};
+use selection::PrimarySelectionSource;
+
+#[derive(Debug)]
+pub struct PrimarySelectionManagerState {
+    manager: ZwpPrimarySelectionDeviceManagerV1,
+}
+
+impl PrimarySelectionManagerState {
+    pub fn bind<State>(globals: &GlobalList, qh: &QueueHandle<State>) -> Result<Self, BindError>
+    where
+        State: Dispatch<ZwpPrimarySelectionDeviceManagerV1, GlobalData, State> + 'static,
+    {
+        let manager = globals.bind(qh, 1..=1, GlobalData)?;
+        Ok(Self { manager })
+    }
+
+    /// The underlying wayland object.
+    pub fn primary_selection_manager(&self) -> &ZwpPrimarySelectionDeviceManagerV1 {
+        &self.manager
+    }
+
+    /// Create a primary selection source.
+    pub fn create_selection_source<State, I, T>(
+        &self,
+        qh: &QueueHandle<State>,
+        mime_types: I,
+    ) -> PrimarySelectionSource
+    where
+        State: Dispatch<ZwpPrimarySelectionSourceV1, GlobalData, State> + 'static,
+        I: IntoIterator<Item = T>,
+        T: ToString,
+    {
+        let source = self.manager.create_source(qh, GlobalData);
+
+        for mime_type in mime_types {
+            source.offer(mime_type.to_string());
+        }
+
+        PrimarySelectionSource::new(source)
+    }
+
+    /// Get the primary selection data device for the given seat.
+    pub fn get_selection_device<State>(
+        &self,
+        qh: &QueueHandle<State>,
+        seat: &WlSeat,
+    ) -> PrimarySelectionDevice
+    where
+        State: Dispatch<ZwpPrimarySelectionDeviceV1, PrimarySelectionDeviceData, State> + 'static,
+    {
+        PrimarySelectionDevice {
+            device: self.manager.get_device(
+                seat,
+                qh,
+                PrimarySelectionDeviceData::new(seat.clone()),
+            ),
+        }
+    }
+}
+
+impl Drop for PrimarySelectionManagerState {
+    fn drop(&mut self) {
+        self.manager.destroy();
+    }
+}
+
+impl<D> Dispatch<ZwpPrimarySelectionDeviceManagerV1, GlobalData, D> for PrimarySelectionManagerState
+where
+    D: Dispatch<ZwpPrimarySelectionDeviceManagerV1, GlobalData>,
+{
+    fn event(
+        _: &mut D,
+        _: &ZwpPrimarySelectionDeviceManagerV1,
+        _: <ZwpPrimarySelectionDeviceManagerV1 as wayland_client::Proxy>::Event,
+        _: &GlobalData,
+        _: &wayland_client::Connection,
+        _: &QueueHandle<D>,
+    ) {
+        unreachable!("zwp_primary_selection_device_manager_v1 has no events")
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_primary_selection {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1: $crate::globals::GlobalData
+            ] => $crate::primary_selection::PrimarySelectionManagerState);
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1: $crate::primary_selection::device::PrimarySelectionDeviceData
+            ] => $crate::primary_selection::PrimarySelectionManagerState);
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1: $crate::primary_selection::offer::PrimarySelectionOfferData
+            ] => $crate::primary_selection::PrimarySelectionManagerState);
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1: $crate::globals::GlobalData
+            ] => $crate::primary_selection::PrimarySelectionManagerState);
+    };
+}

--- a/src/primary_selection/offer.rs
+++ b/src/primary_selection/offer.rs
@@ -1,0 +1,101 @@
+use std::{
+    os::unix::io::{FromRawFd, RawFd},
+    sync::Mutex,
+};
+
+use crate::reexports::client::{Connection, Dispatch, QueueHandle, Proxy};
+use crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1;
+
+use crate::data_device_manager::ReadPipe;
+
+use super::PrimarySelectionManagerState;
+
+/// RAII wrapper around the [`ZwpPrimarySelectionOfferV1`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrimarySelectionOffer {
+    pub(crate) offer: ZwpPrimarySelectionOfferV1,
+}
+
+impl PrimarySelectionOffer {
+    /// Inspect the mime types available on the given offer.
+    pub fn with_mime_types<T, F: Fn(&[String]) -> T>(&self, callback: F) -> T {
+        let mime_types =
+            self.offer.data::<PrimarySelectionOfferData>().unwrap().mimes.lock().unwrap();
+        callback(mime_types.as_ref())
+    }
+
+    /// Request to receive the data of a given mime type.
+    ///
+    /// You can call this function several times.
+    ///
+    /// Note that you should *not* read the contents right away in a
+    /// blocking way, as you may deadlock your application doing so.
+    /// At least make sure you flush your events to the server before
+    /// doing so.
+    ///
+    /// Fails if too many file descriptors were already open and a pipe
+    /// could not be created.
+    pub fn receive(&self, mime_type: String) -> std::io::Result<ReadPipe> {
+        use nix::fcntl::OFlag;
+        use nix::unistd::{close, pipe2};
+        // create a pipe
+        let (readfd, writefd) = pipe2(OFlag::O_CLOEXEC)?;
+
+        self.offer.receive(mime_type, writefd);
+
+        if let Err(err) = close(writefd) {
+            log::warn!("Failed to close write pipe: {}", err);
+        }
+
+        Ok(unsafe { FromRawFd::from_raw_fd(readfd) })
+    }
+
+    /// # Safety
+    ///
+    /// The provided file destructor must be a valid FD for writing, and will be closed
+    /// once the contents are written.
+    pub unsafe fn receive_to_fd(&self, mime_type: String, writefd: RawFd) {
+        use nix::unistd::close;
+
+        self.offer.receive(mime_type, writefd);
+
+        if let Err(err) = close(writefd) {
+            log::warn!("Failed to close write pipe: {}", err);
+        }
+    }
+}
+
+impl Drop for PrimarySelectionOffer {
+    fn drop(&mut self) {
+        self.offer.destroy();
+    }
+}
+
+impl<State> Dispatch<ZwpPrimarySelectionOfferV1, PrimarySelectionOfferData, State>
+    for PrimarySelectionManagerState
+where
+    State: Dispatch<ZwpPrimarySelectionOfferV1, PrimarySelectionOfferData>,
+{
+    fn event(
+        _: &mut State,
+        _: &ZwpPrimarySelectionOfferV1,
+        event: <ZwpPrimarySelectionOfferV1 as wayland_client::Proxy>::Event,
+        data: &PrimarySelectionOfferData,
+        _: &Connection,
+        _: &QueueHandle<State>,
+    ) {
+        use wayland_protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::Event;
+        match event {
+            Event::Offer { mime_type } => {
+                data.mimes.lock().unwrap().push(mime_type);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// The data associated with the [`ZwpPrimarySelectionOfferV1`].
+#[derive(Debug, Default)]
+pub struct PrimarySelectionOfferData {
+    mimes: Mutex<Vec<String>>,
+}

--- a/src/primary_selection/selection.rs
+++ b/src/primary_selection/selection.rs
@@ -1,0 +1,82 @@
+use crate::reexports::client::{Connection, Dispatch, QueueHandle};
+use crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1;
+use crate::{data_device_manager::WritePipe, globals::GlobalData};
+
+use super::{device::PrimarySelectionDevice, PrimarySelectionManagerState};
+
+/// Handler trait for `PrimarySelectionSource` events.
+///
+/// The functions defined in this trait are called as DataSource events are received from the compositor.
+pub trait PrimarySelectionSourceHandler: Sized {
+    /// The client has requested the data for this source to be sent.
+    /// Send the data, then close the fd.
+    fn send_request(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        source: &ZwpPrimarySelectionSourceV1,
+        mime: String,
+        write_pipe: WritePipe,
+    );
+
+    /// The data source is no longer valid
+    /// Cleanup & destroy this resource
+    fn cancelled(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        source: &ZwpPrimarySelectionSourceV1,
+    );
+}
+
+/// Wrapper around the [`ZwpPrimarySelectionSourceV1`].
+#[derive(Debug, PartialEq, Eq)]
+pub struct PrimarySelectionSource {
+    source: ZwpPrimarySelectionSourceV1,
+}
+
+impl PrimarySelectionSource {
+    pub(crate) fn new(source: ZwpPrimarySelectionSourceV1) -> Self {
+        Self { source }
+    }
+
+    /// Set the selection on the given [`PrimarySelectionDevice`].
+    pub fn set_selection(&self, device: &PrimarySelectionDevice, serial: u32) {
+        device.device.set_selection(Some(&self.source), serial);
+    }
+
+    /// The underlying wayland object.
+    pub fn inner(&self) -> &ZwpPrimarySelectionSourceV1 {
+        &self.source
+    }
+}
+
+impl Drop for PrimarySelectionSource {
+    fn drop(&mut self) {
+        self.source.destroy();
+    }
+}
+
+impl<State> Dispatch<ZwpPrimarySelectionSourceV1, GlobalData, State>
+    for PrimarySelectionManagerState
+where
+    State: Dispatch<ZwpPrimarySelectionSourceV1, GlobalData> + PrimarySelectionSourceHandler,
+{
+    fn event(
+        state: &mut State,
+        proxy: &ZwpPrimarySelectionSourceV1,
+        event: <ZwpPrimarySelectionSourceV1 as wayland_client::Proxy>::Event,
+        _: &GlobalData,
+        conn: &wayland_client::Connection,
+        qhandle: &QueueHandle<State>,
+    ) {
+        use wayland_protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::Event as PrimarySelectionSourceEvent;
+        match event {
+            PrimarySelectionSourceEvent::Send { mime_type, fd } => {
+                state.send_request(conn, qhandle, proxy, mime_type, fd.into())
+            }
+            PrimarySelectionSourceEvent::Cancelled => state.cancelled(conn, qhandle, proxy),
+            _ => unreachable!(),
+        }
+    }
+}


### PR DESCRIPTION
Add support for the zwp_primary_selection_v1 protocol. The implementation is similar to the existing data_device protocol, however much simpler, given that there's no drag and drop.

The data_device example was abused to show the primary selection in use.