### PR TITLE
Bump MSRV to 1.65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ['1.64.0', 'stable', 'beta']
+        rust: ['1.65.0', 'stable', 'beta']
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ The documentation for the releases can be found on [docs.rs](https://docs.rs/smi
 
 ## Requirements
 
-Requires at least rust 1.64 to be used and version 1.12 of the wayland system
-libraries.
+Requires at least rust 1.65 to be used and version 1.15 of the wayland system libraries if
+using the system backend.


### PR DESCRIPTION
Update the MSRV following the windowing ecosystem bump in the MSRV.