### PR TITLE
update to rustix 1 and thiserror 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ cursor-icon = "1.1.0"
 libc = "0.2.148"
 log = "0.4"
 memmap2 = "0.9.0"
-rustix = { version = "0.38.15", features = ["fs", "pipe", "shm"] }
-thiserror = "1.0.30"
+rustix = { version = "1.0.7", features = ["fs", "pipe", "shm"] }
+thiserror = "2.0.12"
 wayland-backend = "0.3.0"
 wayland-client = "0.31.1"
 wayland-cursor = "0.31.0"

--- a/src/shm/raw.rs
+++ b/src/shm/raw.rs
@@ -5,7 +5,7 @@
 
 use rustix::{
     io::Errno,
-    shm::{Mode, ShmOFlags},
+    shm::{Mode, OFlags},
 };
 use std::{
     fs::File,
@@ -201,12 +201,12 @@ impl RawPool {
         );
 
         loop {
-            let flags = ShmOFlags::CREATE | ShmOFlags::EXCL | ShmOFlags::RDWR;
+            let flags = OFlags::CREATE | OFlags::EXCL | OFlags::RDWR;
 
             let mode = Mode::RUSR | Mode::WUSR;
 
-            match rustix::shm::shm_open(mem_file_handle.as_str(), flags, mode) {
-                Ok(fd) => match rustix::shm::shm_unlink(mem_file_handle.as_str()) {
+            match rustix::shm::open(mem_file_handle.as_str(), flags, mode) {
+                Ok(fd) => match rustix::shm::unlink(mem_file_handle.as_str()) {
                     Ok(_) => return Ok(fd),
 
                     Err(errno) => {


### PR DESCRIPTION
the only thing that i had to adjust for with the rustix update is the rename of `rustix::shm::shm_open` to just `rustix::shm::open` (and the same with `the `ShmOflags` and `shm_unlink`), everything else seems to have stayed compatible.

i didn't need to change anything for the thiserror update.