### PR TITLE
chore: refactor github ci so that it doesn't use 1.65 for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,25 +25,18 @@ jobs:
           key: cargo-${{ matrix.rust }}
 
       - name: Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: hecrj/setup-rust-action@v1
         with:
-          toolchain: ${{ matrix.rust }}
-          override: true
+          rust-version: ${{ matrix.rust }}
 
       - name: Install system dependencies
         run: sudo apt-get install libxkbcommon-dev libwayland-dev
 
       - name: Check lib no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features
+        run: cargo check --no-default-features
 
       - name: Check full features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features
+        run: cargo check --all-features
 
   test:
     strategy:
@@ -63,31 +56,21 @@ jobs:
           key: cargo-${{ matrix.rust }}
 
       - name: Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: hecrj/setup-rust-action@v1
         with:
-          toolchain: ${{ matrix.rust }}
-          override: true
+          rust-version: ${{ matrix.rust }}
 
       - name: Install system dependencies
         run: sudo apt-get install libxkbcommon-dev libwayland-dev
 
       - name: Test lib no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --lib
+        run: cargo test --no-default-features --lib
 
       - name: Test doc no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --doc
+        run: cargo test --no-default-features --doc
 
       - name: Test full features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: cargo test --all-features
 
   lint:
     runs-on: ubuntu-latest
@@ -97,7 +80,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: hecrj/setup-rust-action@v1
         with:
           toolchain: stable
           override: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,44 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get install libxkbcommon-dev libwayland-dev
 
+      - name: Check lib no features
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features
+
+      - name: Check full features
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-features
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: ['stable', 'beta']
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cargo cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo
+          key: cargo-${{ matrix.rust }}
+
+      - name: Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install system dependencies
+        run: sudo apt-get install libxkbcommon-dev libwayland-dev
+
       - name: Test lib no features
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
This could help fix CI issues on some PRs like #441 and #437