### PR TITLE
Require an explicit unlock call in SessionLock

### DIFF
--- a/examples/session_lock.rs
+++ b/examples/session_lock.rs
@@ -86,8 +86,8 @@ impl SessionLockHandler for AppData {
         // After 5 seconds, destroy lock
         self.loop_handle
             .insert_source(Timer::from_duration(Duration::from_secs(5)), |_, _, app_data| {
-                // Destroy the session lock
-                app_data.session_lock.take();
+                // Unlock the lock
+                app_data.session_lock.take().unwrap().unlock();
                 // Sync connection to make sure compostor receives destroy
                 app_data.conn.roundtrip().unwrap();
                 // Then we can exit


### PR DESCRIPTION
The entire reason unlock_and_destroy is distinct from destroy is to avoid accidental unlock operations.  The current SCTK implementation carefully undoes this work by unlocking on drop, even if that drop is due to a panic or careless drop of the lock object.

Add an explicit unlock call so that screen lockers can indicate when they intend to unlock (generally after some kind of authentication has happened).