### PR TITLE
Remove direct `libc` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 bitflags = "2.4"
 bytemuck = { version = "1.13.0", optional = true }
 cursor-icon = "1.2.0"
-libc = "0.2.148"
 log = "0.4"
 memmap2 = "0.9.0"
-rustix = { version = "1.0.7", features = ["fs", "pipe", "shm"] }
+rustix = { version = "1.1.4", features = ["fs", "pipe", "shm"] }
 thiserror = "2.0.12"
 wayland-client = "0.31.14"
 wayland-cursor = "0.31.0"

--- a/src/dmabuf.rs
+++ b/src/dmabuf.rs
@@ -1,5 +1,6 @@
 use crate::{dispatch2::Dispatch2, error::GlobalError, globals::GlobalData, registry::GlobalProxy};
 use memmap2::{Mmap, MmapOptions};
+use rustix::fs::Dev as dev_t;
 use std::{fmt, mem, os::unix::io::BorrowedFd, slice, sync::Mutex};
 use wayland_client::{
     globals::GlobalList,
@@ -11,12 +12,6 @@ use wayland_protocols::wp::linux_dmabuf::zv1::client::{
     zwp_linux_dmabuf_feedback_v1::{self, TrancheFlags},
     zwp_linux_dmabuf_v1,
 };
-
-// Workaround until `libc` updates to FreeBSD 12 ABI
-#[cfg(target_os = "freebsd")]
-type dev_t = u64;
-#[cfg(not(target_os = "freebsd"))]
-use libc::dev_t;
 
 /// A preference tranche of dmabuf formats
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Replaces uses of `libc::dev_t` with `rustix::fs::Dev`.
`libc` (which is used through `rustix`) also supports the FreeBSD 12 ABI now, so the workaround isn't needed.