### PR TITLE
Add wl shell protocol implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add wl shell protocol implementation
+
 ## 0.19.1 - 2024-06-04
 
 #### Additions

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -32,13 +32,13 @@
 //!
 //! The layer shell may be used to implement many desktop shell components, such as backgrounds, docks and
 //! launchers.
-//! 
+//!
 //! ## Wl shell
-//! 
+//!
 //! The Wl shell is a deprecated protocol which is like xdg shell but less functional.
-//! 
+//!
 //! ### Why use the Wl shell
-//! 
+//!
 //! The Wl shell uses like xdg shell for application windows creation.
 //! It's deprecated, so it uses only in some legacy projects like Sailfish OS.
 //!

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -32,6 +32,15 @@
 //!
 //! The layer shell may be used to implement many desktop shell components, such as backgrounds, docks and
 //! launchers.
+//! 
+//! ## Wl shell
+//! 
+//! The Wl shell is a deprecated protocol which is like xdg shell but less functional.
+//! 
+//! ### Why use the Wl shell
+//! 
+//! The Wl shell uses like xdg shell for application windows creation.
+//! It's deprecated, so it uses only in some legacy projects like Sailfish OS.
 //!
 //! [^window]: The XDG shell protocol actually refers to a window as a toplevel surface, but we use the more
 //! familiar term "window" for the sake of clarity.
@@ -47,6 +56,7 @@ use wayland_client::{
     Proxy,
 };
 
+pub mod wl_shell;
 pub mod wlr_layer;
 pub mod xdg;
 

