### PR TITLE
Add `Clone` derive for `CompositorState`

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -87,7 +87,7 @@ impl SurfaceDataExt for SurfaceData {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CompositorState {
     wl_compositor: wl_compositor::WlCompositor,
 }


### PR DESCRIPTION
Having the option to store the compositor state in multiple places makes functionality like region creation a little simpler, without having to pass the state through everywhere.