### PR TITLE
chore: drop dlib dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 bitflags = "2.4"
 bytemuck = { version = "1.13.0", optional = true }
 cursor-icon = "1.0.0"
-dlib = "0.5"
 libc = "0.2.148"
 log = "0.4"
 memmap2 = "0.9.0"


### PR DESCRIPTION
The dependency is not used.