### PR TITLE
Fix double `close` when calling `xkb::Keymap::new_from_fd`

### DIFF
--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::Debug,
     marker::PhantomData,
     num::NonZeroU32,
-    os::unix::io::AsRawFd,
+    os::unix::io::IntoRawFd,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -534,7 +534,7 @@ where
                             match unsafe {
                                 xkb::Keymap::new_from_fd(
                                     &context,
-                                    fd.as_raw_fd(),
+                                    fd.into_raw_fd(),
                                     size as usize,
                                     xkb::KEYMAP_FORMAT_TEXT_V1,
                                     xkb::COMPILE_NO_FLAGS,


### PR DESCRIPTION
`strace ./target/debug/examples/simple_window 2>&1| grep EBADF` shows this error before this change.

`new_from_fd` calls `File::from` on the fd, which results in closing it on drop.