### PR TITLE
Implement support for xdg-activation

### DIFF
--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -1,11 +1,13 @@
 use std::{convert::TryInto, time::Duration};
 
+use smithay_client_toolkit::activation::RequestData;
 use smithay_client_toolkit::reexports::calloop::{EventLoop, LoopHandle};
 use smithay_client_toolkit::reexports::calloop_wayland_source::WaylandSource;
 use smithay_client_toolkit::{
+    activation::{ActivationHandler, ActivationState},
     compositor::{CompositorHandler, CompositorState},
-    delegate_compositor, delegate_keyboard, delegate_output, delegate_pointer, delegate_registry,
-    delegate_seat, delegate_shm, delegate_xdg_shell, delegate_xdg_window,
+    delegate_activation, delegate_compositor, delegate_keyboard, delegate_output, delegate_pointer,
+    delegate_registry, delegate_seat, delegate_shm, delegate_xdg_shell, delegate_xdg_window,
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
@@ -54,6 +56,8 @@ fn main() {
     // Since we are not using the GPU in this example, we use wl_shm to allow software rendering to a buffer
     // we share with the compositor process.
     let shm = Shm::bind(&globals, &qh).expect("wl shm is not available.");
+    // If the compositor supports xdg-activation it probably wants us to use it to get focus
+    let xdg_activation = ActivationState::bind(&globals, &qh).ok();
 
     // A window is created from a surface.
     let surface = compositor.create_surface(&qh);
@@ -73,6 +77,18 @@ fn main() {
     // the correct options.
     window.commit();
 
+    // To request focus, we first need to request a token
+    if let Some(activation) = xdg_activation.as_ref() {
+        activation.request_token(
+            &qh,
+            RequestData {
+                seat_and_serial: None,
+                surface: Some(window.wl_surface().clone()),
+                app_id: Some(String::from("io.github.smithay.client-toolkit.SimpleWindow")),
+            },
+        )
+    }
+
     // We don't know how large the window will be yet, so lets assume the minimum size we suggested for the
     // initial memory allocation.
     let pool = SlotPool::new(256 * 256 * 4, &shm).expect("Failed to create pool");
@@ -84,6 +100,7 @@ fn main() {
         seat_state: SeatState::new(&globals, &qh),
         output_state: OutputState::new(&globals, &qh),
         shm,
+        xdg_activation,
 
         exit: false,
         first_configure: true,
@@ -115,6 +132,7 @@ struct SimpleWindow {
     seat_state: SeatState,
     output_state: OutputState,
     shm: Shm,
+    xdg_activation: Option<ActivationState>,
 
     exit: bool,
     first_configure: bool,
@@ -216,6 +234,17 @@ impl WindowHandler for SimpleWindow {
             self.first_configure = false;
             self.draw(conn, qh);
         }
+    }
+}
+
+impl ActivationHandler for SimpleWindow {
+    type RequestData = RequestData;
+
+    fn new_token(&mut self, token: String, _data: &Self::RequestData) {
+        self.xdg_activation
+            .as_ref()
+            .unwrap()
+            .activate::<SimpleWindow>(self.window.wl_surface(), token);
     }
 }
 
@@ -464,6 +493,7 @@ delegate_pointer!(SimpleWindow);
 
 delegate_xdg_shell!(SimpleWindow);
 delegate_xdg_window!(SimpleWindow);
+delegate_activation!(SimpleWindow);
 
 delegate_registry!(SimpleWindow);
 

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -1,0 +1,200 @@
+use wayland_client::{
+    globals::{BindError, GlobalList},
+    protocol::{wl_seat, wl_surface},
+    Dispatch, Proxy, QueueHandle,
+};
+use wayland_protocols::xdg::activation::v1::client::{xdg_activation_token_v1, xdg_activation_v1};
+
+use crate::{
+    error::GlobalError,
+    globals::{GlobalData, ProvidesBoundGlobal},
+};
+
+/// Minimal implementation of [`RequestDataExt`].
+///
+/// Use a custom type implementing [`RequestDataExt`] to store more data with a token request
+/// e.g. to identify which request produced which token.
+#[derive(Debug, Clone)]
+pub struct RequestData {
+    /// App_id of the application requesting the token, if applicable
+    pub app_id: Option<String>,
+    /// Seat and serial of the window requesting the token, if applicable.
+    ///
+    /// *Warning*: Many compositors will issue invalid tokens for requests without
+    /// recent serials. There is no way to detect this from the client-side.
+    pub seat_and_serial: Option<(wl_seat::WlSeat, u32)>,
+    /// Surface of the window requesting the token, if applicable.
+    ///
+    /// *Warning*: Many compositors will issue invalid tokens for requests from
+    /// unfocused surfaces. There is no way to detect this from the client-side.
+    pub surface: Option<wl_surface::WlSurface>,
+}
+
+/// Data attached to a token request
+pub trait RequestDataExt: Send + Sync {
+    /// App_id of the application requesting the token, if applicable
+    fn app_id(&self) -> Option<&str>;
+    /// Seat and serial of the window requesting the token, if applicable.
+    ///
+    /// *Warning*: Many compositors will issue invalid tokens for requests without
+    /// recent serials. There is no way to detect this from the client-side.
+    fn seat_and_serial(&self) -> Option<(&wl_seat::WlSeat, u32)>;
+    /// Surface of the window requesting the token, if applicable.
+    ///
+    /// *Warning*: Many compositors will issue invalid tokens for requests from
+    /// unfocused surfaces. There is no way to detect this from the client-side.
+    fn surface(&self) -> Option<&wl_surface::WlSurface>;
+}
+
+impl RequestDataExt for RequestData {
+    fn app_id(&self) -> Option<&str> {
+        self.app_id.as_deref()
+    }
+
+    fn seat_and_serial(&self) -> Option<(&wl_seat::WlSeat, u32)> {
+        self.seat_and_serial.as_ref().map(|(seat, serial)| (seat, *serial))
+    }
+
+    fn surface(&self) -> Option<&wl_surface::WlSurface> {
+        self.surface.as_ref()
+    }
+}
+
+/// Handler for xdg-activation
+pub trait ActivationHandler: Sized {
+    /// Data type used for requesting activation tokens
+    type RequestData: RequestDataExt;
+    /// A token was issued for a previous request with `data`.
+    fn new_token(&mut self, token: String, data: &Self::RequestData);
+}
+
+/// State for xdg-activation
+#[derive(Debug)]
+pub struct ActivationState {
+    xdg_activation: xdg_activation_v1::XdgActivationV1,
+}
+
+impl ActivationState {
+    /// Bind the `xdg-activation` global
+    pub fn bind<State>(
+        globals: &GlobalList,
+        qh: &QueueHandle<State>,
+    ) -> Result<ActivationState, BindError>
+    where
+        State: Dispatch<xdg_activation_v1::XdgActivationV1, GlobalData, State> + 'static,
+    {
+        let xdg_activation = globals.bind(qh, 1..=1, GlobalData)?;
+        Ok(ActivationState { xdg_activation })
+    }
+
+    /// Activate a surface with the provided token.
+    pub fn activate<D>(&self, surface: &wl_surface::WlSurface, token: String) {
+        self.xdg_activation.activate(token, surface)
+    }
+
+    /// Request a token for surface activation.
+    ///
+    /// To attach custom data to the request implement [`RequestDataExt`] on a custom type
+    /// and use [`Self::request_token_with_data`] instead.
+    pub fn request_token<D>(&self, qh: &QueueHandle<D>, request_data: RequestData)
+    where
+        D: ActivationHandler<RequestData = RequestData>,
+        D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData> + 'static,
+    {
+        Self::request_token_with_data::<D, RequestData>(self, qh, request_data)
+    }
+
+    /// Request a token for surface activation with user data.
+    ///
+    /// To use this method you need to provide [`delegate_activation`] with your custom type.
+    /// E.g. `delegate_activation!(SimpleWindow, MyRequestData);`
+    pub fn request_token_with_data<D, R>(&self, qh: &QueueHandle<D>, request_data: R)
+    where
+        D: ActivationHandler<RequestData = R>,
+        D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, R> + 'static,
+        R: RequestDataExt + 'static,
+    {
+        let token = self.xdg_activation.get_activation_token(qh, request_data);
+        let data = token.data::<R>().unwrap();
+        if let Some(app_id) = data.app_id() {
+            token.set_app_id(String::from(app_id));
+        }
+        if let Some((seat, serial)) = data.seat_and_serial() {
+            token.set_serial(serial, seat);
+        }
+        if let Some(surface) = data.surface() {
+            token.set_surface(surface);
+        }
+        token.commit();
+    }
+}
+
+impl<D> Dispatch<xdg_activation_v1::XdgActivationV1, GlobalData, D> for ActivationState
+where
+    D: Dispatch<xdg_activation_v1::XdgActivationV1, GlobalData> + ActivationHandler,
+{
+    fn event(
+        _: &mut D,
+        _: &xdg_activation_v1::XdgActivationV1,
+        _: <xdg_activation_v1::XdgActivationV1 as Proxy>::Event,
+        _: &GlobalData,
+        _: &wayland_client::Connection,
+        _: &QueueHandle<D>,
+    ) {
+        unreachable!("xdg_activation_v1 has no events");
+    }
+}
+
+impl ProvidesBoundGlobal<xdg_activation_v1::XdgActivationV1, 1> for ActivationState {
+    fn bound_global(&self) -> Result<xdg_activation_v1::XdgActivationV1, GlobalError> {
+        Ok(self.xdg_activation.clone())
+    }
+}
+
+impl<D, R> Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, R, D> for ActivationState
+where
+    D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, R>
+        + ActivationHandler<RequestData = R>,
+    R: RequestDataExt,
+{
+    fn event(
+        state: &mut D,
+        _proxy: &xdg_activation_token_v1::XdgActivationTokenV1,
+        event: <xdg_activation_token_v1::XdgActivationTokenV1 as Proxy>::Event,
+        data: &R,
+        _conn: &wayland_client::Connection,
+        _qhandle: &QueueHandle<D>,
+    ) {
+        if let xdg_activation_token_v1::Event::Done { token } = event {
+            state.new_token(token, data);
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_activation {
+   ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_v1::XdgActivationV1: $crate::globals::GlobalData
+            ] => $crate::activation::ActivationState
+        );
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_token_v1::XdgActivationTokenV1: $crate::activation::RequestData
+            ] => $crate::activation::ActivationState
+        );
+    };
+   ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, $data: ty) => {
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_v1::XdgActivationV1: $crate::globals::GlobalData
+            ] => $crate::activation::ActivationState
+        );
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_token_v1::XdgActivationTokenV1: $data
+            ] => $crate::activation::ActivationState
+        );
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod reexports {
     pub use wayland_protocols_wlr as protocols_wlr;
 }
 
+pub mod activation;
 pub mod compositor;
 pub mod data_device_manager;
 pub mod dmabuf;


### PR DESCRIPTION
Implements xdg-activation.

The second commit adds it to the simple-window example as a test. Given how heavily commented that is, I guess that is not really a good place to put it. But without a proper window it doesn't make a whole lot of sense to use it. I could also just drop that commit?