### PR TITLE
wayland/cursor_shape: update to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bitflags = "2.4"
 bytemuck = { version = "1.13.0", optional = true }
-cursor-icon = "1.1.0"
+cursor-icon = "1.2.0"
 libc = "0.2.148"
 log = "0.4"
 memmap2 = "0.9.0"

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -250,7 +250,7 @@ impl SeatState {
             &self.cursor_shape_manager_state
         {
             self.cursor_shape_manager_state =
-                match crate::registry::bind_one(registry, &[global.clone()], qh, 1..=1, GlobalData)
+                match crate::registry::bind_one(registry, &[global.clone()], qh, 1..=2, GlobalData)
                 {
                     Ok(bound) => {
                         CursorShapeManagerState::Bound(CursorShapeManager::from_existing(bound))

--- a/src/seat/pointer/cursor_shape.rs
+++ b/src/seat/pointer/cursor_shape.rs
@@ -21,7 +21,7 @@ impl CursorShapeManager {
     where
         State: Dispatch<WpCursorShapeManagerV1, GlobalData> + 'static,
     {
-        let cursor_shape_manager = globals.bind(queue_handle, 1..=1, GlobalData)?;
+        let cursor_shape_manager = globals.bind(queue_handle, 1..=2, GlobalData)?;
         Ok(Self { cursor_shape_manager })
     }
 
@@ -77,7 +77,7 @@ where
     }
 }
 
-pub(crate) fn cursor_icon_to_shape(cursor_icon: CursorIcon) -> Shape {
+pub(crate) fn cursor_icon_to_shape(cursor_icon: CursorIcon, version: u32) -> Shape {
     match cursor_icon {
         CursorIcon::Default => Shape::Default,
         CursorIcon::ContextMenu => Shape::ContextMenu,
@@ -113,6 +113,8 @@ pub(crate) fn cursor_icon_to_shape(cursor_icon: CursorIcon) -> Shape {
         CursorIcon::AllScroll => Shape::AllScroll,
         CursorIcon::ZoomIn => Shape::ZoomIn,
         CursorIcon::ZoomOut => Shape::ZoomOut,
+        CursorIcon::DndAsk if version >= 2 => Shape::DndAsk,
+        CursorIcon::AllResize if version >= 2 => Shape::AllResize,
         _ => Shape::Default,
     }
 }

--- a/src/seat/pointer/mod.rs
+++ b/src/seat/pointer/mod.rs
@@ -440,7 +440,7 @@ impl<U: PointerDataExt + 'static, S: SurfaceDataExt + 'static> ThemedPointer<U, 
         };
 
         if let Some(shape_device) = self.shape_device.as_ref() {
-            shape_device.set_shape(serial, cursor_icon_to_shape(icon));
+            shape_device.set_shape(serial, cursor_icon_to_shape(icon, shape_device.version()));
             Ok(())
         } else {
             self.set_cursor_legacy(conn, serial, icon)


### PR DESCRIPTION
update the wayland cursor-shape protocol to version 2, released in [wayland-protocols version 1.42](https://lists.freedesktop.org/archives/wayland-devel/2025-March/044027.html). needs `cursor-icon` v1.2.0, as that includes https://github.com/rust-windowing/cursor-icon/pull/17.