### PR TITLE
fix: MultiPool::get now returns an overlap error when its appropriate

### DIFF
--- a/src/shm/multi.rs
+++ b/src/shm/multi.rs
@@ -322,7 +322,7 @@ impl<K> MultiPool<K> {
         let size = (stride * height) as usize;
         let buf_slot = self.buffer_list.get_mut(index).ok_or(PoolError::NotFound)?;
 
-        if buf_slot.size > size {
+        if size > buf_slot.size {
             return Err(PoolError::Overlap);
         }
 


### PR DESCRIPTION
PoolError::Overlap is returned when the buffer is bigger than the slot and not the other way around.