### PR TITLE
Add a `raw_modifiers` argument to `update_modifiers`

### DIFF
--- a/examples/data_device.rs
+++ b/examples/data_device.rs
@@ -31,7 +31,7 @@ use smithay_client_toolkit::{
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
     seat::{
-        keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers},
+        keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers, RawModifiers},
         pointer::{PointerEvent, PointerEventKind, PointerHandler, BTN_LEFT},
         Capability, SeatHandler, SeatState,
     },
@@ -461,6 +461,7 @@ impl KeyboardHandler for DataDeviceWindow {
         _: &wl_keyboard::WlKeyboard,
         _serial: u32,
         modifiers: Modifiers,
+        _raw_modifiers: RawModifiers,
         _layout: u32,
     ) {
         self.modifiers = modifiers;

--- a/examples/generic_simple_window.rs
+++ b/examples/generic_simple_window.rs
@@ -8,7 +8,7 @@ use smithay_client_toolkit::{
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
     seat::{
-        keyboard::{KeyEvent, KeyboardHandler, Modifiers},
+        keyboard::{KeyEvent, KeyboardHandler, Modifiers, RawModifiers},
         pointer::{PointerEvent, PointerEventKind, PointerHandler},
         Capability, SeatHandler, SeatState,
     },
@@ -349,6 +349,7 @@ impl<T: Test + 'static> KeyboardHandler for SimpleWindow<T> {
         _: &wl_keyboard::WlKeyboard,
         _serial: u32,
         modifiers: Modifiers,
+        _raw_modifiers: RawModifiers,
         _layout: u32,
     ) {
         println!("Update modifiers: {modifiers:?}");

--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -10,7 +10,7 @@ use smithay_client_toolkit::{
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
     seat::{
-        keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers},
+        keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers, RawModifiers},
         pointer::{PointerEvent, PointerEventKind, PointerHandler},
         Capability, SeatHandler, SeatState,
     },
@@ -344,6 +344,7 @@ impl KeyboardHandler for SimpleLayer {
         _: &wl_keyboard::WlKeyboard,
         _serial: u32,
         modifiers: Modifiers,
+        _raw_modifiers: RawModifiers,
         _layout: u32,
     ) {
         println!("Update modifiers: {modifiers:?}");

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -12,7 +12,7 @@ use smithay_client_toolkit::{
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
     seat::{
-        keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers},
+        keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers, RawModifiers},
         pointer::{PointerEvent, PointerEventKind, PointerHandler},
         Capability, SeatHandler, SeatState,
     },
@@ -388,6 +388,7 @@ impl KeyboardHandler for SimpleWindow {
         _: &wl_keyboard::WlKeyboard,
         _serial: u32,
         modifiers: Modifiers,
+        _raw_modifiers: RawModifiers,
         _layout: u32,
     ) {
         println!("Update modifiers: {modifiers:?}");

--- a/examples/themed_window.rs
+++ b/examples/themed_window.rs
@@ -19,7 +19,7 @@ use smithay_client_toolkit::{
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
     seat::{
-        keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers},
+        keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers, RawModifiers},
         pointer::{
             CursorIcon, PointerData, PointerEvent, PointerEventKind, PointerHandler, ThemeSpec,
             ThemedPointer,
@@ -483,6 +483,7 @@ impl KeyboardHandler for SimpleWindow {
         _: &wl_keyboard::WlKeyboard,
         _serial: u32,
         _: Modifiers,
+        _raw_modifiers: RawModifiers,
         _layout: u32,
     ) {
     }

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -181,6 +181,7 @@ pub trait KeyboardHandler: Sized {
     ///
     /// This happens when one of the modifier keys, such as "Shift", "Control" or "Alt" is pressed or
     /// released.
+    #[allow(clippy::too_many_arguments)]
     fn update_modifiers(
         &mut self,
         conn: &Connection,
@@ -188,6 +189,7 @@ pub trait KeyboardHandler: Sized {
         keyboard: &wl_keyboard::WlKeyboard,
         serial: u32,
         modifiers: Modifiers,
+        raw_modifiers: RawModifiers,
         layout: u32,
     );
 
@@ -255,6 +257,14 @@ pub struct KeyEvent {
     ///
     /// This will always be [`None`] on release events.
     pub utf8: Option<String>,
+}
+
+/// State of keyboard modifiers, in raw form sent by compositor.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RawModifiers {
+    pub depressed: u32,
+    pub latched: u32,
+    pub locked: u32,
 }
 
 /// The state of keyboard modifiers
@@ -830,9 +840,15 @@ where
                 // Drop guard before calling user code.
                 drop(guard);
 
+                let raw_modifiers = RawModifiers {
+                    depressed: mods_depressed,
+                    latched: mods_latched,
+                    locked: mods_locked,
+                };
+
                 // Always issue the modifiers update for the user.
                 let modifiers = udata.update_modifiers();
-                data.update_modifiers(conn, qh, keyboard, serial, modifiers, group);
+                data.update_modifiers(conn, qh, keyboard, serial, modifiers, raw_modifiers, group);
             }
 
             wl_keyboard::Event::RepeatInfo { rate, delay } => {


### PR DESCRIPTION
This can be used for things like nested compositors, that want to propagate the modifier state as expressed by the compositor.