### PR TITLE
Try alternative cursor icon names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bitflags = "2.4"
 bytemuck = { version = "1.13.0", optional = true }
-cursor-icon = "1.0.0"
+cursor-icon = "1.1.0"
 libc = "0.2.148"
 log = "0.4"
 memmap2 = "0.9.0"
@@ -60,7 +60,3 @@ pollster = "0.3.0"
 [[example]]
 name = "wgpu"
 required-features = ["wayland-backend/client_system"]
-
-# temporary - TODO: remove
-[patch.crates-io]
-cursor-icon = { git = "https://github.com/rust-windowing/cursor-icon.git", rev = "4baa20f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,7 @@ pollster = "0.3.0"
 [[example]]
 name = "wgpu"
 required-features = ["wayland-backend/client_system"]
+
+# temporary - TODO: remove
+[patch.crates-io]
+cursor-icon = { git = "https://github.com/rust-windowing/cursor-icon.git", rev = "4baa20f" }

--- a/src/seat/pointer/mod.rs
+++ b/src/seat/pointer/mod.rs
@@ -458,7 +458,7 @@ impl<U: PointerDataExt + 'static, S: SurfaceDataExt + 'static> ThemedPointer<U, 
         let mut themes = self.themes.lock().unwrap();
 
         let scale = self.surface.data::<S>().unwrap().surface_data().scale_factor();
-        for cursor_icon_name in iter::once(icon.name()).chain(icon.alt_names().iter().copied()) {
+        for cursor_icon_name in iter::once(&icon.name()).chain(icon.alt_names().iter()) {
             if let Some(cursor) = themes
                 .get_cursor(conn, cursor_icon_name, scale as u32, &self.shm)
                 .map_err(PointerThemeError::InvalidId)?


### PR DESCRIPTION
Try the standardized cursor icon name, followed by a list of alternative cursor icon names (provided through https://github.com/rust-windowing/cursor-icon/pull/11).

See also:
- https://github.com/Smithay/client-toolkit/issues/425
- https://github.com/rust-windowing/cursor-icon/pull/11

cc @kchibisov 

Fixes #425