### PR TITLE
Update xkbcommon to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wayland-protocols-wlr = { version = "0.3.1", features = ["client"] }
 wayland-scanner = "0.31.0"
 wayland-csd-frame = "0.3.0"
 
-xkbcommon = { version = "0.7.0", optional = true, features = ["wayland"] }
+xkbcommon = { version = "0.8.0", optional = true, features = ["wayland"] }
 xkeysym = "0.2.0"
 
 calloop = { version = "0.14.0", optional = true }


### PR DESCRIPTION
There doesn’t appear to be any kind of changelog or release notes available for `xkbcommon`, but the full source diff is:

https://github.com/rust-x-bindings/xkbcommon-rs/compare/v0.7.0...v0.8.0

Commit messages indicate that this update contains some bug fixes.

It looks like the SemVer-incompatible change was to the value of the string `MOD_NAME_MOD3`, which is in the public API: https://github.com/rust-x-bindings/xkbcommon-rs/commit/f799423877d345a04a58727a59ab4a38658f89ba. I think that shouldn’t require any code changes in `client-toolkit`.

I confirmed that `cargo test` still passes.