### PR TITLE
seat/touch: Track latest `touch_down` event serial

### DIFF
--- a/src/seat/pointer/mod.rs
+++ b/src/seat/pointer/mod.rs
@@ -215,7 +215,7 @@ pub(crate) struct PointerDataInner {
     /// The serial of the latest enter event for the pointer
     pub(crate) latest_enter: Option<u32>,
 
-    /// The serial of the latest enter event for the pointer
+    /// The serial of the latest button event for the pointer
     pub(crate) latest_btn: Option<u32>,
 }
 

--- a/src/seat/touch.rs
+++ b/src/seat/touch.rs
@@ -25,12 +25,20 @@ impl TouchData {
     pub fn seat(&self) -> &WlSeat {
         &self.seat
     }
+
+    /// Serial from the latest touch down event.
+    pub fn latest_down_serial(&self) -> Option<u32> {
+        self.inner.lock().unwrap().latest_down
+    }
 }
 
 #[derive(Debug, Default)]
 pub(crate) struct TouchDataInner {
     events: Vec<TouchEvent>,
     active_touch_points: Vec<i32>,
+
+    /// The serial of the latest touch down event
+    latest_down: Option<u32>,
 }
 
 #[macro_export]
@@ -171,7 +179,8 @@ where
 
         match &event {
             // Buffer events until frame is received.
-            TouchEvent::Down { id, .. } => {
+            TouchEvent::Down { serial, id, .. } => {
+                guard.latest_down = Some(*serial);
                 save_event = true;
                 if let Err(insert_pos) = guard.active_touch_points.binary_search(id) {
                     guard.active_touch_points.insert(insert_pos, *id);


### PR DESCRIPTION
This is needed to call things like `xdg_toplevel::move` for touch events.