--- a/src/shell/wl_shell/mod.rs
+++ b/src/shell/wl_shell/mod.rs
@@ -1,0 +1,70 @@
+use wayland_client::{
+    globals::{BindError, GlobalList},
+    protocol::{wl_shell, wl_shell_surface, wl_surface::WlSurface},
+    Connection, Dispatch, QueueHandle
+};
+
+use crate::{
+    error::GlobalError, globals::{GlobalData, ProvidesBoundGlobal}
+};
+
+pub mod window;
+
+use window::Window;
+
+
+#[derive(Debug)]
+pub struct WlShell {
+    wl_shell: wl_shell::WlShell,
+}
+
+impl WlShell {
+    pub fn bind<State>(globals: &GlobalList, qh: &QueueHandle<State>) -> Result<WlShell, BindError>
+    where
+        State: Dispatch<wl_shell::WlShell, GlobalData, State>  + 'static,
+    {
+        let wl_shell = globals.bind(qh, 1..=1, GlobalData)?;
+        
+        Ok(WlShell { wl_shell})
+    }
+
+    pub fn create_window<State>(&self, surface: WlSurface, qh: &QueueHandle<State>) -> Window 
+    where
+        State: Dispatch<wl_shell_surface::WlShellSurface, GlobalData, State> + 'static
+    {
+        let wl_shell_surface = self.wl_shell.get_shell_surface(&surface, qh, GlobalData);
+
+        Window::new(surface, wl_shell_surface)
+    }
+
+    pub fn wl_shell(&self) -> &wl_shell::WlShell {
+        &self.wl_shell
+    }
+}
+
+
+impl ProvidesBoundGlobal<wl_shell::WlShell, 1> for WlShell {
+    fn bound_global(&self) -> Result<wl_shell::WlShell, GlobalError> {
+        Ok(self.wl_shell.clone())
+    }
+}
+
+impl<D> Dispatch<wl_shell_surface::WlShellSurface, GlobalData, D> for WlShell
+where
+    D: Dispatch<wl_shell_surface::WlShellSurface, GlobalData>{
+    fn event(
+        _state: &mut D,
+        proxy: &wl_shell_surface::WlShellSurface,
+        event: wl_shell_surface::Event,
+        _data: &GlobalData,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<D>,
+    ) {
+        match event {
+            wl_shell_surface::Event::Ping { serial } => {
+                proxy.pong(serial);
+            },
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/shell/wl_shell/mod.rs
+++ b/src/shell/wl_shell/mod.rs
@@ -1,17 +1,17 @@
 use wayland_client::{
     globals::{BindError, GlobalList},
     protocol::{wl_shell, wl_shell_surface, wl_surface::WlSurface},
-    Connection, Dispatch, QueueHandle
+    Connection, Dispatch, QueueHandle,
 };
 
 use crate::{
-    error::GlobalError, globals::{GlobalData, ProvidesBoundGlobal}
+    error::GlobalError,
+    globals::{GlobalData, ProvidesBoundGlobal},
 };
 
 pub mod window;
 
 use window::Window;
-
 
 #[derive(Debug)]
 pub struct WlShell {
@@ -21,16 +21,16 @@ pub struct WlShell {
 impl WlShell {
     pub fn bind<State>(globals: &GlobalList, qh: &QueueHandle<State>) -> Result<WlShell, BindError>
     where
-        State: Dispatch<wl_shell::WlShell, GlobalData, State>  + 'static,
+        State: Dispatch<wl_shell::WlShell, GlobalData, State> + 'static,
     {
         let wl_shell = globals.bind(qh, 1..=1, GlobalData)?;
-        
-        Ok(WlShell { wl_shell})
+
+        Ok(WlShell { wl_shell })
     }
 
-    pub fn create_window<State>(&self, surface: WlSurface, qh: &QueueHandle<State>) -> Window 
+    pub fn create_window<State>(&self, surface: WlSurface, qh: &QueueHandle<State>) -> Window
     where
-        State: Dispatch<wl_shell_surface::WlShellSurface, GlobalData, State> + 'static
+        State: Dispatch<wl_shell_surface::WlShellSurface, GlobalData, State> + 'static,
     {
         let wl_shell_surface = self.wl_shell.get_shell_surface(&surface, qh, GlobalData);
 
@@ -42,7 +42,6 @@ impl WlShell {
     }
 }
 
-
 impl ProvidesBoundGlobal<wl_shell::WlShell, 1> for WlShell {
     fn bound_global(&self) -> Result<wl_shell::WlShell, GlobalError> {
         Ok(self.wl_shell.clone())
@@ -51,7 +50,8 @@ impl ProvidesBoundGlobal<wl_shell::WlShell, 1> for WlShell {
 
 impl<D> Dispatch<wl_shell_surface::WlShellSurface, GlobalData, D> for WlShell
 where
-    D: Dispatch<wl_shell_surface::WlShellSurface, GlobalData>{
+    D: Dispatch<wl_shell_surface::WlShellSurface, GlobalData>,
+{
     fn event(
         _state: &mut D,
         proxy: &wl_shell_surface::WlShellSurface,
@@ -63,7 +63,7 @@ where
         match event {
             wl_shell_surface::Event::Ping { serial } => {
                 proxy.pong(serial);
-            },
+            }
             _ => unreachable!(),
         }
     }

--- a/src/shell/wl_shell/window.rs
+++ b/src/shell/wl_shell/window.rs
@@ -1,40 +1,42 @@
 use std::sync::{Arc, Weak};
 
 use crate::{compositor::Surface, shell::WaylandSurface};
-use wayland_client::{protocol::{
-    wl_output::WlOutput,
-    wl_seat::WlSeat,
-    wl_shell_surface::{Resize, WlShellSurface},
-    wl_surface::WlSurface
-}, Connection, QueueHandle};
+use wayland_client::{
+    protocol::{
+        wl_output::WlOutput,
+        wl_seat::WlSeat,
+        wl_shell_surface::{Resize, WlShellSurface},
+        wl_surface::WlSurface,
+    },
+    Connection, QueueHandle,
+};
 
 pub trait WindowHandler: Sized {
-    fn configure(&mut self,
+    fn configure(
+        &mut self,
         conn: &Connection,
         qh: &QueueHandle<Self>,
         wl_surface: &WlSurface,
-        configure: (Resize, u32, u32)
+        configure: (Resize, u32, u32),
     );
-    
+
     fn request_close(&mut self, _: &Connection, _: &QueueHandle<Self>, wl_surface: &WlSurface);
 }
 
 #[derive(Debug)]
 pub struct WlShellWindowInner {
     pub surface: Surface,
-    pub wl_shell_surface: WlShellSurface
+    pub wl_shell_surface: WlShellSurface,
 }
 
 #[derive(Clone, Debug)]
-pub struct Window (Arc<WlShellWindowInner>);
+pub struct Window(Arc<WlShellWindowInner>);
 
 impl Window {
     pub fn new(surface: impl Into<Surface>, wl_shell_surface: WlShellSurface) -> Self {
-        Self(Arc::new_cyclic(|_weak| {
-            WlShellWindowInner{
-                surface: surface.into(),
-                wl_shell_surface
-            }
+        Self(Arc::new_cyclic(|_weak| WlShellWindowInner {
+            surface: surface.into(),
+            wl_shell_surface,
         }))
     }
 
@@ -50,7 +52,11 @@ impl Window {
     }
 
     pub fn set_fullscreen(&self, output: Option<&WlOutput>) {
-        self.0.wl_shell_surface.set_fullscreen(wayland_client::protocol::wl_shell_surface::FullscreenMethod::Fill, 60000, output);
+        self.0.wl_shell_surface.set_fullscreen(
+            wayland_client::protocol::wl_shell_surface::FullscreenMethod::Fill,
+            60000,
+            output,
+        );
     }
 
     pub fn resize(&self, seat: &WlSeat, serial: u32, edges: Resize) {

--- a/src/shell/wl_shell/window.rs
+++ b/src/shell/wl_shell/window.rs
@@ -1,0 +1,80 @@
+use std::sync::{Arc, Weak};
+
+use crate::{compositor::Surface, shell::WaylandSurface};
+use wayland_client::{protocol::{
+    wl_output::WlOutput,
+    wl_seat::WlSeat,
+    wl_shell_surface::{Resize, WlShellSurface},
+    wl_surface::WlSurface
+}, Connection, QueueHandle};
+
+pub trait WindowHandler: Sized {
+    fn configure(&mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        wl_surface: &WlSurface,
+        configure: (Resize, u32, u32)
+    );
+    
+    fn request_close(&mut self, _: &Connection, _: &QueueHandle<Self>, wl_surface: &WlSurface);
+}
+
+#[derive(Debug)]
+pub struct WlShellWindowInner {
+    pub surface: Surface,
+    pub wl_shell_surface: WlShellSurface
+}
+
+#[derive(Clone, Debug)]
+pub struct Window (Arc<WlShellWindowInner>);
+
+impl Window {
+    pub fn new(surface: impl Into<Surface>, wl_shell_surface: WlShellSurface) -> Self {
+        Self(Arc::new_cyclic(|_weak| {
+            WlShellWindowInner{
+                surface: surface.into(),
+                wl_shell_surface
+            }
+        }))
+    }
+
+    pub fn wl_shell_surface(&self) -> &WlShellSurface {
+        &self.0.wl_shell_surface
+    }
+
+    pub fn set_maximized(&self) {
+        self.0.wl_shell_surface.set_maximized(None)
+    }
+    pub fn set_top_level(&self) {
+        self.0.wl_shell_surface.set_toplevel()
+    }
+
+    pub fn set_fullscreen(&self, output: Option<&WlOutput>) {
+        self.0.wl_shell_surface.set_fullscreen(wayland_client::protocol::wl_shell_surface::FullscreenMethod::Fill, 60000, output);
+    }
+
+    pub fn resize(&self, seat: &WlSeat, serial: u32, edges: Resize) {
+        self.0.wl_shell_surface.resize(seat, serial, edges)
+    }
+
+    pub fn move_(&self, seat: &WlSeat, serial: u32) {
+        self.0.wl_shell_surface._move(seat, serial)
+    }
+
+    pub fn set_title(&self, title: impl Into<String>) {
+        self.0.wl_shell_surface.set_title(title.into())
+    }
+
+    pub fn set_app_id(&self, app_id: impl Into<String>) {
+        self.0.wl_shell_surface.set_class(app_id.into())
+    }
+}
+
+impl WaylandSurface for Window {
+    fn wl_surface(&self) -> &WlSurface {
+        &self.0.surface.wl_surface()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WindowData(pub(crate) Weak<WlShellWindowInner>);


### PR DESCRIPTION
Make available using wl shell protocol for windows creation.

## Important

This implementation is only for make available to create windows in Sailfish OS by `winit`.
I don't know what else it is need for, because it's deprecated and xdg uses everywhere.