### PR TITLE
fix(wl_data_device): drop and leave event handling

### DIFF
--- a/examples/data_device.rs
+++ b/examples/data_device.rs
@@ -587,7 +587,7 @@ impl DataDeviceHandler for DataDeviceWindow {
     }
 
     fn leave(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _data_device: &WlDataDevice) {
-        println!("data offer left");
+        println!("Data offer left");
     }
 
     fn motion(
@@ -739,6 +739,7 @@ impl DataDeviceHandler for DataDeviceWindow {
                             loop_handle.remove(token);
                             println!("Dropped data: {:?}", String::from_utf8(data.clone()));
                             offer.finish();
+                            offer.destroy();
                             state.dnd_offers.push((offer, Vec::new(), None));
                             return;
                         } else {
@@ -754,6 +755,7 @@ impl DataDeviceHandler for DataDeviceWindow {
                     Err(e) => {
                         eprintln!("Error reading dropped data: {}", e);
                         offer.finish();
+                        offer.destroy();
                         loop_handle.remove(token);
 
                         return;
@@ -851,7 +853,7 @@ impl DataSourceHandler for DataDeviceWindow {
         _qh: &QueueHandle<Self>,
         _source: &wayland_client::protocol::wl_data_source::WlDataSource,
     ) {
-        println!("DROP PERFORMED");
+        println!("Drop performed");
     }
 
     fn dnd_finished(
@@ -860,6 +862,7 @@ impl DataSourceHandler for DataDeviceWindow {
         _qh: &QueueHandle<Self>,
         source: &wayland_client::protocol::wl_data_source::WlDataSource,
     ) {
+        println!("Finished");
         self.drag_sources.retain(|s| s.0.inner() != source);
         source.destroy();
     }


### PR DESCRIPTION
While the spec says to destroy the wl_data_offer after wl_data_device::leave, I think compositors often send the leave event right away after a drop. This is a bit problematic if an application hasn't finished receiving the data and then the data offer is destroyed before it can make the finish request. I believe this can currently be recreated in the data_device example. The source never receives a finish event because the offer was destroyed and isn't alive by the time we make the request.

This PR tries to avoid destroying an offer after the leave event if a drop event already occurred. It also tries to avoid making request besides finish or destroy.