### PR TITLE
Bind dmabuf v5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0.30"
 wayland-backend = "0.3.0"
 wayland-client = "0.31.1"
 wayland-cursor = "0.31.0"
-wayland-protocols = { version = "0.31.0", features = ["client", "staging", "unstable"] }
+wayland-protocols = { version = "0.31.2", features = ["client", "staging", "unstable"] }
 wayland-protocols-wlr = { version = "0.2.0", features = ["client"] }
 wayland-scanner = "0.31.0"
 wayland-csd-frame = "0.3.0"

--- a/examples/dmabuf_formats.rs
+++ b/examples/dmabuf_formats.rs
@@ -92,8 +92,8 @@ fn main() {
 
             return;
         }
-        Some(4..) => {
-            println!("Version `4` of `zwp_linux_dmabuf_v1` supported. Showing default dmabuf feedback.\n");
+        Some(ver @ 4..) => {
+            println!("Version `{}` of `zwp_linux_dmabuf_v1` supported. Showing default dmabuf feedback.\n", ver);
 
             app_data.dmabuf_state.get_default_feedback(&qh).unwrap();
 

--- a/src/dmabuf.rs
+++ b/src/dmabuf.rs
@@ -124,7 +124,7 @@ impl DmabufState {
         D: Dispatch<zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, GlobalData> + 'static,
     {
         // Mesa (at least the latest version) also requires version 3 or 4
-        let zwp_linux_dmabuf = GlobalProxy::from(globals.bind(qh, 3..=4, GlobalData));
+        let zwp_linux_dmabuf = GlobalProxy::from(globals.bind(qh, 3..=5, GlobalData));
         Self { zwp_linux_dmabuf, modifiers: Vec::new() }
     }
 
@@ -230,6 +230,9 @@ impl DmabufParams {
     ///
     /// In version `4`, it is a protocol error if `format`/`modifier` pair wasn't
     /// advertised as supported.
+    ///
+    /// `modifier` should be the same for all planes. It is a protocol error in version `5` if
+    /// they differ.
     pub fn add(&self, fd: BorrowedFd<'_>, plane_idx: u32, offset: u32, stride: u32, modifier: u64) {
         let modifier_hi = (modifier >> 32) as u32;
         let modifier_lo = (modifier & 0xffffffff) as u32;


### PR DESCRIPTION
This makes creating a dmabuf with different modifiers for different planes a protocol error.

This *could* be considered a breaking API change, but I don't think we need a semver bump for it because:
* Callers should never have actually used different modifiers for different planes, since this was never valid.
* Most users of this protocol tend to use `create_immed`, in which case they would get a protocol error. So it's "breaking" only if an application calls `create` with non-sense params and then expects to get `failed`.

When we do have an API break, the API should probably be changed to only allow a single modifier.

This change isn't important, but will be needed for future updates to dmabuf.