### PR TITLE
simple_layer example: Handle 0 width/height in configure correctly

### DIFF
--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -1,6 +1,6 @@
 //! This example is horrible. Please make a better one soon.
 
-use std::convert::TryInto;
+use std::{convert::TryInto, num::NonZeroU32};
 
 use smithay_client_toolkit::{
     compositor::{CompositorHandler, CompositorState},
@@ -215,13 +215,8 @@ impl LayerShellHandler for SimpleLayer {
         configure: LayerSurfaceConfigure,
         _serial: u32,
     ) {
-        if configure.new_size.0 == 0 || configure.new_size.1 == 0 {
-            self.width = 256;
-            self.height = 256;
-        } else {
-            self.width = configure.new_size.0;
-            self.height = configure.new_size.1;
-        }
+        self.width = NonZeroU32::new(configure.new_size.0).map_or(256, NonZeroU32::get);
+        self.height = NonZeroU32::new(configure.new_size.1).map_or(256, NonZeroU32::get);
 
         // Initiate the first draw.
         if self.first_configure {


### PR DESCRIPTION
The `wlr-layer-shell-unstable` protocol says:
> If the width or height arguments are zero, it means the client should decide its own window dimension.

While the wording doesn't make it clear, I think it's reasonable to assume it's talking about each dimension *separately* - the word "dimension" isn't plural, and there's legitimate use cases for this behavior (e.g. scrolling compositors like niri).

Relevent issue: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/155 (about xdg-shell not layer-shell, the wording comes from there)

This can also be written as:
```rs
self.width = Some(configure.new_size.0).filter(|width| *width != 0).unwrap_or(256);
self.height = Some(configure.new_size.1).filter(|height| *height != 0).unwrap_or(256);
```
or plain ifs, which might be a little bit more readable, but I feel like using and encouraging `NonZeroU32` is more idiomatic and flexible. It's not clear what's the MSRV policy, but I avoided `NonZero` since it's pretty new (rust `1.79.0`).