### PR TITLE
Take `OwnedFd` instead of `RawFd` as argument to `receive_to_fd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `xkeysym::Keysym` is used as a keyboard key representation instead of `u32`
 - `wayland-rs` dependencies are updated to 0.31
 - `calloop` dependency updated to 0.12.1
+- Take `OwnedFd` instead of `RawFd` as argument to `receive_to_fd` functions.
 
 #### Fixed
 


### PR DESCRIPTION
This appears to be the only use of `RawFd` in a public API. With this change, these functions should be safe to call.

I'm not sure if it would make more sense for these functions to not close the file descriptor. In which case they could take `BorrowedFd`. But this matches the current implementation, but with an IO safe type.