### PR TITLE
Fix wgpu example by adding new CompositorHandler implimentations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4"
 memmap2 = "0.9.0"
 rustix = { version = "0.38.15", features = ["fs", "pipe", "shm"] }
 thiserror = "1.0.30"
-wayland-backend = { version = "0.3.0", features = ["client_system"] }
+wayland-backend = "0.3.0"
 wayland-client = "0.31.1"
 wayland-cursor = "0.31.0"
 wayland-protocols = { version = "0.32.1", features = ["client", "staging", "unstable"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4"
 memmap2 = "0.9.0"
 rustix = { version = "0.38.15", features = ["fs", "pipe", "shm"] }
 thiserror = "1.0.30"
-wayland-backend = "0.3.0"
+wayland-backend = { version = "0.3.0", features = ["client_system"] }
 wayland-client = "0.31.1"
 wayland-cursor = "0.31.0"
 wayland-protocols = { version = "0.32.1", features = ["client", "staging", "unstable"] }

--- a/examples/wgpu.rs
+++ b/examples/wgpu.rs
@@ -153,6 +153,26 @@ impl CompositorHandler for Wgpu {
         _time: u32,
     ) {
     }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+        // Not needed for this example.
+    }
 }
 
 impl OutputHandler for Wgpu {


### PR DESCRIPTION
Hello, recently had to reference wgpu example and noticed that it does not implement `surface_enter` and `surface_leave` that are required by CompositorHandler.