### PR TITLE
WIP Update wayland-rs and calloop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,20 +23,21 @@ log = "0.4"
 memmap2 = "0.7.0"
 nix = { version = "0.26.1", default-features = false, features = ["fs", "mman"] }
 thiserror = "1.0.30"
-wayland-backend = "0.1.0"
-wayland-client = "0.30.2"
-wayland-cursor = "0.30.0"
-wayland-protocols = { version = "0.30.1", features = ["client", "staging", "unstable"] }
-wayland-protocols-wlr = { version = "0.1.0", features = ["client"] }
-wayland-scanner = "0.30.0"
-wayland-csd-frame = { version = "0.2.2", default-features = false, features = ["wayland-backend_0_1"] }
+wayland-backend = "0.3.0"
+wayland-client = "0.31.0"
+wayland-cursor = "0.31.0"
+wayland-protocols = { version = "0.31.0", features = ["client", "staging", "unstable"] }
+wayland-protocols-wlr = { version = "0.2.0", features = ["client"] }
+wayland-scanner = "0.31.0"
+# wayland-csd-frame = { version = "0.2.2", default-features = false, features = ["wayland-backend_0_3"] }
+wayland-csd-frame = { git = "https://github.com/ids1024/wayland-csd-frame", branch = "wayland_backend_0_3", default-features = false, features = ["wayland-backend_0_3"] }
 
 xkbcommon = { version = "0.5", optional = true, features = ["wayland"] }
-calloop = { version = "0.10.5", optional = true }
+calloop = { version = "0.11.0", optional = true }
 
 [features]
 default = ["calloop", "xkbcommon"]
-calloop = ["dep:calloop", "wayland-client/calloop"]
+calloop = ["dep:calloop"]
 xkbcommon = ["dep:xkbcommon", "pkg-config"]
 
 [build-dependencies]
@@ -55,3 +56,7 @@ pollster = "0.2.5"
 [[example]]
 name = "wgpu"
 required-features = ["wayland-backend/client_system"]
