### PR TITLE
build(deps): Increase minimum version of `log` to 0.4.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bitflags = "2.4"
 bytemuck = { version = "1.13.0", optional = true }
 cursor-icon = "1.1.0"
 libc = "0.2.148"
-log = "0.4"
+log = "0.4.8"
 memmap2 = "0.9.0"
 rustix = { version = "0.38.15", features = ["fs", "pipe", "shm"] }
 thiserror = "1.0.30"


### PR DESCRIPTION
The crate `log` requires a mimimum version of 0.4.8. This version is release over 5 years ago.

I found this using `cargo minimal-versions check --all-features`, which fails to compile.