### PR TITLE
Add wl_pointer extensions from v8 and v9

### DIFF
--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -92,7 +92,7 @@ impl SeatState {
                 .unwrap_or(CursorShapeManagerState::NotPresent);
 
             (
-                crate::registry::bind_all(global_list.registry(), globals, qh, 1..=8, |id| {
+                crate::registry::bind_all(global_list.registry(), globals, qh, 1..=9, |id| {
                     SeatData {
                         has_keyboard: Arc::new(AtomicBool::new(false)),
                         has_pointer: Arc::new(AtomicBool::new(false)),


### PR DESCRIPTION
I've done a little testing on it.
The user of the API is responsible for choosing which event they want to rely on.