+
+[patch.crates-io]
+wayland-backend = { git = "https://github.com/ids1024/wayland-rs", branch = "client-as-fd" }
+wayland-client = { git = "https://github.com/ids1024/wayland-rs", branch = "client-as-fd" }

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -2,6 +2,7 @@ use std::{convert::TryInto, time::Duration};
 
 use calloop::{EventLoop, LoopHandle};
 use smithay_client_toolkit::{
+    calloop::WaylandSource,
     compositor::{CompositorHandler, CompositorState},
     delegate_compositor, delegate_keyboard, delegate_output, delegate_pointer, delegate_registry,
     delegate_seat, delegate_shm, delegate_xdg_shell, delegate_xdg_window,
@@ -28,7 +29,7 @@ use smithay_client_toolkit::{
 use wayland_client::{
     globals::registry_queue_init,
     protocol::{wl_keyboard, wl_output, wl_pointer, wl_seat, wl_shm, wl_surface},
-    Connection, QueueHandle, WaylandSource,
+    Connection, QueueHandle,
 };
 
 fn main() {

--- a/src/calloop.rs
+++ b/src/calloop.rs
@@ -1,0 +1,200 @@
+//! Utilities for using an [`EventQueue`] from wayland-client with an event loop that performs polling with
+//! [`calloop`](https://crates.io/crates/calloop).
+
+use std::io;
+
+use calloop::{
+    generic::Generic, EventSource, InsertError, Interest, LoopHandle, Mode, Poll, PostAction,
+    Readiness, RegistrationToken, Token, TokenFactory,
+};
+use nix::errno::Errno;
+use wayland_backend::client::{ReadEventsGuard, WaylandError};
+use wayland_client::{DispatchError, EventQueue};
+
+/// An adapter to insert an [`EventQueue`] into a calloop [`EventLoop`](calloop::EventLoop).
+///
+/// This type implements [`EventSource`] which generates an event whenever events on the event queue need to be
+/// dispatched. The event queue available in the callback calloop registers may be used to dispatch pending
+/// events using [`EventQueue::dispatch_pending`].
+///
+/// [`WaylandSource::insert`] can be used to insert this source into an event loop and automatically dispatch
+/// pending events on the event queue.
+#[derive(Debug)]
+pub struct WaylandSource<D> {
+    queue: Generic<EventQueue<D>>,
+    read_guard: Option<ReadEventsGuard>,
+}
+
+impl<D> WaylandSource<D> {
+    /// Wrap an [`EventQueue`] as a [`WaylandSource`].
+    pub fn new(queue: EventQueue<D>) -> Result<WaylandSource<D>, WaylandError> {
+        let queue = Generic::new(queue, Interest::READ, Mode::Level);
+
+        Ok(WaylandSource { queue, read_guard: None })
+    }
+
+    /// Access the underlying event queue
+    ///
+    /// Note that you should be careful when interacting with it if you invoke methods that
+    /// interact with the wayland socket (such as `dispatch()` or `prepare_read()`). These may
+    /// interfere with the proper waking up of this event source in the event loop.
+    pub fn queue(&mut self) -> &mut EventQueue<D> {
+        &mut self.queue.file
+    }
+
+    /// Insert this source into the given event loop.
+    ///
+    /// This adapter will pass the event loop's shared data as the `D` type for the event loop.
+    pub fn insert(self, handle: LoopHandle<D>) -> Result<RegistrationToken, InsertError<Self>>
+    where
+        D: 'static,
+    {
+        handle.insert_source(self, |_, queue, data| queue.dispatch_pending(data))
+    }
+}
+
+impl<D> EventSource for WaylandSource<D> {
+    type Event = ();
+
+    /// The underlying event queue.
+    ///
+    /// You should call [`EventQueue::dispatch_pending`] inside your callback using this queue.
+    type Metadata = EventQueue<D>;
+    type Ret = Result<usize, DispatchError>;
+    type Error = calloop::Error;
+
+    fn process_events<F>(
+        &mut self,
+        readiness: Readiness,
+        token: Token,
+        mut callback: F,
+    ) -> Result<PostAction, Self::Error>
+    where
+        F: FnMut(Self::Event, &mut Self::Metadata) -> Self::Ret,
+    {
+        let read_guard = &mut self.read_guard;
+
+        let action = self.queue.process_events(readiness, token, |_, queue| {
+            // 1. read events from the socket if any are available
+            if let Some(guard) = read_guard.take() {
+                // might be None if some other thread read events before us, concurrently
+                if let Err(WaylandError::Io(err)) = guard.read() {
+                    if err.kind() != io::ErrorKind::WouldBlock {
+                        return Err(err);
+                    }
+                }
+            }
+
+            // 2. dispatch any pending events in the queue
+            // This is done to ensure we are not waiting for messages that are already in the buffer.
+            Self::loop_callback_pending(queue, &mut callback)?;
+            *read_guard = queue.prepare_read();
+
+            // 3. Once dispatching is finished, flush the responses to the compositor
+            if let Err(WaylandError::Io(e)) = queue.flush() {
+                if e.kind() != io::ErrorKind::WouldBlock {
+                    // in case of error, forward it and fast-exit
+                    return Err(e);
+                }
+                // WouldBlock error means the compositor could not process all our messages
+                // quickly. Either it is slowed down or we are a spammer.
+                // Should not really happen, if it does we do nothing and will flush again later
+            }
+
+            Ok(PostAction::Continue)
+        })?;
+
+        Ok(action)
+    }
+
+    fn register(
+        &mut self,
+        poll: &mut Poll,
+        token_factory: &mut TokenFactory,
+    ) -> calloop::Result<()> {
+        self.queue.register(poll, token_factory)
+    }
+
+    fn reregister(
+        &mut self,
+        poll: &mut Poll,
+        token_factory: &mut TokenFactory,
+    ) -> calloop::Result<()> {
+        self.queue.reregister(poll, token_factory)
+    }
+
+    fn unregister(&mut self, poll: &mut Poll) -> calloop::Result<()> {
+        self.queue.unregister(poll)
+    }
+
+    fn pre_run<F>(&mut self, mut callback: F) -> calloop::Result<()>
+    where
+        F: FnMut((), &mut Self::Metadata) -> Self::Ret,
+    {
+        debug_assert!(self.read_guard.is_none());
+
+        // flush the display before starting to poll
+        if let Err(WaylandError::Io(err)) = self.queue().flush() {
+            if err.kind() != io::ErrorKind::WouldBlock {
+                // in case of error, don't prepare a read, if the error is persistent, it'll trigger in other
+                // wayland methods anyway
+                log::error!("Error trying to flush the wayland display: {}", err);
+                return Err(err.into());
+            }
+        }
+
+        // ensure we are not waiting for messages that are already in the buffer.
+        Self::loop_callback_pending(&mut self.queue(), &mut callback)?;
+        self.read_guard = self.queue().prepare_read();
+
+        Ok(())
+    }
+
+    fn post_run<F>(&mut self, _: F) -> calloop::Result<()>
+    where
+        F: FnMut((), &mut Self::Metadata) -> Self::Ret,
+    {
+        // Drop implementation of ReadEventsGuard will do cleanup
+        self.read_guard.take();
+        Ok(())
+    }
+}
+
+impl<D> WaylandSource<D> {
+    /// Loop over the callback until all pending messages have been dispatched.
+    fn loop_callback_pending<F>(queue: &mut EventQueue<D>, callback: &mut F) -> io::Result<()>
+    where
+        F: FnMut((), &mut EventQueue<D>) -> Result<usize, DispatchError>,
+    {
+        // Loop on the callback until no pending events are left.
+        loop {
+            match callback((), queue) {
+                // No more pending events.
+                Ok(0) => break Ok(()),
+
+                Ok(_) => continue,
+
+                Err(DispatchError::Backend(WaylandError::Io(err))) => {
+                    return Err(err);
+                }
+
+                Err(DispatchError::Backend(WaylandError::Protocol(err))) => {
+                    log::error!("Protocol error received on display: {}", err);
+
+                    break Err(Errno::EPROTO.into());
+                }
+
+                Err(DispatchError::BadMessage { interface, sender_id, opcode }) => {
+                    log::error!(
+                        "Bad message on interface \"{}\": (sender_id: {}, opcode: {})",
+                        interface,
+                        sender_id,
+                        opcode,
+                    );
+
+                    break Err(Errno::EPROTO.into());
+                }
+            }
+        }
+    }
+}

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -423,7 +423,7 @@ impl wayland_client::backend::ObjectData for RegionData {
         _: &wayland_client::backend::Backend,
         _: wayland_client::backend::protocol::Message<
             wayland_client::backend::ObjectId,
-            wayland_backend::io_lifetimes::OwnedFd,
+            std::os::unix::io::OwnedFd,
         >,
     ) -> Option<Arc<(dyn wayland_client::backend::ObjectData + 'static)>> {
         unreachable!("wl_region has no events");

--- a/src/data_device_manager/read_pipe.rs
+++ b/src/data_device_manager/read_pipe.rs
@@ -1,8 +1,7 @@
 use std::{
     fs, io,
-    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd},
 };
-use wayland_backend::io_lifetimes::{AsFd, OwnedFd};
 
 /// If the `calloop` cargo feature is enabled, this can be used
 /// as an `EventSource` in a calloop event loop.
@@ -78,7 +77,7 @@ impl AsRawFd for ReadPipe {
 
 #[cfg(feature = "calloop")]
 impl AsFd for ReadPipe {
-    fn as_fd(&self) -> wayland_backend::io_lifetimes::BorrowedFd<'_> {
+    fn as_fd(&self) -> std::os::unix::io::BorrowedFd<'_> {
         self.file.file.as_fd()
     }
 }
@@ -92,7 +91,7 @@ impl AsRawFd for ReadPipe {
 #[cfg(not(feature = "calloop"))]
 
 impl AsFd for ReadPipe {
-    fn as_fd(&self) -> wayland_backend::io_lifetimes::BorrowedFd<'_> {
+    fn as_fd(&self) -> std::os::unix::io::BorrowedFd<'_> {
         self.file.as_fd()
     }
 }

--- a/src/data_device_manager/write_pipe.rs
+++ b/src/data_device_manager/write_pipe.rs
@@ -1,8 +1,7 @@
 use std::{
     fs, io,
-    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd},
 };
-use wayland_backend::io_lifetimes::{AsFd, OwnedFd};
 
 /// If the `calloop` cargo feature is enabled, this can be used
 /// as an `EventSource` in a calloop event loop.
@@ -86,7 +85,7 @@ impl AsRawFd for WritePipe {
 
 #[cfg(feature = "calloop")]
 impl AsFd for WritePipe {
-    fn as_fd(&self) -> wayland_backend::io_lifetimes::BorrowedFd<'_> {
+    fn as_fd(&self) -> std::os::unix::io::BorrowedFd<'_> {
         self.file.file.as_fd()
     }
 }
@@ -100,7 +99,7 @@ impl AsRawFd for WritePipe {
 #[cfg(not(feature = "calloop"))]
 
 impl AsFd for WritePipe {
-    fn as_fd(&self) -> wayland_backend::io_lifetimes::BorrowedFd<'_> {
+    fn as_fd(&self) -> std::os::unix::io::BorrowedFd<'_> {
         self.file.as_fd()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ pub mod reexports {
     pub use wayland_protocols_wlr as protocols_wlr;
 }
 
+#[cfg(feature = "calloop")]
+pub mod calloop;
 pub mod compositor;
 pub mod data_device_manager;
 pub mod error;

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -205,7 +205,7 @@ impl wayland_client::backend::ObjectData for PositionerData {
         _: &wayland_client::backend::Backend,
         _: wayland_client::backend::protocol::Message<
             wayland_client::backend::ObjectId,
-            wayland_backend::io_lifetimes::OwnedFd,
+            std::os::unix::io::OwnedFd,
         >,
     ) -> Option<Arc<(dyn wayland_client::backend::ObjectData + 'static)>> {
         unreachable!("xdg_positioner has no events");

--- a/src/shm/multi.rs
+++ b/src/shm/multi.rs
@@ -406,7 +406,7 @@ impl wayland_client::backend::ObjectData for BufferObjectData {
         _backend: &wayland_backend::client::Backend,
         msg: wayland_backend::protocol::Message<
             wayland_backend::client::ObjectId,
-            wayland_backend::io_lifetimes::OwnedFd,
+            std::os::unix::io::OwnedFd,
         >,
     ) -> Option<Arc<dyn wayland_backend::client::ObjectData>> {
         debug_assert!(wayland_client::backend::protocol::same_interface(

--- a/src/shm/raw.rs
+++ b/src/shm/raw.rs
@@ -6,7 +6,7 @@
 use std::{
     fs::File,
     io,
-    os::unix::prelude::{FromRawFd, RawFd},
+    os::unix::prelude::{AsFd, FromRawFd, RawFd},
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -53,7 +53,7 @@ impl RawPool {
 
         let pool = shm
             .send_constructor(
-                wl_shm::Request::CreatePool { fd: shm_fd, size: len as i32 },
+                wl_shm::Request::CreatePool { fd: mem_file.as_fd(), size: len as i32 },
                 Arc::new(ShmPoolData),
             )
             .unwrap_or_else(|_| Proxy::inert(shm.backend().clone()));
@@ -274,7 +274,7 @@ impl ObjectData for ShmPoolData {
         _: &wayland_client::backend::Backend,
         _: wayland_client::backend::protocol::Message<
             wayland_client::backend::ObjectId,
-            wayland_backend::io_lifetimes::OwnedFd,
+            std::os::unix::io::OwnedFd,
         >,
     ) -> Option<Arc<(dyn ObjectData + 'static)>> {
         unreachable!("wl_shm_pool has no events")

--- a/src/shm/slot.rs
+++ b/src/shm/slot.rs
@@ -507,7 +507,7 @@ impl wayland_client::backend::ObjectData for BufferData {
         handle: &wayland_client::backend::Backend,
         msg: wayland_backend::protocol::Message<
             wayland_backend::client::ObjectId,
-            wayland_backend::io_lifetimes::OwnedFd,
+            std::os::unix::io::OwnedFd,
         >,
     ) -> Option<Arc<dyn wayland_backend::client::ObjectData>> {
         debug_assert!(wayland_client::backend::protocol::same_interface(


### PR DESCRIPTION
`simple_Window` example here works.

Depends on https://github.com/Smithay/wayland-rs/pull/656 and https://github.com/rust-windowing/wayland-csd-frame/pull/10.

Incorporates the calloop source that was part of wayland-client, updated for current wayland-rs and wayland-client. Unless we want that somewhere else?

Updating these crates is a breaking change, so we might as well update APIs to use io safe types. Perhaps rustix could be used in some places.