### PR TITLE
Use `doc_cfg` feature instead of `doc_auto_cfg` on `docsrs`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
 //    missing_docs, // Commented out for now so the project isn't all yellow.
     missing_debug_implementations


### PR DESCRIPTION
Fixes build with recent nightly, as now used by docs.rs.

Can be tested with `RUSTDOCFLAGS=--cfg=docsrs cargo +nightly doc --all-features`, with these patches:

```toml
[patch.crates-io]
cursor-icon = { git = "https://github.com/rust-windowing/cursor-icon" }
wayland-client = { git = "https://github.com/smithay/wayland-rs" }
wayland-protocols = { git = "https://github.com/smithay/wayland-rs" }
wayland-protocols-wlr = { git = "https://github.com/smithay/wayland-rs" }
wayland-protocols-misc = { git = "https://github.com/smithay/wayland-rs" }
wayland-cursor = { git = "https://github.com/smithay/wayland-rs" }
wayland-backend = { git = "https://github.com/smithay/wayland-rs" }
wayland-csd-frame = { git = "https://github.com/ids1024/wayland-csd-frame", branch = "docsrs" }
```

As well as updating the `wayland-protocols-experimental` dependency to `git = "https://github.com/smithay/wayland-rs"`. (Though presumably other changes may be needed to correctly update experimental protocols.)