### PR TITLE
ci: Update hecrj/setup-rust-action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           key: cargo-${{ matrix.rust }}
 
       - name: Rust toolchain
-        uses: hecrj/setup-rust-action@v1
+        uses: hecrj/setup-rust-action@v2
         with:
           rust-version: ${{ matrix.rust }}
 
@@ -56,7 +56,7 @@ jobs:
           key: cargo-${{ matrix.rust }}
 
       - name: Rust toolchain
-        uses: hecrj/setup-rust-action@v1
+        uses: hecrj/setup-rust-action@v2
         with:
           rust-version: ${{ matrix.rust }}
 
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Rust toolchain
-        uses: hecrj/setup-rust-action@v1
+        uses: hecrj/setup-rust-action@v2
         with:
           toolchain: stable
           override: true


### PR DESCRIPTION
This should fix the [currently broken](https://github.com/Smithay/client-toolkit/actions/runs/14986221417/job/42100552606) `lint` stage of the CI