### PR TITLE
Add Clone for dmabuf feedback structs

### DIFF
--- a/src/dmabuf.rs
+++ b/src/dmabuf.rs
@@ -19,7 +19,7 @@ type dev_t = u64;
 use libc::dev_t;
 
 /// A preference tranche of dmabuf formats
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DmabufFeedbackTranche {
     /// `dev_t` value for preferred target device. May be scan-out or
     /// renderer device.
@@ -43,6 +43,7 @@ impl Default for DmabufFeedbackTranche {
 /// A single dmabuf format/modifier pair
 // Must have correct representation to be able to mmap format table
 #[repr(C)]
+#[derive(Copy, Clone)]
 pub struct DmabufFormat {
     /// Fourcc format
     pub format: u32,

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -7,13 +7,13 @@ use wayland_client::Proxy;
 /// argument.  For example:
 ///
 /// - A global that binds to `wl_compositor` with maximum version 4 could implement
-/// `ProvidesBoundGlobal<WlCompositor, 4>`, `ProvidesBoundGlobal<WlCompositor, 3>`,
-/// `ProvidesBoundGlobal<WlCompositor, 2>`, and `ProvidesBoundGlobal<WlCompositor, 1>` because
-/// versions 2-4 only add additional requests to the `wl_surface` API.
+///   `ProvidesBoundGlobal<WlCompositor, 4>`, `ProvidesBoundGlobal<WlCompositor, 3>`,
+///   `ProvidesBoundGlobal<WlCompositor, 2>`, and `ProvidesBoundGlobal<WlCompositor, 1>` because
+///   versions 2-4 only add additional requests to the `wl_surface` API.
 /// - A global that binds to `wl_compositor` with maximum version 5 may only implement
-/// `ProvidesBoundGlobal<WlCompositor, 5>` because version 5 makes using `wl_surface::attach` with
-/// a nonzero offset a protocol error.  A caller who is only aware of the version 4 API risks
-/// causing these protocol errors if it uses surfaces created by such a global.
+///   `ProvidesBoundGlobal<WlCompositor, 5>` because version 5 makes using `wl_surface::attach` with
+///   a nonzero offset a protocol error.  A caller who is only aware of the version 4 API risks
+///   causing these protocol errors if it uses surfaces created by such a global.
 ///
 /// Changes that cause compatibility breaks include:
 ///


### PR DESCRIPTION
The `DmabufHandler::dmabuf_feedback` handler provides access to DMA buffer feedback, however working with this feedback becomes difficult when it needs to be stored in multiple places due to missing derives.

So this patch adds the automatic `Clone` derive so the existing types in SCTK can be reused downstream.

The `DmabufFeedback` itself does not implement `Clones` since it relies on the `Mmap` type, which is not cloneable.

---

Note I didn't actually require this myself since I was able to clone the WebKit type I used it for. But it seems useful for other people so I thought I might as well put up a PR.