### PR TITLE
wl_keyboard: Add support for repeating from v10

### DIFF
--- a/examples/data_device.rs
+++ b/examples/data_device.rs
@@ -448,6 +448,16 @@ impl KeyboardHandler for DataDeviceWindow {
         };
     }
 
+    fn repeat_key(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        _serial: u32,
+        _event: KeyEvent,
+    ) {
+    }
+
     fn release_key(
         &mut self,
         _: &Connection,

--- a/examples/generic_simple_window.rs
+++ b/examples/generic_simple_window.rs
@@ -331,6 +331,17 @@ impl<T: Test + 'static> KeyboardHandler for SimpleWindow<T> {
         println!("Key press: {event:?}");
     }
 
+    fn repeat_key(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _: u32,
+        event: KeyEvent,
+    ) {
+        println!("Key repeat: {event:?}");
+    }
+
     fn release_key(
         &mut self,
         _: &Connection,

--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -321,6 +321,17 @@ impl KeyboardHandler for SimpleLayer {
         }
     }
 
+    fn repeat_key(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        _serial: u32,
+        event: KeyEvent,
+    ) {
+        println!("Key repeat: {event:?}");
+    }
+
     fn release_key(
         &mut self,
         _: &Connection,

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -370,6 +370,17 @@ impl KeyboardHandler for SimpleWindow {
         println!("Key press: {event:?}");
     }
 
+    fn repeat_key(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &wl_keyboard::WlKeyboard,
+        _: u32,
+        event: KeyEvent,
+    ) {
+        println!("Key repeat: {event:?}");
+    }
+
     fn release_key(
         &mut self,
         _: &Connection,

--- a/examples/themed_window.rs
+++ b/examples/themed_window.rs
@@ -466,6 +466,16 @@ impl KeyboardHandler for SimpleWindow {
         }
     }
 
+    fn repeat_key(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &wl_keyboard::WlKeyboard,
+        _serial: u32,
+        _event: KeyEvent,
+    ) {
+    }
+
     fn release_key(
         &mut self,
         _: &Connection,

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -92,7 +92,7 @@ impl SeatState {
                 .unwrap_or(CursorShapeManagerState::NotPresent);
 
             (
-                crate::registry::bind_all(global_list.registry(), globals, qh, 1..=9, |id| {
+                crate::registry::bind_all(global_list.registry(), globals, qh, 1..=10, |id| {
                     SeatData {
                         has_keyboard: Arc::new(AtomicBool::new(false)),
                         has_pointer: Arc::new(AtomicBool::new(false)),


### PR DESCRIPTION
This adds a new method repeat_key for the keys that come with the repeated mark.