### PR TITLE
add way to make subsurfaces from surfaces

### DIFF
--- a/src/subcompositor.rs
+++ b/src/subcompositor.rs
@@ -42,6 +42,21 @@ impl SubcompositorState {
             self.subcompositor.get_subsurface(&surface, &parent, queue_handle, subsurface_data);
         (subsurface, surface)
     }
+
+    pub fn subsurface_from_surface<State>(
+        &self,
+        surface: &WlSurface,
+        queue_handle: &QueueHandle<State>,
+    ) -> Option<WlSubsurface>
+    where
+        State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+    {
+        let parent = surface.data::<SurfaceData>().unwrap().parent_surface();
+        let subsurface_data = SubsurfaceData::new(surface.clone());
+        parent.map(|parent| {
+            self.subcompositor.get_subsurface(surface, parent, queue_handle, subsurface_data)
+        })
+    }
 }
 
 impl<D> Dispatch<WlSubsurface, SubsurfaceData, D> for SubcompositorState


### PR DESCRIPTION
I'd like to be able to pass an existing surface and make it a subsurface, instead of using the surface created in `create_subsurface`.  Would that be possible with something like this?   Thanks :)