### PR TITLE
ProvidesBoundGlobal API_VERSION fixes

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -185,7 +185,7 @@ pub struct Surface(wl_surface::WlSurface);
 
 impl Surface {
     pub fn new<D>(
-        compositor: &impl ProvidesBoundGlobal<wl_compositor::WlCompositor, 5>,
+        compositor: &impl ProvidesBoundGlobal<wl_compositor::WlCompositor, 6>,
         qh: &QueueHandle<D>,
     ) -> Result<Self, GlobalError>
     where
@@ -195,7 +195,7 @@ impl Surface {
     }
 
     pub fn with_data<D, U>(
-        compositor: &impl ProvidesBoundGlobal<wl_compositor::WlCompositor, 5>,
+        compositor: &impl ProvidesBoundGlobal<wl_compositor::WlCompositor, 6>,
         qh: &QueueHandle<D>,
         data: U,
     ) -> Result<Self, GlobalError>
@@ -386,7 +386,7 @@ pub struct Region(wl_region::WlRegion);
 
 impl Region {
     pub fn new(
-        compositor: &impl ProvidesBoundGlobal<wl_compositor::WlCompositor, 5>,
+        compositor: &impl ProvidesBoundGlobal<wl_compositor::WlCompositor, 6>,
     ) -> Result<Region, GlobalError> {
         compositor
             .bound_global()
@@ -445,7 +445,7 @@ where
     }
 }
 
-impl ProvidesBoundGlobal<wl_compositor::WlCompositor, 5> for CompositorState {
+impl ProvidesBoundGlobal<wl_compositor::WlCompositor, 6> for CompositorState {
     fn bound_global(&self) -> Result<wl_compositor::WlCompositor, GlobalError> {
         Ok(self.wl_compositor.clone())
     }

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -168,7 +168,7 @@ pub struct XdgPositioner(xdg_positioner::XdgPositioner);
 
 impl XdgPositioner {
     pub fn new(
-        wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4>,
+        wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 5>,
     ) -> Result<Self, GlobalError> {
         wm_base
             .bound_global()
@@ -240,7 +240,7 @@ impl XdgShellSurface {
     /// [`XdgSurface`]: xdg_surface::XdgSurface
     /// [`WlSurface`]: wl_surface::WlSurface
     pub fn new<U, D>(
-        wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4>,
+        wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 5>,
         qh: &QueueHandle<D>,
         surface: impl Into<Surface>,
         udata: U,
@@ -307,8 +307,14 @@ impl Drop for XdgShellSurface {
     }
 }
 
-// Version 4 adds the configure_bounds event, which is a break
-impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4> for XdgShell {
+// Version 5 adds the wm_capabilities event, which is a break
+impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 5> for XdgShell {
+    fn bound_global(&self) -> Result<xdg_wm_base::XdgWmBase, GlobalError> {
+        Ok(self.xdg_wm_base.clone())
+    }
+}
+
+impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 6> for XdgShell {
     fn bound_global(&self) -> Result<xdg_wm_base::XdgWmBase, GlobalError> {
         Ok(self.xdg_wm_base.clone())
     }

--- a/src/shell/xdg/popup.rs
+++ b/src/shell/xdg/popup.rs
@@ -51,7 +51,7 @@ impl Popup {
         position: &xdg_positioner::XdgPositioner,
         qh: &QueueHandle<D>,
         compositor: &impl ProvidesBoundGlobal<WlCompositor, 6>,
-        wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4>,
+        wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 5>,
     ) -> Result<Popup, GlobalError>
     where
         D: Dispatch<wl_surface::WlSurface, SurfaceData>
@@ -78,7 +78,7 @@ impl Popup {
         position: &xdg_positioner::XdgPositioner,
         qh: &QueueHandle<D>,
         surface: impl Into<Surface>,
-        wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4>,
+        wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 5>,
     ) -> Result<Popup, GlobalError>
     where
         D: Dispatch<xdg_surface::XdgSurface, PopupData>

--- a/src/shell/xdg/popup.rs
+++ b/src/shell/xdg/popup.rs
@@ -50,7 +50,7 @@ impl Popup {
         parent: &xdg_surface::XdgSurface,
         position: &xdg_positioner::XdgPositioner,
         qh: &QueueHandle<D>,
-        compositor: &impl ProvidesBoundGlobal<WlCompositor, 5>,
+        compositor: &impl ProvidesBoundGlobal<WlCompositor, 6>,
         wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 4>,
     ) -> Result<Popup, GlobalError>
     where


### PR DESCRIPTION
Two recent bumps to maximum API versions did not also bump the implementations of ProvidesBoundGlobal even though API breaks were present.  This series bumps those API versions.  This is technically an API change, albeit a minor one that would only break code directly using the ProvidesBoundGlobal interface on one of these objects - and such code may already be broken in 0.18 because it will not handle the new events.