### PR TITLE
Use `rustix` instead of `nix`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cursor-icon = "1.0.0"
 dlib = "0.5"
 log = "0.4"
 memmap2 = "0.7.0"
-nix = { version = "0.26.1", default-features = false, features = ["fs", "mman"] }
+rustix = { version = "0.38.15", features = ["fs", "pipe", "shm"] }
 thiserror = "1.0.30"
 wayland-backend = "0.3.0"
 wayland-client = "0.31.1"

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -4,7 +4,6 @@ pub mod slot;
 
 use std::io;
 
-use nix::errno::Errno;
 use wayland_client::{
     globals::{BindError, GlobalList},
     protocol::wl_shm,
@@ -68,12 +67,6 @@ pub enum CreatePoolError {
     /// Error while allocating the shared memory.
     #[error(transparent)]
     Create(#[from] io::Error),
-}
-
-impl From<Errno> for CreatePoolError {
-    fn from(errno: Errno) -> Self {
-        Into::<io::Error>::into(errno).into()
-    }
 }
 
 /// Delegates the handling of [`wl_shm`] to some [`Shm`].


### PR DESCRIPTION
This is cleaner than `nix` due to the use of `OwnedFd`/`BorrowedFd`.

`calloop` is already using `rustix`.

Depends on https://github.com/bytecodealliance/rustix/pull/848.