### PR TITLE
Restrict SimpleGlobal bindings to our max API version

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -283,6 +283,7 @@ impl<I: Interface + Clone + From<Proxy<I>> + AsRef<Proxy<I>>> GlobalHandler<I> f
         version: u32,
         _: DispatchData,
     ) {
+        let version = I::VERSION.min(version);
         self.global = Some((*registry.bind::<I>(version, id)).clone())
     }
     fn get(&self) -> Option<Attached<I>> {


### PR DESCRIPTION
This is a partial fix for the way SimpleGlobal binds to the latest version offered by the server instead of the latest version the client understands, which causes errors (usually leading to crashes) when a server actually uses the later version and sends an event we don't know about.

This fixes crashes in a number of clients using SCTK-0.16 on compositors supporting the newest wayland surface APIs (to be precise, any that send a `preferred_buffer_scale` event).