### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
         with:
           rust-version: ${{ matrix.rust }}
 
+      - name: Update system repositories
+        run: sudo apt-get update
+
       - name: Install system dependencies
         run: sudo apt-get install libfontconfig1-dev libxkbcommon-dev libwayland-dev
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 )]
 #![forbid(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::new_without_default)]
+// keep existing usage
+#![allow(clippy::uninlined_format_args)]
 
 /// Re-exports of some crates, for convenience.
 pub mod reexports {


### PR DESCRIPTION
The CI is set up in such a way that changes in external projects can fail runs that succeeded previously. This adds an exception for clippy to keep existing usages of the offending feature.