### PR TITLE
Add `surface_enter`/`surface_leave` methods to `CompositorHandler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Breaking Changes
 - Updated `calloop` to 0.13.0, `calloop-wayland-source` to `0.3.0`
+- Add `surface_enter`/`surface_leave` methods to `CompositorHandler` trait.
 
 #### Fixed
 

--- a/examples/data_device.rs
+++ b/examples/data_device.rs
@@ -222,6 +222,26 @@ impl CompositorHandler for DataDeviceWindow {
     ) {
         self.draw(conn, qh);
     }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
 }
 
 impl OutputHandler for DataDeviceWindow {

--- a/examples/generic_simple_window.rs
+++ b/examples/generic_simple_window.rs
@@ -163,6 +163,26 @@ impl<T: Test + 'static> CompositorHandler for SimpleWindow<T> {
     ) {
         self.draw(conn, qh);
     }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
 }
 
 impl<T: Test + 'static> OutputHandler for SimpleWindow<T> {

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -159,6 +159,26 @@ impl CompositorHandler for State {
     ) {
         self.draw(conn, qh);
     }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
 }
 
 impl OutputHandler for State {

--- a/examples/image_viewporter.rs
+++ b/examples/image_viewporter.rs
@@ -184,6 +184,26 @@ impl CompositorHandler for State {
     ) {
         self.draw(conn, qh);
     }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
 }
 
 impl OutputHandler for State {

--- a/examples/relative_pointer.rs
+++ b/examples/relative_pointer.rs
@@ -159,6 +159,26 @@ impl CompositorHandler for SimpleWindow {
     ) {
         self.draw(conn, qh);
     }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
 }
 
 impl OutputHandler for SimpleWindow {

--- a/examples/session_lock.rs
+++ b/examples/session_lock.rs
@@ -176,6 +176,26 @@ impl CompositorHandler for AppData {
         _time: u32,
     ) {
     }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
 }
 
 impl OutputHandler for AppData {

--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -150,6 +150,26 @@ impl CompositorHandler for SimpleLayer {
     ) {
         self.draw(qh);
     }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
 }
 
 impl OutputHandler for SimpleLayer {

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -178,6 +178,26 @@ impl CompositorHandler for SimpleWindow {
     ) {
         self.draw(conn, qh);
     }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
 }
 
 impl OutputHandler for SimpleWindow {

--- a/examples/themed_window.rs
+++ b/examples/themed_window.rs
@@ -213,6 +213,26 @@ impl CompositorHandler for SimpleWindow {
     ) {
         self.draw(conn, qh);
     }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
 }
 
 impl OutputHandler for SimpleWindow {

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -57,6 +57,24 @@ pub trait CompositorHandler: Sized {
         surface: &wl_surface::WlSurface,
         time: u32,
     );
+
+    /// The surface has entered an output.
+    fn surface_enter(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        surface: &wl_surface::WlSurface,
+        output: &wl_output::WlOutput,
+    );
+
+    /// The surface has left an output.
+    fn surface_leave(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        surface: &wl_surface::WlSurface,
+        output: &wl_output::WlOutput,
+    );
 }
 
 pub trait SurfaceDataExt: Send + Sync {
@@ -293,12 +311,16 @@ where
         let data = data.surface_data();
         let mut inner = data.inner.lock().unwrap();
 
+        let mut enter_or_leave_output: Option<(wl_output::WlOutput, bool)> = None;
+
         match event {
             wl_surface::Event::Enter { output } => {
-                inner.outputs.push(output);
+                inner.outputs.push(output.clone());
+                enter_or_leave_output.replace((output, true));
             }
             wl_surface::Event::Leave { output } => {
                 inner.outputs.retain(|o| o != &output);
+                enter_or_leave_output.replace((output, false));
             }
             wl_surface::Event::PreferredBufferScale { factor } => {
                 let current_scale = data.scale_factor.load(Ordering::Relaxed);
@@ -326,6 +348,13 @@ where
         // NOTE: with v6 we don't need any special handling of the scale factor, everything
         // was handled from the above, so return.
         if surface.version() >= 6 {
+            drop(inner);
+            match enter_or_leave_output {
+                Some((output, true)) => state.surface_enter(conn, qh, surface, &output),
+                Some((output, false)) => state.surface_leave(conn, qh, surface, &output),
+                None => {}
+            };
+
             return;
         }
 
@@ -346,6 +375,12 @@ where
         });
 
         dispatch_surface_state_updates(state, conn, qh, surface, data, inner);
+
+        match enter_or_leave_output {
+            Some((output, true)) => state.surface_enter(conn, qh, surface, &output),
+            Some((output, false)) => state.surface_leave(conn, qh, surface, &output),
+            None => {}
+        };
     }
 }
 


### PR DESCRIPTION
While the `outputs()` method on `SurfaceData` allows an app to retrieve the *current* outputs of a surface, it's not currently possible to easily *detect changes* to this value.

This pull-request adds the `surface_enter`/`surface_leave`  methods to the `CompositorHandler` trait. These methods correspond to the [`wl_surface::enter`](https://wayland.app/protocols/wayland#wl_surface:event:enter)/[`wl_surface::leave`](https://wayland.app/protocols/wayland#wl_surface:event:leave) events and should make it easier for client apps to detect  changes to a surface's outputs.

> [!NOTE] 
> See https://github.com/vially/flutter-rs/commit/03ff77836c12e0092b6a46f7445013f9a48c1035 for a more realistic use-case of these methods.