### PR TITLE
data_device: return `PostAction` for the Read/Write pipe

### DIFF
--- a/src/data_device_manager/read_pipe.rs
+++ b/src/data_device_manager/read_pipe.rs
@@ -129,7 +129,7 @@ impl calloop::EventSource for ReadPipe {
     type Event = ();
     type Error = std::io::Error;
     type Metadata = calloop::generic::NoIoDrop<fs::File>;
-    type Ret = ();
+    type Ret = calloop::PostAction;
 
     fn process_events<F>(
         &mut self,
@@ -138,12 +138,9 @@ impl calloop::EventSource for ReadPipe {
         mut callback: F,
     ) -> std::io::Result<calloop::PostAction>
     where
-        F: FnMut((), &mut calloop::generic::NoIoDrop<fs::File>),
+        F: FnMut((), &mut calloop::generic::NoIoDrop<fs::File>) -> Self::Ret,
     {
-        self.file.process_events(readiness, token, |_, file| {
-            callback((), file);
-            Ok(calloop::PostAction::Continue)
-        })
+        self.file.process_events(readiness, token, |_, file| Ok(callback((), file)))
     }
 
     fn register(

--- a/src/data_device_manager/write_pipe.rs
+++ b/src/data_device_manager/write_pipe.rs
@@ -137,7 +137,7 @@ impl calloop::EventSource for WritePipe {
     type Event = ();
     type Error = std::io::Error;
     type Metadata = calloop::generic::NoIoDrop<fs::File>;
-    type Ret = ();
+    type Ret = calloop::PostAction;
 
     fn process_events<F>(
         &mut self,
@@ -146,12 +146,9 @@ impl calloop::EventSource for WritePipe {
         mut callback: F,
     ) -> std::io::Result<calloop::PostAction>
     where
-        F: FnMut((), &mut calloop::generic::NoIoDrop<fs::File>),
+        F: FnMut((), &mut calloop::generic::NoIoDrop<fs::File>) -> Self::Ret,
     {
-        self.file.process_events(readiness, token, |_, file| {
-            callback((), file);
-            Ok(calloop::PostAction::Continue)
-        })
+        self.file.process_events(readiness, token, |_, file| Ok(callback((), file)))
     }
 
     fn register(

--- a/src/primary_selection/offer.rs
+++ b/src/primary_selection/offer.rs
@@ -10,7 +10,7 @@ use crate::data_device_manager::ReadPipe;
 
 use super::PrimarySelectionManagerState;
 
-/// RAII wrapper around the [`ZwpPrimarySelectionOfferV1`].
+/// Wrapper around the [`ZwpPrimarySelectionOfferV1`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrimarySelectionOffer {
     pub(crate) offer: ZwpPrimarySelectionOfferV1,
@@ -51,12 +51,6 @@ impl PrimarySelectionOffer {
     /// once the contents are written.
     pub fn receive_to_fd(&self, mime_type: String, writefd: OwnedFd) {
         self.offer.receive(mime_type, writefd.as_fd());
-    }
-}
-
-impl Drop for PrimarySelectionOffer {
-    fn drop(&mut self) {
-        self.offer.destroy();
     }
 }
 


### PR DESCRIPTION
This should simplify client handling, since they can properly model the read/write loop.