### PR TITLE
Expose compositor from subcompositor

### DIFF
--- a/src/subcompositor.rs
+++ b/src/subcompositor.rs
@@ -44,6 +44,17 @@ impl SubcompositorState {
     }
 }
 
+impl
+    crate::globals::ProvidesBoundGlobal<
+        WlCompositor,
+        { crate::compositor::CompositorState::API_VERSION_MAX },
+    > for SubcompositorState
+{
+    fn bound_global(&self) -> Result<WlCompositor, crate::error::GlobalError> {
+        Ok(self.compositor.clone())
+    }
+}
+
 impl<D> Dispatch<WlSubsurface, SubsurfaceData, D> for SubcompositorState
 where
     D: Dispatch<WlSubsurface, SubsurfaceData>,


### PR DESCRIPTION
This PR implements one way of exposing a `WlCompositor` from a `SubcompositorState`.

To avoid a potential [XY problem](https://en.wikipedia.org/wiki/XY_problem), here's my situation:

I want to change the input region of a (sub)surface of a wayland frame. I only have access to a `SubcompositorState`. To change the input region, I need to create new regions that I can pass into `set_input_region`. SCTK only allows the creation of new regions through a compositor, but not through a subcompositor.

See:

- https://github.com/PolyMeilex/sctk-adwaita/pull/43

Is exposing the compositor from the subcompositor the correct way of going about this, and if so, is my solution good?

By implementing `ProvidesBoundGlobal`, I can leverage the `Region` abstraction from SCTK: https://docs.rs/smithay-client-toolkit/latest/smithay_client_toolkit/compositor/struct.Region.html#method.new