### PR TITLE
Prototype a `Dispatch2` trait to dispatch delegate macros to oblivion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ['1.71.0', 'stable', 'beta']
+        rust: ['1.71.1', 'stable', 'beta']
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+#### Breaking Changes
+- `*DataExt` traits removed; now `*Data` types wrap custom data
+  * Any calls to `Proxy::data` will need to be updated for new type
+- All `delegate_*!` macros except `delegate_registry!` replaced with single
+  `delegate_dispatch2!` in preparation for future wayland-rs release.
+
 ## 0.20.0 - 2025-07-29
 
 #### Breaking Changes

--- a/examples/data_device.rs
+++ b/examples/data_device.rs
@@ -11,16 +11,14 @@ use smithay_client_toolkit::reexports::calloop::{
 };
 use smithay_client_toolkit::reexports::calloop_wayland_source::WaylandSource;
 use smithay_client_toolkit::{
-    compositor::{CompositorHandler, CompositorState},
+    compositor::{CompositorHandler, CompositorState, FrameCallbackData},
     data_device_manager::{
         data_device::{DataDevice, DataDeviceHandler},
         data_offer::{DataOfferHandler, DragOffer, SelectionOffer},
         data_source::{CopyPasteSource, DataSourceHandler, DragSource},
         DataDeviceManagerState, WritePipe,
     },
-    delegate_compositor, delegate_data_device, delegate_keyboard, delegate_output,
-    delegate_pointer, delegate_primary_selection, delegate_registry, delegate_seat, delegate_shm,
-    delegate_xdg_shell, delegate_xdg_window,
+    delegate_registry,
     output::{OutputHandler, OutputState},
     primary_selection::{
         device::{PrimarySelectionDevice, PrimarySelectionDeviceHandler},
@@ -614,7 +612,7 @@ impl DataDeviceWindow {
         self.window.wl_surface().damage_buffer(0, 0, self.width as i32, self.height as i32);
 
         // Request our next frame
-        self.window.wl_surface().frame(qh, self.window.wl_surface().clone());
+        self.window.wl_surface().frame(qh, FrameCallbackData(self.window.wl_surface().clone()));
 
         // Attach and commit to present.
         buffer.attach_to(self.window.wl_surface()).expect("buffer attach");
@@ -1081,21 +1079,6 @@ struct SeatObject {
     primary_device: Option<PrimarySelectionDevice>,
 }
 
-delegate_compositor!(DataDeviceWindow);
-delegate_output!(DataDeviceWindow);
-delegate_shm!(DataDeviceWindow);
-
-delegate_seat!(DataDeviceWindow);
-delegate_keyboard!(DataDeviceWindow);
-delegate_pointer!(DataDeviceWindow);
-
-delegate_xdg_shell!(DataDeviceWindow);
-delegate_xdg_window!(DataDeviceWindow);
-
-delegate_data_device!(DataDeviceWindow);
-
-delegate_primary_selection!(DataDeviceWindow);
-
 delegate_registry!(DataDeviceWindow);
 
 const SUPPORTED_MIME_TYPES: &[&str; 6] = &[
@@ -1115,3 +1098,5 @@ fn pick_mime(mime_types: &[String]) -> Option<String> {
 
     None
 }
+
+smithay_client_toolkit::delegate_dispatch2!(DataDeviceWindow);

--- a/examples/dmabuf_formats.rs
+++ b/examples/dmabuf_formats.rs
@@ -127,5 +127,5 @@ fn print_format(format: &DmabufFormat) {
     println!(", Modifier: {:?}", DrmModifier::from(format.modifier));
 }
 
-smithay_client_toolkit::delegate_dmabuf!(AppData);
 smithay_client_toolkit::delegate_registry!(AppData);
+smithay_client_toolkit::delegate_dispatch2!(AppData);

--- a/examples/foreign-toplevel-monitor.rs
+++ b/examples/foreign-toplevel-monitor.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use smithay_client_toolkit::{
-    delegate_foreign_toplevel_list, delegate_registry,
+    delegate_registry,
     foreign_toplevel_list::{ForeignToplevelList, ForeignToplevelListHandler},
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
@@ -77,5 +77,5 @@ impl ForeignToplevelListHandler for State {
     }
 }
 
-delegate_foreign_toplevel_list!(State);
 delegate_registry!(State);
+smithay_client_toolkit::delegate_dispatch2!(State);

--- a/examples/generic_list_seats.rs
+++ b/examples/generic_list_seats.rs
@@ -1,5 +1,5 @@
 use smithay_client_toolkit::{
-    delegate_registry, delegate_seat,
+    delegate_registry,
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
     seat::{Capability, SeatHandler, SeatState},
@@ -81,8 +81,6 @@ impl<T: Test + 'static> SeatHandler for ListSeats<T> {
     }
 }
 
-delegate_seat!(@<T: Test + 'static> ListSeats<T>);
-
 delegate_registry!(@<T: Test + 'static> ListSeats<T>);
 
 impl<T: Test + 'static> ProvidesRegistryState for ListSeats<T> {
@@ -92,3 +90,5 @@ impl<T: Test + 'static> ProvidesRegistryState for ListSeats<T> {
 
     registry_handlers!(SeatState);
 }
+
+smithay_client_toolkit::delegate_dispatch2!(@<T: Test + 'static> ListSeats<T>);

--- a/examples/generic_simple_window.rs
+++ b/examples/generic_simple_window.rs
@@ -1,9 +1,8 @@
 use std::convert::TryInto;
 
 use smithay_client_toolkit::{
-    compositor::{CompositorHandler, CompositorState},
-    delegate_compositor, delegate_keyboard, delegate_output, delegate_pointer, delegate_registry,
-    delegate_seat, delegate_shm, delegate_xdg_shell, delegate_xdg_window,
+    compositor::{CompositorHandler, CompositorState, FrameCallbackData},
+    delegate_registry,
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
@@ -468,24 +467,13 @@ impl<T: Test + 'static> SimpleWindow<T> {
         self.window.wl_surface().damage_buffer(0, 0, self.width as i32, self.height as i32);
 
         // Request our next frame
-        self.window.wl_surface().frame(qh, self.window.wl_surface().clone());
+        self.window.wl_surface().frame(qh, FrameCallbackData(self.window.wl_surface().clone()));
 
         // Attach and commit to present.
         buffer.attach_to(self.window.wl_surface()).expect("buffer attach");
         self.window.commit();
     }
 }
-
-delegate_compositor!(@<T: Test + 'static> SimpleWindow<T>);
-delegate_output!(@<T: Test + 'static> SimpleWindow<T>);
-delegate_shm!(@<T: Test + 'static> SimpleWindow<T>);
-
-delegate_seat!(@<T: Test + 'static> SimpleWindow<T>);
-delegate_keyboard!(@<T: Test + 'static> SimpleWindow<T>);
-delegate_pointer!(@<T: Test + 'static> SimpleWindow<T>);
-
-delegate_xdg_shell!(@<T: Test + 'static> SimpleWindow<T>);
-delegate_xdg_window!(@<T: Test + 'static> SimpleWindow<T>);
 
 delegate_registry!(@<T: Test + 'static> SimpleWindow<T>);
 
@@ -495,3 +483,5 @@ impl<T: Test + 'static> ProvidesRegistryState for SimpleWindow<T> {
     }
     registry_handlers![OutputState, SeatState,];
 }
+
+smithay_client_toolkit::delegate_dispatch2!(@<T: Test + 'static> SimpleWindow<T>);

--- a/examples/image_viewer.rs
+++ b/examples/image_viewer.rs
@@ -1,9 +1,8 @@
 use std::env;
 
 use smithay_client_toolkit::{
-    compositor::{CompositorHandler, CompositorState},
-    delegate_compositor, delegate_output, delegate_registry, delegate_shm, delegate_xdg_shell,
-    delegate_xdg_window,
+    compositor::{CompositorHandler, CompositorState, FrameCallbackData},
+    delegate_registry,
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
@@ -309,7 +308,7 @@ impl State {
             viewer.damaged = false;
 
             // Request our next frame
-            window.wl_surface().frame(qh, window.wl_surface().clone());
+            window.wl_surface().frame(qh, FrameCallbackData(window.wl_surface().clone()));
 
             // Attach and commit to present.
             buffer.attach_to(window.wl_surface()).expect("buffer attach");
@@ -317,13 +316,6 @@ impl State {
         }
     }
 }
-
-delegate_compositor!(State);
-delegate_output!(State);
-delegate_shm!(State);
-
-delegate_xdg_shell!(State);
-delegate_xdg_window!(State);
 
 delegate_registry!(State);
 
@@ -334,3 +326,5 @@ impl ProvidesRegistryState for State {
 
     registry_handlers!(OutputState);
 }
+
+smithay_client_toolkit::delegate_dispatch2!(State);

--- a/examples/image_viewporter.rs
+++ b/examples/image_viewporter.rs
@@ -2,8 +2,7 @@ use std::{env, path::Path};
 
 use smithay_client_toolkit::{
     compositor::{CompositorHandler, CompositorState},
-    delegate_compositor, delegate_output, delegate_registry, delegate_shm, delegate_simple,
-    delegate_xdg_shell, delegate_xdg_window,
+    delegate_registry,
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState, SimpleGlobal},
     registry_handlers,
@@ -318,14 +317,7 @@ impl State {
     }
 }
 
-delegate_compositor!(State);
-delegate_output!(State);
-delegate_shm!(State);
-
-delegate_xdg_shell!(State);
-delegate_xdg_window!(State);
-
-delegate_simple!(State, WpViewporter, 1);
+wayland_client::delegate_noop!(State: WpViewporter);
 
 delegate_registry!(State);
 
@@ -361,3 +353,5 @@ impl Drop for ImageViewer {
         self.viewport.destroy()
     }
 }
+
+smithay_client_toolkit::delegate_dispatch2!(State);

--- a/examples/list_outputs.rs
+++ b/examples/list_outputs.rs
@@ -3,7 +3,7 @@
 use std::error::Error;
 
 use smithay_client_toolkit::{
-    delegate_output, delegate_registry,
+    delegate_registry,
     output::{OutputHandler, OutputInfo, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
@@ -103,10 +103,6 @@ impl OutputHandler for ListOutputs {
     }
 }
 
-// Now we need to say we are delegating the responsibility of output related events for our application data
-// type to the requisite delegate.
-delegate_output!(ListOutputs);
-
 // In order for our delegate to know of the existence of globals, we need to implement registry
 // handling for the program. This trait will forward events to the RegistryHandler trait
 // implementations.
@@ -125,7 +121,7 @@ impl ProvidesRegistryState for ListOutputs {
     registry_handlers! {
         // Here we specify that OutputState needs to receive events regarding the creation and destruction of
         // globals.
-        OutputState,
+        OutputState
     }
 }
 
@@ -157,3 +153,5 @@ fn print_output(info: &OutputInfo) {
         println!("\t\t{mode}");
     }
 }
+
+smithay_client_toolkit::delegate_dispatch2!(ListOutputs);

--- a/examples/list_seats.rs
+++ b/examples/list_seats.rs
@@ -1,5 +1,5 @@
 use smithay_client_toolkit::{
-    delegate_registry, delegate_seat,
+    delegate_registry,
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
     seat::{Capability, SeatHandler, SeatState},
@@ -69,8 +69,6 @@ impl SeatHandler for ListSeats {
     }
 }
 
-delegate_seat!(ListSeats);
-
 delegate_registry!(ListSeats);
 
 impl ProvidesRegistryState for ListSeats {
@@ -80,3 +78,5 @@ impl ProvidesRegistryState for ListSeats {
 
     registry_handlers!(SeatState);
 }
+
+smithay_client_toolkit::delegate_dispatch2!(ListSeats);

--- a/examples/list_shm_formats.rs
+++ b/examples/list_shm_formats.rs
@@ -1,8 +1,5 @@
 /// Example app showing how to use delegate types from Smithay's client toolkit and initializing state.
-use smithay_client_toolkit::{
-    delegate_shm,
-    shm::{Shm, ShmHandler},
-};
+use smithay_client_toolkit::shm::{Shm, ShmHandler};
 use wayland_client::{
     globals::{registry_queue_init, GlobalListContents},
     protocol::wl_registry,
@@ -45,9 +42,6 @@ impl ShmHandler for ListShmFormats {
     }
 }
 
-// Delegate handling of the wl_shm protocol to our state object.
-delegate_shm!(ListShmFormats);
-
 impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for ListShmFormats {
     fn event(
         _state: &mut Self,
@@ -60,3 +54,5 @@ impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for ListShmFormats {
         // We don't need any other globals.
     }
 }
+
+smithay_client_toolkit::delegate_dispatch2!(ListShmFormats);

--- a/examples/relative_pointer.rs
+++ b/examples/relative_pointer.rs
@@ -1,10 +1,8 @@
 //! An example demonstrating relative pointer and (if supported) pointer constraints
 
 use smithay_client_toolkit::{
-    compositor::{CompositorHandler, CompositorState},
-    delegate_compositor, delegate_output, delegate_pointer, delegate_pointer_constraints,
-    delegate_registry, delegate_relative_pointer, delegate_seat, delegate_shm, delegate_xdg_shell,
-    delegate_xdg_window,
+    compositor::{CompositorHandler, CompositorState, FrameCallbackData},
+    delegate_registry,
     globals::ProvidesBoundGlobal,
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
@@ -444,7 +442,7 @@ impl SimpleWindow {
             window.wl_surface().damage_buffer(0, 0, self.width as i32, self.height as i32);
 
             // Request our next frame
-            window.wl_surface().frame(qh, window.wl_surface().clone());
+            window.wl_surface().frame(qh, FrameCallbackData(window.wl_surface().clone()));
 
             // Attach and commit to present.
             buffer.attach_to(window.wl_surface()).expect("buffer attach");
@@ -546,18 +544,6 @@ impl SimpleWindow {
     }
 }
 
-delegate_compositor!(SimpleWindow);
-delegate_output!(SimpleWindow);
-delegate_shm!(SimpleWindow);
-
-delegate_seat!(SimpleWindow);
-delegate_pointer!(SimpleWindow);
-delegate_pointer_constraints!(SimpleWindow);
-delegate_relative_pointer!(SimpleWindow);
-
-delegate_xdg_shell!(SimpleWindow);
-delegate_xdg_window!(SimpleWindow);
-
 delegate_registry!(SimpleWindow);
 
 impl ProvidesRegistryState for SimpleWindow {
@@ -578,3 +564,5 @@ impl Dispatch<wl_region::WlRegion, ()> for SimpleWindow {
     ) {
     }
 }
+
+smithay_client_toolkit::delegate_dispatch2!(SimpleWindow);

--- a/examples/session_lock.rs
+++ b/examples/session_lock.rs
@@ -249,9 +249,6 @@ impl ShmHandler for AppData {
     }
 }
 
-smithay_client_toolkit::delegate_compositor!(AppData);
-smithay_client_toolkit::delegate_output!(AppData);
-smithay_client_toolkit::delegate_session_lock!(AppData);
-smithay_client_toolkit::delegate_shm!(AppData);
 smithay_client_toolkit::delegate_registry!(AppData);
 wayland_client::delegate_noop!(AppData: ignore wl_buffer::WlBuffer);
+smithay_client_toolkit::delegate_dispatch2!(AppData);

--- a/examples/simple_layer.rs
+++ b/examples/simple_layer.rs
@@ -3,9 +3,8 @@
 use std::{convert::TryInto, num::NonZeroU32};
 
 use smithay_client_toolkit::{
-    compositor::{CompositorHandler, CompositorState},
-    delegate_compositor, delegate_keyboard, delegate_layer, delegate_output, delegate_pointer,
-    delegate_registry, delegate_seat, delegate_shm,
+    compositor::{CompositorHandler, CompositorState, FrameCallbackData},
+    delegate_registry,
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
@@ -437,7 +436,7 @@ impl SimpleLayer {
         self.layer.wl_surface().damage_buffer(0, 0, width as i32, height as i32);
 
         // Request our next frame
-        self.layer.wl_surface().frame(qh, self.layer.wl_surface().clone());
+        self.layer.wl_surface().frame(qh, FrameCallbackData(self.layer.wl_surface().clone()));
 
         // Attach and commit to present.
         buffer.attach_to(self.layer.wl_surface()).expect("buffer attach");
@@ -449,16 +448,6 @@ impl SimpleLayer {
     }
 }
 
-delegate_compositor!(SimpleLayer);
-delegate_output!(SimpleLayer);
-delegate_shm!(SimpleLayer);
-
-delegate_seat!(SimpleLayer);
-delegate_keyboard!(SimpleLayer);
-delegate_pointer!(SimpleLayer);
-
-delegate_layer!(SimpleLayer);
-
 delegate_registry!(SimpleLayer);
 
 impl ProvidesRegistryState for SimpleLayer {
@@ -467,3 +456,5 @@ impl ProvidesRegistryState for SimpleLayer {
     }
     registry_handlers![OutputState, SeatState];
 }
+
+smithay_client_toolkit::delegate_dispatch2!(SimpleLayer);

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -85,6 +85,7 @@ fn main() {
                 seat_and_serial: None,
                 surface: Some(window.wl_surface().clone()),
                 app_id: Some(String::from("io.github.smithay.client-toolkit.SimpleWindow")),
+                udata: (),
             },
         )
     }
@@ -258,9 +259,9 @@ impl WindowHandler for SimpleWindow {
 }
 
 impl ActivationHandler for SimpleWindow {
-    type RequestData = RequestData;
+    type RequestUdata = ();
 
-    fn new_token(&mut self, token: String, _data: &Self::RequestData) {
+    fn new_token(&mut self, token: String, _data: &RequestData<()>) {
         self.xdg_activation
             .as_ref()
             .unwrap()

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -5,9 +5,8 @@ use smithay_client_toolkit::reexports::calloop::{EventLoop, LoopHandle};
 use smithay_client_toolkit::reexports::calloop_wayland_source::WaylandSource;
 use smithay_client_toolkit::{
     activation::{ActivationHandler, ActivationState},
-    compositor::{CompositorHandler, CompositorState},
-    delegate_activation, delegate_compositor, delegate_keyboard, delegate_output, delegate_pointer,
-    delegate_registry, delegate_seat, delegate_shm, delegate_xdg_shell, delegate_xdg_window,
+    compositor::{CompositorHandler, CompositorState, FrameCallbackData},
+    delegate_registry,
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
@@ -509,25 +508,13 @@ impl SimpleWindow {
         self.window.wl_surface().damage_buffer(0, 0, self.width as i32, self.height as i32);
 
         // Request our next frame
-        self.window.wl_surface().frame(qh, self.window.wl_surface().clone());
+        self.window.wl_surface().frame(qh, FrameCallbackData(self.window.wl_surface().clone()));
 
         // Attach and commit to present.
         buffer.attach_to(self.window.wl_surface()).expect("buffer attach");
         self.window.commit();
     }
 }
-
-delegate_compositor!(SimpleWindow);
-delegate_output!(SimpleWindow);
-delegate_shm!(SimpleWindow);
-
-delegate_seat!(SimpleWindow);
-delegate_keyboard!(SimpleWindow);
-delegate_pointer!(SimpleWindow);
-
-delegate_xdg_shell!(SimpleWindow);
-delegate_xdg_window!(SimpleWindow);
-delegate_activation!(SimpleWindow);
 
 delegate_registry!(SimpleWindow);
 
@@ -537,3 +524,5 @@ impl ProvidesRegistryState for SimpleWindow {
     }
     registry_handlers![OutputState, SeatState,];
 }
+
+smithay_client_toolkit::delegate_dispatch2!(SimpleWindow);

--- a/examples/themed_window.rs
+++ b/examples/themed_window.rs
@@ -387,7 +387,7 @@ impl SeatHandler for SimpleWindow {
             let surface = self.compositor_state.create_surface(qh);
             let themed_pointer = self
                 .seat_state
-                .get_pointer_with_theme(
+                .get_pointer_with_theme::<_, ()>(
                     qh,
                     &seat,
                     self.shm_state.wl_shm(),
@@ -563,7 +563,7 @@ impl PointerHandler for SimpleWindow {
 
 impl SimpleWindow {
     fn frame_action(&mut self, pointer: &wl_pointer::WlPointer, serial: u32, action: FrameAction) {
-        let pointer_data = pointer.data::<PointerData>().unwrap();
+        let pointer_data = pointer.data::<PointerData<()>>().unwrap();
         let seat = pointer_data.seat();
         match action {
             FrameAction::Close => self.exit = true,

--- a/examples/themed_window.rs
+++ b/examples/themed_window.rs
@@ -12,9 +12,8 @@ use smithay_client_toolkit::reexports::csd_frame::{
 };
 use smithay_client_toolkit::reexports::protocols::xdg::shell::client::xdg_toplevel::ResizeEdge as XdgResizeEdge;
 use smithay_client_toolkit::{
-    compositor::{CompositorHandler, CompositorState},
-    delegate_compositor, delegate_keyboard, delegate_output, delegate_pointer, delegate_registry,
-    delegate_seat, delegate_shm, delegate_subcompositor, delegate_xdg_shell, delegate_xdg_window,
+    compositor::{CompositorHandler, CompositorState, FrameCallbackData},
+    delegate_registry,
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
@@ -665,25 +664,13 @@ impl SimpleWindow {
         self.window.wl_surface().damage_buffer(0, 0, width as i32, height as i32);
 
         // Request our next frame
-        self.window.wl_surface().frame(qh, self.window.wl_surface().clone());
+        self.window.wl_surface().frame(qh, FrameCallbackData(self.window.wl_surface().clone()));
 
         // Attach and commit to present.
         buffer.attach_to(self.window.wl_surface()).expect("buffer attach");
         self.window.wl_surface().commit();
     }
 }
-
-delegate_compositor!(SimpleWindow);
-delegate_subcompositor!(SimpleWindow);
-delegate_output!(SimpleWindow);
-delegate_shm!(SimpleWindow);
-
-delegate_seat!(SimpleWindow);
-delegate_keyboard!(SimpleWindow);
-delegate_pointer!(SimpleWindow);
-
-delegate_xdg_shell!(SimpleWindow);
-delegate_xdg_window!(SimpleWindow);
 
 delegate_registry!(SimpleWindow);
 
@@ -693,3 +680,5 @@ impl ProvidesRegistryState for SimpleWindow {
     }
     registry_handlers![OutputState, SeatState,];
 }
+
+smithay_client_toolkit::delegate_dispatch2!(SimpleWindow);

--- a/examples/wgpu.rs
+++ b/examples/wgpu.rs
@@ -3,8 +3,7 @@ use raw_window_handle::{
 };
 use smithay_client_toolkit::{
     compositor::{CompositorHandler, CompositorState},
-    delegate_compositor, delegate_output, delegate_registry, delegate_seat, delegate_xdg_shell,
-    delegate_xdg_window,
+    delegate_registry,
     output::{OutputHandler, OutputState},
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
@@ -300,14 +299,6 @@ impl SeatHandler for Wgpu {
     fn remove_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_seat::WlSeat) {}
 }
 
-delegate_compositor!(Wgpu);
-delegate_output!(Wgpu);
-
-delegate_seat!(Wgpu);
-
-delegate_xdg_shell!(Wgpu);
-delegate_xdg_window!(Wgpu);
-
 delegate_registry!(Wgpu);
 
 impl ProvidesRegistryState for Wgpu {
@@ -316,3 +307,5 @@ impl ProvidesRegistryState for Wgpu {
     }
     registry_handlers![OutputState];
 }
+
+smithay_client_toolkit::delegate_dispatch2!(Wgpu);

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -6,6 +6,7 @@ use wayland_client::{
 use wayland_protocols::xdg::activation::v1::client::{xdg_activation_token_v1, xdg_activation_v1};
 
 use crate::{
+    dispatch2::Dispatch2,
     error::GlobalError,
     globals::{GlobalData, ProvidesBoundGlobal},
 };
@@ -90,15 +91,15 @@ impl ActivationState {
     }
 }
 
-impl<D> Dispatch<xdg_activation_v1::XdgActivationV1, GlobalData, D> for ActivationState
+impl<D> Dispatch2<xdg_activation_v1::XdgActivationV1, D> for GlobalData
 where
-    D: Dispatch<xdg_activation_v1::XdgActivationV1, GlobalData> + ActivationHandler,
+    D: ActivationHandler,
 {
     fn event(
+        &self,
         _: &mut D,
         _: &xdg_activation_v1::XdgActivationV1,
         _: <xdg_activation_v1::XdgActivationV1 as Proxy>::Event,
-        _: &GlobalData,
         _: &wayland_client::Connection,
         _: &QueueHandle<D>,
     ) {
@@ -112,41 +113,20 @@ impl ProvidesBoundGlobal<xdg_activation_v1::XdgActivationV1, 1> for ActivationSt
     }
 }
 
-impl<D, U> Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData<U>, D>
-    for ActivationState
+impl<D, U> Dispatch2<xdg_activation_token_v1::XdgActivationTokenV1, D> for RequestData<U>
 where
-    D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData<U>>
-        + ActivationHandler<RequestUdata = U>,
+    D: ActivationHandler<RequestUdata = U>,
 {
     fn event(
+        &self,
         state: &mut D,
         _proxy: &xdg_activation_token_v1::XdgActivationTokenV1,
         event: <xdg_activation_token_v1::XdgActivationTokenV1 as Proxy>::Event,
-        data: &RequestData<U>,
         _conn: &wayland_client::Connection,
         _qhandle: &QueueHandle<D>,
     ) {
         if let xdg_activation_token_v1::Event::Done { token } = event {
-            state.new_token(token, data);
+            state.new_token(token, self);
         }
     }
-}
-
-#[macro_export]
-macro_rules! delegate_activation {
-   ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-       $crate::delegate_activation!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty, ());
-   };
-   ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, $data: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_v1::XdgActivationV1: $crate::globals::GlobalData
-            ] => $crate::activation::ActivationState
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_token_v1::XdgActivationTokenV1: $crate::activation::RequestData<$data>
-            ] => $crate::activation::ActivationState
-        );
-    };
 }

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -15,7 +15,7 @@ use crate::{
 /// Use a custom type implementing [`RequestDataExt`] to store more data with a token request
 /// e.g. to identify which request produced which token.
 #[derive(Debug, Clone)]
-pub struct RequestData {
+pub struct RequestData<U> {
     /// App_id of the application requesting the token, if applicable
     pub app_id: Option<String>,
     /// Seat and serial of the window requesting the token, if applicable.
@@ -28,44 +28,17 @@ pub struct RequestData {
     /// *Warning*: Many compositors will issue invalid tokens for requests from
     /// unfocused surfaces. There is no way to detect this from the client-side.
     pub surface: Option<wl_surface::WlSurface>,
-}
 
-/// Data attached to a token request
-pub trait RequestDataExt: Send + Sync {
-    /// App_id of the application requesting the token, if applicable
-    fn app_id(&self) -> Option<&str>;
-    /// Seat and serial of the window requesting the token, if applicable.
-    ///
-    /// *Warning*: Many compositors will issue invalid tokens for requests without
-    /// recent serials. There is no way to detect this from the client-side.
-    fn seat_and_serial(&self) -> Option<(&wl_seat::WlSeat, u32)>;
-    /// Surface of the window requesting the token, if applicable.
-    ///
-    /// *Warning*: Many compositors will issue invalid tokens for requests from
-    /// unfocused surfaces. There is no way to detect this from the client-side.
-    fn surface(&self) -> Option<&wl_surface::WlSurface>;
-}
-
-impl RequestDataExt for RequestData {
-    fn app_id(&self) -> Option<&str> {
-        self.app_id.as_deref()
-    }
-
-    fn seat_and_serial(&self) -> Option<(&wl_seat::WlSeat, u32)> {
-        self.seat_and_serial.as_ref().map(|(seat, serial)| (seat, *serial))
-    }
-
-    fn surface(&self) -> Option<&wl_surface::WlSurface> {
-        self.surface.as_ref()
-    }
+    pub udata: U,
 }
 
 /// Handler for xdg-activation
 pub trait ActivationHandler: Sized {
     /// Data type used for requesting activation tokens
-    type RequestData: RequestDataExt;
+    // TODO: Default to `()` if default associated types are ever supported
+    type RequestUdata;
     /// A token was issued for a previous request with `data`.
-    fn new_token(&mut self, token: String, data: &Self::RequestData);
+    fn new_token(&mut self, token: String, data: &RequestData<Self::RequestUdata>);
 }
 
 /// State for xdg-activation
@@ -96,33 +69,21 @@ impl ActivationState {
     ///
     /// To attach custom data to the request implement [`RequestDataExt`] on a custom type
     /// and use [`Self::request_token_with_data`] instead.
-    pub fn request_token<D>(&self, qh: &QueueHandle<D>, request_data: RequestData)
+    pub fn request_token<D, U>(&self, qh: &QueueHandle<D>, request_data: RequestData<U>)
     where
-        D: ActivationHandler<RequestData = RequestData>,
-        D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData> + 'static,
-    {
-        Self::request_token_with_data::<D, RequestData>(self, qh, request_data)
-    }
-
-    /// Request a token for surface activation with user data.
-    ///
-    /// To use this method you need to provide [`delegate_activation`][crate::delegate_activation] with your custom type.
-    /// E.g. `delegate_activation!(SimpleWindow, MyRequestData);`
-    pub fn request_token_with_data<D, R>(&self, qh: &QueueHandle<D>, request_data: R)
-    where
-        D: ActivationHandler<RequestData = R>,
-        D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, R> + 'static,
-        R: RequestDataExt + 'static,
+        D: ActivationHandler<RequestUdata = U>,
+        D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData<U>> + 'static,
+        U: Send + Sync + 'static,
     {
         let token = self.xdg_activation.get_activation_token(qh, request_data);
-        let data = token.data::<R>().unwrap();
-        if let Some(app_id) = data.app_id() {
+        let data = token.data::<RequestData<U>>().unwrap();
+        if let Some(app_id) = &data.app_id {
             token.set_app_id(String::from(app_id));
         }
-        if let Some((seat, serial)) = data.seat_and_serial() {
-            token.set_serial(serial, seat);
+        if let Some((seat, serial)) = &data.seat_and_serial {
+            token.set_serial(*serial, seat);
         }
-        if let Some(surface) = data.surface() {
+        if let Some(surface) = &data.surface {
             token.set_surface(surface);
         }
         token.commit();
@@ -151,17 +112,17 @@ impl ProvidesBoundGlobal<xdg_activation_v1::XdgActivationV1, 1> for ActivationSt
     }
 }
 
-impl<D, R> Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, R, D> for ActivationState
+impl<D, U> Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData<U>, D>
+    for ActivationState
 where
-    D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, R>
-        + ActivationHandler<RequestData = R>,
-    R: RequestDataExt,
+    D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData<U>>
+        + ActivationHandler<RequestUdata = U>,
 {
     fn event(
         state: &mut D,
         _proxy: &xdg_activation_token_v1::XdgActivationTokenV1,
         event: <xdg_activation_token_v1::XdgActivationTokenV1 as Proxy>::Event,
-        data: &R,
+        data: &RequestData<U>,
         _conn: &wayland_client::Connection,
         _qhandle: &QueueHandle<D>,
     ) {
@@ -174,17 +135,8 @@ where
 #[macro_export]
 macro_rules! delegate_activation {
    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_v1::XdgActivationV1: $crate::globals::GlobalData
-            ] => $crate::activation::ActivationState
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_token_v1::XdgActivationTokenV1: $crate::activation::RequestData
-            ] => $crate::activation::ActivationState
-        );
-    };
+       $crate::delegate_activation!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty, ());
+   };
    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, $data: ty) => {
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
@@ -193,7 +145,7 @@ macro_rules! delegate_activation {
         );
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
-                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_token_v1::XdgActivationTokenV1: $data
+                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_token_v1::XdgActivationTokenV1: $crate::activation::RequestData<$data>
             ] => $crate::activation::ActivationState
         );
     };

--- a/src/background_effect.rs
+++ b/src/background_effect.rs
@@ -5,7 +5,7 @@ use wayland_protocols::ext::background_effect::v1::client::{
     ext_background_effect_manager_v1, ext_background_effect_surface_v1,
 };
 
-use crate::{error::GlobalError, globals::GlobalData, registry::GlobalProxy};
+use crate::{dispatch2::Dispatch2, error::GlobalError, globals::GlobalData, registry::GlobalProxy};
 
 #[derive(Debug)]
 pub struct BackgroundEffectState {
@@ -62,17 +62,15 @@ pub trait BackgroundEffectHandler {
     fn update_capabilities(&mut self);
 }
 
-impl<D> Dispatch<ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1, GlobalData, D>
-    for BackgroundEffectState
+impl<D> Dispatch2<ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1, D> for GlobalData
 where
-    D: Dispatch<ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1, GlobalData>
-        + BackgroundEffectHandler,
+    D: BackgroundEffectHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         _manager: &ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1,
         event: ext_background_effect_manager_v1::Event,
-        _: &GlobalData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
@@ -92,31 +90,17 @@ where
     }
 }
 
-impl<D> Dispatch<ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1, GlobalData, D>
-    for BackgroundEffectState
-where
-    D: Dispatch<ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1, GlobalData>,
+impl<D> Dispatch2<ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1, D>
+    for GlobalData
 {
     fn event(
+        &self,
         _data: &mut D,
         _surface: &ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1,
         _event: ext_background_effect_surface_v1::Event,
-        _: &GlobalData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
         unreachable!()
     }
-}
-
-#[macro_export]
-macro_rules! delegate_background_effect {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::ext::background_effect::v1::client::ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1: $crate::globals::GlobalData
-        ] => $crate::background_effect::BackgroundEffectState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::ext::background_effect::v1::client::ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1: $crate::globals::GlobalData
-        ] => $crate::background_effect::BackgroundEffectState);
-    };
 }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -77,16 +77,6 @@ pub trait CompositorHandler: Sized {
     );
 }
 
-pub trait SurfaceDataExt: Send + Sync {
-    fn surface_data(&self) -> &SurfaceData;
-}
-
-impl SurfaceDataExt for SurfaceData {
-    fn surface_data(&self) -> &SurfaceData {
-        self
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct CompositorState {
     wl_compositor: wl_compositor::WlCompositor,
@@ -116,27 +106,30 @@ impl CompositorState {
 
     pub fn create_surface<D>(&self, qh: &QueueHandle<D>) -> wl_surface::WlSurface
     where
-        D: Dispatch<wl_surface::WlSurface, SurfaceData> + 'static,
+        D: Dispatch<wl_surface::WlSurface, SurfaceData<()>> + 'static,
     {
-        self.create_surface_with_data(qh, Default::default())
+        self.create_surface_with_data(qh, None, 1, ())
     }
 
     pub fn create_surface_with_data<D, U>(
         &self,
         qh: &QueueHandle<D>,
+        parent_surface: Option<WlSurface>,
+        scale_factor: i32,
         data: U,
     ) -> wl_surface::WlSurface
     where
-        D: Dispatch<wl_surface::WlSurface, U> + 'static,
-        U: SurfaceDataExt + 'static,
+        D: Dispatch<wl_surface::WlSurface, SurfaceData<U>> + 'static,
+        U: Send + Sync + 'static,
     {
+        let data = SurfaceData::new(parent_surface, scale_factor, data);
         self.wl_compositor.create_surface(qh, data)
     }
 }
 
 /// Data associated with a [`WlSurface`].
 #[derive(Debug)]
-pub struct SurfaceData {
+pub struct SurfaceData<U> {
     /// The scale factor of the output with the highest scale factor.
     pub(crate) scale_factor: AtomicI32,
 
@@ -147,16 +140,27 @@ pub struct SurfaceData {
 
     /// The inner mutable storage.
     inner: Mutex<SurfaceDataInner>,
+
+    udata: U,
 }
 
-impl SurfaceData {
+impl<U> SurfaceData<U> {
     /// Create a new surface that initially reports the given scale factor and parent.
-    pub fn new(parent_surface: Option<WlSurface>, scale_factor: i32) -> Self {
+    pub fn new(parent_surface: Option<WlSurface>, scale_factor: i32, udata: U) -> Self {
         Self {
             scale_factor: AtomicI32::new(scale_factor),
             parent_surface,
             inner: Default::default(),
+            udata,
         }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 
     /// The scale factor of the output with the highest scale factor.
@@ -183,11 +187,13 @@ impl SurfaceData {
     }
 }
 
+/* XXX
 impl Default for SurfaceData {
     fn default() -> Self {
         Self::new(None, 1)
     }
 }
+*/
 
 #[derive(Debug)]
 struct SurfaceDataInner {
@@ -222,9 +228,9 @@ impl Surface {
         qh: &QueueHandle<D>,
     ) -> Result<Self, GlobalError>
     where
-        D: Dispatch<wl_surface::WlSurface, SurfaceData> + 'static,
+        D: Dispatch<wl_surface::WlSurface, SurfaceData<()>> + 'static,
     {
-        Self::with_data(compositor, qh, Default::default())
+        Self::with_data(compositor, qh, None, 1, ())
     }
 
     pub fn with_data<D, U>(
@@ -233,12 +239,15 @@ impl Surface {
             { CompositorState::API_VERSION_MAX },
         >,
         qh: &QueueHandle<D>,
+        parent_surface: Option<WlSurface>,
+        scale_factor: i32,
         data: U,
     ) -> Result<Self, GlobalError>
     where
-        D: Dispatch<wl_surface::WlSurface, U> + 'static,
+        D: Dispatch<wl_surface::WlSurface, SurfaceData<U>> + 'static,
         U: Send + Sync + 'static,
     {
+        let data = SurfaceData::new(parent_surface, scale_factor, data);
         Ok(Surface(compositor.bound_global()?.create_surface(qh, data)))
     }
 
@@ -262,53 +271,40 @@ impl Drop for Surface {
 #[macro_export]
 macro_rules! delegate_compositor {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::delegate_compositor!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; surface: []);
-        $crate::delegate_compositor!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; surface-only: $crate::compositor::SurfaceData);
-    };
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, surface: [$($surface: ty),*$(,)?]) => {
-        $crate::delegate_compositor!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; surface: [ $($surface),* ]);
-    };
-    (@{$($ty:tt)*}; surface: []) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
                 $crate::reexports::client::protocol::wl_compositor::WlCompositor: $crate::globals::GlobalData
             ] => $crate::compositor::CompositorState
         );
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
                 $crate::reexports::client::protocol::wl_callback::WlCallback: $crate::reexports::client::protocol::wl_surface::WlSurface
             ] => $crate::compositor::CompositorState
         );
-    };
-    (@{$($ty:tt)*}; surface-only: $surface:ty) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U: Send + Sync + 'static > $ty:
             [
-                    $crate::reexports::client::protocol::wl_surface::WlSurface: $surface
+                $crate::reexports::client::protocol::wl_surface::WlSurface: $crate::compositor::SurfaceData<U>
             ] => $crate::compositor::CompositorState
         );
     };
-    (@$ty:tt; surface: [ $($surface:ty),+ ]) => {
-        $crate::delegate_compositor!(@$ty; surface: []);
-        $(
-            $crate::delegate_compositor!(@$ty; surface-only: $surface);
-        )*
-    };
 }
 
-impl<D, U> Dispatch<wl_surface::WlSurface, U, D> for CompositorState
+impl<D, U> Dispatch<wl_surface::WlSurface, SurfaceData<U>, D> for CompositorState
 where
-    D: Dispatch<wl_surface::WlSurface, U> + CompositorHandler + OutputHandler + 'static,
-    U: SurfaceDataExt + 'static,
+    D: Dispatch<wl_surface::WlSurface, SurfaceData<U>>
+        + CompositorHandler
+        + OutputHandler
+        + 'static,
+    U: Send + Sync + 'static,
 {
     fn event(
         state: &mut D,
         surface: &wl_surface::WlSurface,
         event: wl_surface::Event,
-        data: &U,
+        data: &SurfaceData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let data = data.surface_data();
         let mut inner = data.inner.lock().unwrap();
 
         let mut enter_or_leave_output: Option<(wl_output::WlOutput, bool)> = None;
@@ -365,8 +361,7 @@ where
             OutputState::add_scale_watcher(state, move |state, conn, qh, _| {
                 let id = id.clone();
                 if let Ok(surface) = wl_surface::WlSurface::from_id(conn, id) {
-                    if let Some(data) = surface.data::<U>() {
-                        let data = data.surface_data();
+                    if let Some(data) = surface.data::<SurfaceData<U>>() {
                         let inner = data.inner.lock().unwrap();
                         dispatch_surface_state_updates(state, conn, qh, &surface, data, inner);
                     }
@@ -389,11 +384,13 @@ fn dispatch_surface_state_updates<D, U>(
     conn: &Connection,
     qh: &QueueHandle<D>,
     surface: &WlSurface,
-    data: &SurfaceData,
+    data: &SurfaceData<U>,
     mut inner: MutexGuard<SurfaceDataInner>,
 ) where
-    D: Dispatch<wl_surface::WlSurface, U> + CompositorHandler + OutputHandler + 'static,
-    U: SurfaceDataExt + 'static,
+    D: Dispatch<wl_surface::WlSurface, SurfaceData<U>>
+        + CompositorHandler
+        + OutputHandler
+        + 'static,
 {
     let current_scale = data.scale_factor.load(Ordering::Relaxed);
     let (factor, transform) = match inner

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -16,6 +16,7 @@ use wayland_client::{
 };
 
 use crate::{
+    dispatch2::Dispatch2,
     error::GlobalError,
     globals::{GlobalData, ProvidesBoundGlobal},
     output::{OutputData, OutputHandler, OutputState, ScaleWatcherHandle},
@@ -268,44 +269,20 @@ impl Drop for Surface {
     }
 }
 
-#[macro_export]
-macro_rules! delegate_compositor {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::client::protocol::wl_compositor::WlCompositor: $crate::globals::GlobalData
-            ] => $crate::compositor::CompositorState
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::client::protocol::wl_callback::WlCallback: $crate::reexports::client::protocol::wl_surface::WlSurface
-            ] => $crate::compositor::CompositorState
-        );
-        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U: Send + Sync + 'static > $ty:
-            [
-                $crate::reexports::client::protocol::wl_surface::WlSurface: $crate::compositor::SurfaceData<U>
-            ] => $crate::compositor::CompositorState
-        );
-    };
-}
-
-impl<D, U> Dispatch<wl_surface::WlSurface, SurfaceData<U>, D> for CompositorState
+impl<D, U> Dispatch2<wl_surface::WlSurface, D> for SurfaceData<U>
 where
-    D: Dispatch<wl_surface::WlSurface, SurfaceData<U>>
-        + CompositorHandler
-        + OutputHandler
-        + 'static,
+    D: CompositorHandler + OutputHandler + 'static,
     U: Send + Sync + 'static,
 {
     fn event(
+        &self,
         state: &mut D,
         surface: &wl_surface::WlSurface,
         event: wl_surface::Event,
-        data: &SurfaceData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let mut inner = data.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap();
 
         let mut enter_or_leave_output: Option<(wl_output::WlOutput, bool)> = None;
 
@@ -319,9 +296,9 @@ where
                 enter_or_leave_output.replace((output, false));
             }
             wl_surface::Event::PreferredBufferScale { factor } => {
-                let current_scale = data.scale_factor.load(Ordering::Relaxed);
+                let current_scale = self.scale_factor.load(Ordering::Relaxed);
                 drop(inner);
-                data.scale_factor.store(factor, Ordering::Relaxed);
+                self.scale_factor.store(factor, Ordering::Relaxed);
                 if current_scale != factor {
                     state.scale_factor_changed(conn, qh, surface, factor);
                 }
@@ -369,7 +346,7 @@ where
             })
         });
 
-        dispatch_surface_state_updates(state, conn, qh, surface, data, inner);
+        dispatch_surface_state_updates(state, conn, qh, surface, self, inner);
 
         match enter_or_leave_output {
             Some((output, true)) => state.surface_enter(conn, qh, surface, &output),
@@ -387,10 +364,7 @@ fn dispatch_surface_state_updates<D, U>(
     data: &SurfaceData<U>,
     mut inner: MutexGuard<SurfaceDataInner>,
 ) where
-    D: Dispatch<wl_surface::WlSurface, SurfaceData<U>>
-        + CompositorHandler
-        + OutputHandler
-        + 'static,
+    D: CompositorHandler + OutputHandler + 'static,
 {
     let current_scale = data.scale_factor.load(Ordering::Relaxed);
     let (factor, transform) = match inner
@@ -478,15 +452,15 @@ impl wayland_client::backend::ObjectData for RegionData {
     fn destroyed(&self, _: wayland_client::backend::ObjectId) {}
 }
 
-impl<D> Dispatch<wl_compositor::WlCompositor, GlobalData, D> for CompositorState
+impl<D> Dispatch2<wl_compositor::WlCompositor, D> for GlobalData
 where
-    D: Dispatch<wl_compositor::WlCompositor, GlobalData> + CompositorHandler,
+    D: CompositorHandler,
 {
     fn event(
+        &self,
         _: &mut D,
         _: &wl_compositor::WlCompositor,
         _: wl_compositor::Event,
-        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
@@ -502,21 +476,24 @@ impl ProvidesBoundGlobal<wl_compositor::WlCompositor, { CompositorState::API_VER
     }
 }
 
-impl<D> Dispatch<wl_callback::WlCallback, wl_surface::WlSurface, D> for CompositorState
+#[derive(Debug)]
+pub struct FrameCallbackData(pub wl_surface::WlSurface);
+
+impl<D> Dispatch2<wl_callback::WlCallback, D> for FrameCallbackData
 where
-    D: Dispatch<wl_callback::WlCallback, wl_surface::WlSurface> + CompositorHandler,
+    D: CompositorHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         _: &wl_callback::WlCallback,
         event: wl_callback::Event,
-        surface: &wl_surface::WlSurface,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
         match event {
             wl_callback::Event::Done { callback_data } => {
-                state.frame(conn, qh, surface, callback_data);
+                state.frame(conn, qh, &self.0, callback_data);
             }
 
             _ => unreachable!(),

--- a/src/data_device_manager/data_device.rs
+++ b/src/data_device_manager/data_device.rs
@@ -7,6 +7,7 @@ use wayland_client::protocol::wl_surface::WlSurface;
 
 use crate::{
     data_device_manager::data_offer::DataDeviceOffer,
+    dispatch2::Dispatch2,
     reexports::client::{
         event_created_child,
         protocol::{
@@ -18,10 +19,7 @@ use crate::{
     },
 };
 
-use super::{
-    data_offer::{DataOfferData, DataOfferHandler, DragOffer, SelectionOffer},
-    DataDeviceManagerState,
-};
+use super::data_offer::{DataOfferData, DataOfferHandler, DragOffer, SelectionOffer};
 
 /// Handler trait for DataDevice events.
 ///
@@ -105,10 +103,9 @@ impl Drop for DataDevice {
     }
 }
 
-impl<D> Dispatch<wl_data_device::WlDataDevice, DataDeviceData, D> for DataDeviceManagerState
+impl<D> Dispatch2<wl_data_device::WlDataDevice, D> for DataDeviceData
 where
-    D: Dispatch<wl_data_device::WlDataDevice, DataDeviceData>
-        + Dispatch<wl_data_offer::WlDataOffer, DataOfferData>
+    D: Dispatch<wl_data_offer::WlDataOffer, DataOfferData>
         + DataDeviceHandler
         + DataOfferHandler
         + 'static,
@@ -118,15 +115,15 @@ where
     ]);
 
     fn event(
+        &self,
         state: &mut D,
         data_device: &wl_data_device::WlDataDevice,
         event: wl_data_device::Event,
-        data: &DataDeviceData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
         use wayland_client::protocol::wl_data_device::Event;
-        let mut inner = data.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap();
 
         match event {
             Event::DataOffer { id } => {

--- a/src/data_device_manager/data_offer.rs
+++ b/src/data_device_manager/data_offer.rs
@@ -6,16 +6,17 @@ use std::{
 
 use log::warn;
 
+use crate::dispatch2::Dispatch2;
 use crate::reexports::client::{
     protocol::{
         wl_data_device_manager::DndAction,
         wl_data_offer::{self, WlDataOffer},
         wl_surface::WlSurface,
     },
-    Connection, Dispatch, Proxy, QueueHandle,
+    Connection, Proxy, QueueHandle,
 };
 
-use super::{DataDeviceManagerState, ReadPipe};
+use super::ReadPipe;
 
 /// Handler trait for DataOffer events.
 ///
@@ -359,27 +360,27 @@ impl Default for DataDeviceOffer {
     }
 }
 
-impl<D> Dispatch<wl_data_offer::WlDataOffer, DataOfferData, D> for DataDeviceManagerState
+impl<D> Dispatch2<wl_data_offer::WlDataOffer, D> for DataOfferData
 where
-    D: Dispatch<wl_data_offer::WlDataOffer, DataOfferData> + DataOfferHandler,
+    D: DataOfferHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         _offer: &wl_data_offer::WlDataOffer,
         event: <wl_data_offer::WlDataOffer as wayland_client::Proxy>::Event,
-        data: &DataOfferData,
         conn: &wayland_client::Connection,
         qh: &wayland_client::QueueHandle<D>,
     ) {
         match event {
             wl_data_offer::Event::Offer { mime_type } => {
-                data.push_mime_type(mime_type);
+                self.push_mime_type(mime_type);
             }
             wl_data_offer::Event::SourceActions { source_actions } => {
                 match source_actions {
                     wayland_client::WEnum::Value(a) => {
-                        data.set_source_action(a);
-                        match &mut data.inner.lock().unwrap().offer {
+                        self.set_source_action(a);
+                        match &mut self.inner.lock().unwrap().offer {
                             DataDeviceOffer::Drag(o) => {
                                 state.source_actions(conn, qh, o, a);
                             }
@@ -393,8 +394,8 @@ where
             wl_data_offer::Event::Action { dnd_action } => {
                 match dnd_action {
                     wayland_client::WEnum::Value(a) => {
-                        data.set_selected_action(a);
-                        match &mut data.inner.lock().unwrap().offer {
+                        self.set_selected_action(a);
+                        match &mut self.inner.lock().unwrap().offer {
                             DataDeviceOffer::Drag(o) => {
                                 state.selected_action(conn, qh, o, a);
                             }

--- a/src/data_device_manager/data_source.rs
+++ b/src/data_device_manager/data_source.rs
@@ -10,15 +10,21 @@ use crate::reexports::client::{
 use super::{data_device::DataDevice, DataDeviceManagerState, WritePipe};
 
 #[derive(Debug, Default)]
-pub struct DataSourceData {}
-
-pub trait DataSourceDataExt: Send + Sync {
-    fn data_source_data(&self) -> &DataSourceData;
+pub struct DataSourceData<U> {
+    udata: U,
 }
 
-impl DataSourceDataExt for DataSourceData {
-    fn data_source_data(&self) -> &DataSourceData {
-        self
+impl<U> DataSourceData<U> {
+    pub fn new(udata: U) -> Self {
+        Self { udata }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 }
 
@@ -68,16 +74,15 @@ pub trait DataSourceHandler: Sized {
     );
 }
 
-impl<D, U> Dispatch<wl_data_source::WlDataSource, U, D> for DataDeviceManagerState
+impl<D, U> Dispatch<wl_data_source::WlDataSource, DataSourceData<U>, D> for DataDeviceManagerState
 where
-    D: Dispatch<wl_data_source::WlDataSource, U> + DataSourceHandler,
-    U: DataSourceDataExt,
+    D: Dispatch<wl_data_source::WlDataSource, DataSourceData<U>> + DataSourceHandler,
 {
     fn event(
         state: &mut D,
         source: &wl_data_source::WlDataSource,
         event: <wl_data_source::WlDataSource as wayland_client::Proxy>::Event,
-        _data: &U,
+        _data: &DataSourceData<U>,
         conn: &wayland_client::Connection,
         qh: &wayland_client::QueueHandle<D>,
     ) {

--- a/src/data_device_manager/data_source.rs
+++ b/src/data_device_manager/data_source.rs
@@ -1,13 +1,14 @@
+use crate::dispatch2::Dispatch2;
 use crate::reexports::client::{
     protocol::{
         wl_data_device_manager::DndAction,
         wl_data_source::{self, WlDataSource},
         wl_surface::WlSurface,
     },
-    Connection, Dispatch, Proxy, QueueHandle, WEnum,
+    Connection, Proxy, QueueHandle, WEnum,
 };
 
-use super::{data_device::DataDevice, DataDeviceManagerState, WritePipe};
+use super::{data_device::DataDevice, WritePipe};
 
 #[derive(Debug, Default)]
 pub struct DataSourceData<U> {
@@ -74,15 +75,15 @@ pub trait DataSourceHandler: Sized {
     );
 }
 
-impl<D, U> Dispatch<wl_data_source::WlDataSource, DataSourceData<U>, D> for DataDeviceManagerState
+impl<D, U> Dispatch2<wl_data_source::WlDataSource, D> for DataSourceData<U>
 where
-    D: Dispatch<wl_data_source::WlDataSource, DataSourceData<U>> + DataSourceHandler,
+    D: DataSourceHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         source: &wl_data_source::WlDataSource,
         event: <wl_data_source::WlDataSource as wayland_client::Proxy>::Event,
-        _data: &DataSourceData<U>,
         conn: &wayland_client::Connection,
         qh: &wayland_client::QueueHandle<D>,
     ) {

--- a/src/data_device_manager/mod.rs
+++ b/src/data_device_manager/mod.rs
@@ -1,3 +1,4 @@
+use crate::dispatch2::Dispatch2;
 use crate::error::GlobalError;
 use crate::globals::{GlobalData, ProvidesBoundGlobal};
 use crate::reexports::client::{
@@ -107,43 +108,15 @@ impl ProvidesBoundGlobal<WlDataDeviceManager, 3> for DataDeviceManagerState {
     }
 }
 
-impl<D> Dispatch<wl_data_device_manager::WlDataDeviceManager, GlobalData, D>
-    for DataDeviceManagerState
-where
-    D: Dispatch<wl_data_device_manager::WlDataDeviceManager, GlobalData>,
-{
+impl<D> Dispatch2<wl_data_device_manager::WlDataDeviceManager, D> for GlobalData {
     fn event(
+        &self,
         _state: &mut D,
         _proxy: &wl_data_device_manager::WlDataDeviceManager,
         _event: <wl_data_device_manager::WlDataDeviceManager as wayland_client::Proxy>::Event,
-        _data: &GlobalData,
         _conn: &Connection,
         _qhandle: &QueueHandle<D>,
     ) {
         unreachable!("wl_data_device_manager has no events")
     }
-}
-
-#[macro_export]
-macro_rules! delegate_data_device {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::client::protocol::wl_data_device_manager::WlDataDeviceManager: $crate::globals::GlobalData
-            ] => $crate::data_device_manager::DataDeviceManagerState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::client::protocol::wl_data_offer::WlDataOffer: $crate::data_device_manager::data_offer::DataOfferData
-            ] => $crate::data_device_manager::DataDeviceManagerState);
-        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty:
-            [
-                $crate::reexports::client::protocol::wl_data_source::WlDataSource: $crate::data_device_manager::data_source::DataSourceData<U>
-            ] => $crate::data_device_manager::DataDeviceManagerState
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::client::protocol::wl_data_device::WlDataDevice: $crate::data_device_manager::data_device::DataDeviceData
-            ] => $crate::data_device_manager::DataDeviceManagerState
-        );
-    };
 }

--- a/src/data_device_manager/mod.rs
+++ b/src/data_device_manager/mod.rs
@@ -48,7 +48,7 @@ impl DataDeviceManagerState {
         mime_types: impl IntoIterator<Item = T>,
     ) -> CopyPasteSource
     where
-        D: Dispatch<WlDataSource, DataSourceData> + 'static,
+        D: Dispatch<WlDataSource, DataSourceData<()>> + 'static,
     {
         CopyPasteSource { inner: self.create_data_source(qh, mime_types, None) }
     }
@@ -61,7 +61,7 @@ impl DataDeviceManagerState {
         dnd_actions: DndAction,
     ) -> DragSource
     where
-        D: Dispatch<WlDataSource, DataSourceData> + 'static,
+        D: Dispatch<WlDataSource, DataSourceData<()>> + 'static,
     {
         DragSource { inner: self.create_data_source(qh, mime_types, Some(dnd_actions)) }
     }
@@ -74,7 +74,7 @@ impl DataDeviceManagerState {
         dnd_actions: Option<DndAction>,
     ) -> WlDataSource
     where
-        D: Dispatch<WlDataSource, DataSourceData> + 'static,
+        D: Dispatch<WlDataSource, DataSourceData<()>> + 'static,
     {
         let source = self.manager.create_data_source(qh, Default::default());
 
@@ -135,9 +135,9 @@ macro_rules! delegate_data_device {
             [
                 $crate::reexports::client::protocol::wl_data_offer::WlDataOffer: $crate::data_device_manager::data_offer::DataOfferData
             ] => $crate::data_device_manager::DataDeviceManagerState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty:
             [
-                $crate::reexports::client::protocol::wl_data_source::WlDataSource: $crate::data_device_manager::data_source::DataSourceData
+                $crate::reexports::client::protocol::wl_data_source::WlDataSource: $crate::data_device_manager::data_source::DataSourceData<U>
             ] => $crate::data_device_manager::DataDeviceManagerState
         );
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:

--- a/src/dispatch2.rs
+++ b/src/dispatch2.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+use wayland_client::backend::ObjectData;
+use wayland_client::{Connection, Proxy, QueueHandle};
+
+pub trait Dispatch2<I: Proxy, State> {
+    fn event(
+        &self,
+        _: &mut State,
+        _: &I,
+        _: <I as Proxy>::Event,
+        _: &Connection,
+        _: &QueueHandle<State>,
+    );
+
+    fn event_created_child(opcode: u16, _qh: &QueueHandle<State>) -> Arc<dyn ObjectData> {
+        panic!(
+            "Missing event_created_child specialization for event opcode {} of {}",
+            opcode,
+            I::interface().name
+        );
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_dispatch2 {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        impl<$( $( $lt $( : $clt $(+ $dlt )* )? ),+, )? I, UserData> $crate::reexports::client::Dispatch<I, UserData> for $ty
+        where
+            I: $crate::reexports::client::Proxy,
+            UserData: $crate::dispatch2::Dispatch2<I, $ty> {
+            fn event(
+                state: &mut $ty,
+                proxy: &I,
+                event: <I as $crate::reexports::client::Proxy>::Event,
+                data: &UserData,
+                conn: &$crate::reexports::client::Connection,
+                qh: &$crate::reexports::client::QueueHandle<$ty>,
+            ) {
+                data.event(state, proxy, event, conn, qh);
+            }
+
+            fn event_created_child(opcode: u16, qh: &$crate::reexports::client::QueueHandle<$ty>) -> ::std::sync::Arc<dyn $crate::reexports::client::backend::ObjectData> {
+                UserData::event_created_child(opcode, qh)
+            }
+        }
+    };
+}

--- a/src/dmabuf.rs
+++ b/src/dmabuf.rs
@@ -1,4 +1,4 @@
-use crate::{error::GlobalError, globals::GlobalData, registry::GlobalProxy};
+use crate::{dispatch2::Dispatch2, error::GlobalError, globals::GlobalData, registry::GlobalProxy};
 use memmap2::{Mmap, MmapOptions};
 use std::{fmt, mem, os::unix::io::BorrowedFd, slice, sync::Mutex};
 use wayland_client::{
@@ -275,15 +275,15 @@ impl DmabufParams {
     }
 }
 
-impl<D> Dispatch<zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, GlobalData, D> for DmabufState
+impl<D> Dispatch2<zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, D> for GlobalData
 where
-    D: Dispatch<zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1, GlobalData> + DmabufHandler,
+    D: DmabufHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         proxy: &zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1,
         event: zwp_linux_dmabuf_v1::Event,
-        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
@@ -307,23 +307,21 @@ where
     }
 }
 
-impl<D> Dispatch<zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1, DmabufFeedbackData, D>
-    for DmabufState
+impl<D> Dispatch2<zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1, D> for DmabufFeedbackData
 where
-    D: Dispatch<zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1, DmabufFeedbackData>
-        + DmabufHandler,
+    D: DmabufHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         proxy: &zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1,
         event: zwp_linux_dmabuf_feedback_v1::Event,
-        data: &DmabufFeedbackData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
         match event {
             zwp_linux_dmabuf_feedback_v1::Event::Done => {
-                let feedback = mem::take(&mut *data.pending.lock().unwrap());
+                let feedback = mem::take(&mut *self.pending.lock().unwrap());
                 state.dmabuf_feedback(conn, qh, proxy, feedback);
             }
             zwp_linux_dmabuf_feedback_v1::Event::FormatTable { fd, size } => {
@@ -335,46 +333,43 @@ where
                 let entry_size = mem::size_of::<DmabufFormat>();
                 assert!((size % entry_size) == 0);
                 let len = size / entry_size;
-                data.pending.lock().unwrap().format_table = Some((mmap, len));
+                self.pending.lock().unwrap().format_table = Some((mmap, len));
             }
             zwp_linux_dmabuf_feedback_v1::Event::MainDevice { device } => {
                 let device = dev_t::from_ne_bytes(device.try_into().unwrap());
-                data.pending.lock().unwrap().main_device = device;
+                self.pending.lock().unwrap().main_device = device;
             }
             zwp_linux_dmabuf_feedback_v1::Event::TrancheDone => {
-                let tranche = mem::take(&mut *data.pending_tranche.lock().unwrap());
-                data.pending.lock().unwrap().tranches.push(tranche);
+                let tranche = mem::take(&mut *self.pending_tranche.lock().unwrap());
+                self.pending.lock().unwrap().tranches.push(tranche);
             }
             zwp_linux_dmabuf_feedback_v1::Event::TrancheTargetDevice { device } => {
                 let device = dev_t::from_ne_bytes(device.try_into().unwrap());
-                data.pending_tranche.lock().unwrap().device = device;
+                self.pending_tranche.lock().unwrap().device = device;
             }
             zwp_linux_dmabuf_feedback_v1::Event::TrancheFormats { indices } => {
                 assert!((indices.len() % 2) == 0);
                 let indices =
                     indices.chunks(2).map(|i| u16::from_ne_bytes([i[0], i[1]])).collect::<Vec<_>>();
-                data.pending_tranche.lock().unwrap().formats = indices;
+                self.pending_tranche.lock().unwrap().formats = indices;
             }
             zwp_linux_dmabuf_feedback_v1::Event::TrancheFlags { flags } => {
-                data.pending_tranche.lock().unwrap().flags = flags;
+                self.pending_tranche.lock().unwrap().flags = flags;
             }
             _ => unreachable!(),
         }
     }
 }
 
-impl<D> Dispatch<zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1, GlobalData, D> for DmabufState
+impl<D> Dispatch2<zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1, D> for GlobalData
 where
-    D: Dispatch<zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1, GlobalData>
-        + Dispatch<wl_buffer::WlBuffer, DmaBufferData>
-        + DmabufHandler
-        + 'static,
+    D: Dispatch<wl_buffer::WlBuffer, DmaBufferData> + DmabufHandler + 'static,
 {
     fn event(
+        &self,
         state: &mut D,
         proxy: &zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1,
         event: zwp_linux_buffer_params_v1::Event,
-        _: &GlobalData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -394,15 +389,15 @@ where
     ]);
 }
 
-impl<D> Dispatch<wl_buffer::WlBuffer, DmaBufferData, D> for DmabufState
+impl<D> Dispatch2<wl_buffer::WlBuffer, D> for DmaBufferData
 where
-    D: Dispatch<wl_buffer::WlBuffer, DmaBufferData> + DmabufHandler,
+    D: DmabufHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         proxy: &wl_buffer::WlBuffer,
         event: wl_buffer::Event,
-        _: &DmaBufferData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -411,30 +406,4 @@ where
             _ => unreachable!(),
         }
     }
-}
-
-#[macro_export]
-macro_rules! delegate_dmabuf {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::wp::linux_dmabuf::zv1::client::zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1: $crate::globals::GlobalData
-            ] => $crate::dmabuf::DmabufState
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::wp::linux_dmabuf::zv1::client::zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1: $crate::globals::GlobalData
-            ] => $crate::dmabuf::DmabufState
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::wp::linux_dmabuf::zv1::client::zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1: $crate::dmabuf::DmabufFeedbackData
-            ] => $crate::dmabuf::DmabufState
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::client::protocol::wl_buffer::WlBuffer: $crate::dmabuf::DmaBufferData
-            ] => $crate::dmabuf::DmabufState
-        );
-    };
 }

--- a/src/foreign_toplevel_list.rs
+++ b/src/foreign_toplevel_list.rs
@@ -1,4 +1,4 @@
-use crate::{globals::GlobalData, registry::GlobalProxy};
+use crate::{dispatch2::Dispatch2, globals::GlobalData, registry::GlobalProxy};
 use std::sync::{Arc, Mutex};
 use wayland_client::{globals::GlobalList, Connection, Dispatch, Proxy, QueueHandle};
 use wayland_protocols::ext::foreign_toplevel_list::v1::client::{
@@ -96,19 +96,17 @@ pub trait ForeignToplevelListHandler: Sized {
     fn finished(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>) {}
 }
 
-impl<D> Dispatch<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, GlobalData, D>
-    for ForeignToplevelList
+impl<D> Dispatch2<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, D> for GlobalData
 where
-    D: Dispatch<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, GlobalData>
-        + Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ForeignToplevelData>
+    D: Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ForeignToplevelData>
         + ForeignToplevelListHandler
         + 'static,
 {
     fn event(
+        &self,
         state: &mut D,
         proxy: &ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
         event: ext_foreign_toplevel_list_v1::Event,
-        _: &GlobalData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -127,17 +125,16 @@ where
     ]);
 }
 
-impl<D> Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ForeignToplevelData, D>
-    for ForeignToplevelList
+impl<D> Dispatch2<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, D>
+    for ForeignToplevelData
 where
-    D: Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ForeignToplevelData>
-        + ForeignToplevelListHandler,
+    D: ForeignToplevelListHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         handle: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
         event: ext_foreign_toplevel_handle_v1::Event,
-        data: &ForeignToplevelData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -151,7 +148,7 @@ where
                 handle.destroy();
             }
             ext_foreign_toplevel_handle_v1::Event::Done => {
-                let mut inner = data.0.lock().unwrap();
+                let mut inner = self.0.lock().unwrap();
                 let just_created = inner.current_info.is_none();
                 inner.current_info = Some(inner.pending_info.clone());
                 drop(inner);
@@ -163,31 +160,15 @@ where
                 }
             }
             ext_foreign_toplevel_handle_v1::Event::Title { title } => {
-                data.0.lock().unwrap().pending_info.title = title;
+                self.0.lock().unwrap().pending_info.title = title;
             }
             ext_foreign_toplevel_handle_v1::Event::AppId { app_id } => {
-                data.0.lock().unwrap().pending_info.app_id = app_id;
+                self.0.lock().unwrap().pending_info.app_id = app_id;
             }
             ext_foreign_toplevel_handle_v1::Event::Identifier { identifier } => {
-                data.0.lock().unwrap().pending_info.identifier = identifier;
+                self.0.lock().unwrap().pending_info.identifier = identifier;
             }
             _ => unreachable!(),
         }
     }
-}
-
-#[macro_export]
-macro_rules! delegate_foreign_toplevel_list {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1: $crate::globals::GlobalData
-            ] => $crate::foreign_toplevel_list::ForeignToplevelList
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1: $crate::foreign_toplevel_list::ForeignToplevelData
-            ] => $crate::foreign_toplevel_list::ForeignToplevelList
-        );
-    };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod activation;
 pub mod background_effect;
 pub mod compositor;
 pub mod data_device_manager;
+pub mod dispatch2;
 pub mod dmabuf;
 pub mod error;
 pub mod foreign_toplevel_list;

--- a/src/output.rs
+++ b/src/output.rs
@@ -16,6 +16,7 @@ use wayland_protocols::xdg::xdg_output::zv1::client::{
 };
 
 use crate::{
+    dispatch2::Dispatch2,
     globals::GlobalData,
     registry::{GlobalProxy, ProvidesRegistryState, RegistryHandler},
 };
@@ -68,7 +69,7 @@ type ScaleWatcherFn =
 /// use smithay_client_toolkit::output::{OutputHandler,OutputState};
 /// use smithay_client_toolkit::registry::{ProvidesRegistryState,RegistryHandler};
 /// # use smithay_client_toolkit::registry::RegistryState;
-/// use smithay_client_toolkit::{registry_handlers,delegate_output, delegate_registry};
+/// use smithay_client_toolkit::{registry_handlers, delegate_registry};
 /// use wayland_client::{Connection,QueueHandle,protocol::wl_output};
 ///
 /// struct ExampleState {
@@ -96,7 +97,7 @@ type ScaleWatcherFn =
 ///
 /// // Delegating to the registry is required to use `OutputState`.
 /// delegate_registry!(ExampleState);
-/// delegate_output!(ExampleState);
+/// smithay_client_toolkit::delegate_dispatch2!(ExampleState);
 ///
 /// impl ProvidesRegistryState for ExampleState {
 /// #    fn registry(&mut self) -> &mut RegistryState {
@@ -391,30 +392,15 @@ pub struct OutputInfo {
     pub description: Option<String>,
 }
 
-#[macro_export]
-macro_rules! delegate_output {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::client::protocol::wl_output::WlOutput: $crate::output::OutputData
-        ] => $crate::output::OutputState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::xdg::xdg_output::zv1::client::zxdg_output_manager_v1::ZxdgOutputManagerV1: $crate::globals::GlobalData
-        ] => $crate::output::OutputState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::xdg::xdg_output::zv1::client::zxdg_output_v1::ZxdgOutputV1: $crate::output::OutputData
-        ] => $crate::output::OutputState);
-    };
-}
-
-impl<D> Dispatch<wl_output::WlOutput, OutputData, D> for OutputState
+impl<D> Dispatch2<wl_output::WlOutput, D> for OutputData
 where
-    D: Dispatch<wl_output::WlOutput, OutputData> + OutputHandler + 'static,
+    D: OutputHandler + 'static,
 {
     fn event(
+        &self,
         state: &mut D,
         output: &wl_output::WlOutput,
         event: wl_output::Event,
-        data: &OutputData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -519,7 +505,7 @@ where
                 inner.pending_wl = false;
 
                 // Set the user data, see if we need to run scale callbacks
-                let run_callbacks = data.set(info);
+                let run_callbacks = self.set(info);
 
                 // Don't call `new_output` until we have xdg output info
                 if !inner.pending_xdg {
@@ -545,15 +531,15 @@ where
     }
 }
 
-impl<D> Dispatch<zxdg_output_manager_v1::ZxdgOutputManagerV1, GlobalData, D> for OutputState
+impl<D> Dispatch2<zxdg_output_manager_v1::ZxdgOutputManagerV1, D> for GlobalData
 where
-    D: Dispatch<zxdg_output_manager_v1::ZxdgOutputManagerV1, GlobalData> + OutputHandler,
+    D: OutputHandler,
 {
     fn event(
+        &self,
         _: &mut D,
         _: &zxdg_output_manager_v1::ZxdgOutputManagerV1,
         _: zxdg_output_manager_v1::Event,
-        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
@@ -561,15 +547,15 @@ where
     }
 }
 
-impl<D> Dispatch<zxdg_output_v1::ZxdgOutputV1, OutputData, D> for OutputState
+impl<D> Dispatch2<zxdg_output_v1::ZxdgOutputV1, D> for OutputData
 where
-    D: Dispatch<zxdg_output_v1::ZxdgOutputV1, OutputData> + OutputHandler,
+    D: OutputHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         output: &zxdg_output_v1::ZxdgOutputV1,
         event: zxdg_output_v1::Event,
-        data: &OutputData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -631,7 +617,7 @@ where
                     inner.pending_xdg = false;
 
                     // Set the user data
-                    data.set(info);
+                    self.set(info);
 
                     let pending_wl = inner.pending_wl;
                     let just_created = inner.just_created;

--- a/src/presentation_time.rs
+++ b/src/presentation_time.rs
@@ -6,7 +6,7 @@ use wayland_client::{
 };
 use wayland_protocols::wp::presentation_time::client::{wp_presentation, wp_presentation_feedback};
 
-use crate::{error::GlobalError, globals::GlobalData, registry::GlobalProxy};
+use crate::{dispatch2::Dispatch2, error::GlobalError, globals::GlobalData, registry::GlobalProxy};
 
 #[derive(Debug)]
 pub struct PresentTime {
@@ -84,15 +84,15 @@ pub struct PresentationTimeData {
     sync_outputs: Mutex<Vec<wl_output::WlOutput>>,
 }
 
-impl<D> Dispatch<wp_presentation::WpPresentation, GlobalData, D> for PresentationTimeState
+impl<D> Dispatch2<wp_presentation::WpPresentation, D> for GlobalData
 where
-    D: Dispatch<wp_presentation::WpPresentation, GlobalData> + PresentationTimeHandler,
+    D: PresentationTimeHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         _presentation: &wp_presentation::WpPresentation,
         event: wp_presentation::Event,
-        _: &GlobalData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
@@ -105,23 +105,21 @@ where
     }
 }
 
-impl<D> Dispatch<wp_presentation_feedback::WpPresentationFeedback, PresentationTimeData, D>
-    for PresentationTimeState
+impl<D> Dispatch2<wp_presentation_feedback::WpPresentationFeedback, D> for PresentationTimeData
 where
-    D: Dispatch<wp_presentation_feedback::WpPresentationFeedback, PresentationTimeData>
-        + PresentationTimeHandler,
+    D: PresentationTimeHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         feedback: &wp_presentation_feedback::WpPresentationFeedback,
         event: wp_presentation_feedback::Event,
-        udata: &PresentationTimeData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
         match event {
             wp_presentation_feedback::Event::SyncOutput { output } => {
-                udata.sync_outputs.lock().unwrap().push(output);
+                self.sync_outputs.lock().unwrap().push(output);
             }
             wp_presentation_feedback::Event::Presented {
                 tv_sec_hi,
@@ -132,7 +130,7 @@ where
                 seq_lo,
                 flags,
             } => {
-                let sync_outputs = mem::take(&mut *udata.sync_outputs.lock().unwrap());
+                let sync_outputs = mem::take(&mut *self.sync_outputs.lock().unwrap());
                 let clk_id = data.presentation_time_state().clk_id.unwrap(); // XXX unwrap
                 let time = PresentTime {
                     clk_id,
@@ -144,7 +142,7 @@ where
                     conn,
                     qh,
                     feedback,
-                    &udata.wl_surface,
+                    &self.wl_surface,
                     sync_outputs,
                     time,
                     refresh,
@@ -153,21 +151,9 @@ where
                 );
             }
             wp_presentation_feedback::Event::Discarded => {
-                data.discarded(conn, qh, feedback, &udata.wl_surface)
+                data.discarded(conn, qh, feedback, &self.wl_surface)
             }
             _ => {}
         }
     }
-}
-
-#[macro_export]
-macro_rules! delegate_presentation_time {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::wp::presentation_time::client::wp_presentation::WpPresentation: $crate::globals::GlobalData
-        ] => $crate::presentation_time::PresentationTimeState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::wp::presentation_time::client::wp_presentation_feedback::WpPresentationFeedback: $crate::presentation_time::PresentationTimeData
-        ] => $crate::presentation_time::PresentationTimeState);
-    };
 }

--- a/src/primary_selection/device.rs
+++ b/src/primary_selection/device.rs
@@ -8,10 +8,9 @@ use crate::reexports::protocols::wp::primary_selection::zv1::client::{
     zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1,
 };
 
-use super::{
-    offer::{PrimarySelectionOffer, PrimarySelectionOfferData},
-    PrimarySelectionManagerState,
-};
+use crate::dispatch2::Dispatch2;
+
+use super::offer::{PrimarySelectionOffer, PrimarySelectionOfferData};
 
 pub trait PrimarySelectionDeviceHandler: Sized {
     /// The new selection is received.
@@ -54,11 +53,9 @@ impl Drop for PrimarySelectionDevice {
     }
 }
 
-impl<State> Dispatch<ZwpPrimarySelectionDeviceV1, PrimarySelectionDeviceData, State>
-    for PrimarySelectionManagerState
+impl<State> Dispatch2<ZwpPrimarySelectionDeviceV1, State> for PrimarySelectionDeviceData
 where
-    State: Dispatch<ZwpPrimarySelectionDeviceV1, PrimarySelectionDeviceData>
-        + Dispatch<ZwpPrimarySelectionOfferV1, PrimarySelectionOfferData>
+    State: Dispatch<ZwpPrimarySelectionOfferV1, PrimarySelectionOfferData>
         + PrimarySelectionDeviceHandler
         + 'static,
 {
@@ -67,15 +64,15 @@ where
     ]);
 
     fn event(
+        &self,
         state: &mut State,
         proxy: &ZwpPrimarySelectionDeviceV1,
         event: <ZwpPrimarySelectionDeviceV1 as wayland_client::Proxy>::Event,
-        data: &PrimarySelectionDeviceData,
         conn: &Connection,
         qhandle: &QueueHandle<State>,
     ) {
         use wayland_protocols::wp::primary_selection::zv1::client::zwp_primary_selection_device_v1::Event;
-        let mut data = data.inner.lock().unwrap();
+        let mut data = self.inner.lock().unwrap();
         match event {
             Event::DataOffer { offer } => {
                 // Try to resist faulty compositors.

--- a/src/primary_selection/mod.rs
+++ b/src/primary_selection/mod.rs
@@ -1,3 +1,4 @@
+use crate::dispatch2::Dispatch2;
 use crate::globals::GlobalData;
 use crate::reexports::client::{
     globals::{BindError, GlobalList},
@@ -81,40 +82,15 @@ impl Drop for PrimarySelectionManagerState {
     }
 }
 
-impl<D> Dispatch<ZwpPrimarySelectionDeviceManagerV1, GlobalData, D> for PrimarySelectionManagerState
-where
-    D: Dispatch<ZwpPrimarySelectionDeviceManagerV1, GlobalData>,
-{
+impl<D> Dispatch2<ZwpPrimarySelectionDeviceManagerV1, D> for GlobalData {
     fn event(
+        &self,
         _: &mut D,
         _: &ZwpPrimarySelectionDeviceManagerV1,
         _: <ZwpPrimarySelectionDeviceManagerV1 as wayland_client::Proxy>::Event,
-        _: &GlobalData,
         _: &wayland_client::Connection,
         _: &QueueHandle<D>,
     ) {
         unreachable!("zwp_primary_selection_device_manager_v1 has no events")
     }
-}
-
-#[macro_export]
-macro_rules! delegate_primary_selection {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1: $crate::globals::GlobalData
-            ] => $crate::primary_selection::PrimarySelectionManagerState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1: $crate::primary_selection::device::PrimarySelectionDeviceData
-            ] => $crate::primary_selection::PrimarySelectionManagerState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1: $crate::primary_selection::offer::PrimarySelectionOfferData
-            ] => $crate::primary_selection::PrimarySelectionManagerState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1: $crate::globals::GlobalData
-            ] => $crate::primary_selection::PrimarySelectionManagerState);
-    };
 }

--- a/src/primary_selection/offer.rs
+++ b/src/primary_selection/offer.rs
@@ -3,12 +3,11 @@ use std::{
     sync::Mutex,
 };
 
-use crate::reexports::client::{Connection, Dispatch, QueueHandle, Proxy};
+use crate::reexports::client::{Connection, QueueHandle, Proxy};
 use crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1;
 
 use crate::data_device_manager::ReadPipe;
-
-use super::PrimarySelectionManagerState;
+use crate::dispatch2::Dispatch2;
 
 /// Wrapper around the [`ZwpPrimarySelectionOfferV1`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,23 +53,19 @@ impl PrimarySelectionOffer {
     }
 }
 
-impl<State> Dispatch<ZwpPrimarySelectionOfferV1, PrimarySelectionOfferData, State>
-    for PrimarySelectionManagerState
-where
-    State: Dispatch<ZwpPrimarySelectionOfferV1, PrimarySelectionOfferData>,
-{
+impl<State> Dispatch2<ZwpPrimarySelectionOfferV1, State> for PrimarySelectionOfferData {
     fn event(
+        &self,
         _: &mut State,
         _: &ZwpPrimarySelectionOfferV1,
         event: <ZwpPrimarySelectionOfferV1 as wayland_client::Proxy>::Event,
-        data: &PrimarySelectionOfferData,
         _: &Connection,
         _: &QueueHandle<State>,
     ) {
         use wayland_protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::Event;
         match event {
             Event::Offer { mime_type } => {
-                data.mimes.lock().unwrap().push(mime_type);
+                self.mimes.lock().unwrap().push(mime_type);
             }
             _ => unreachable!(),
         }

--- a/src/primary_selection/selection.rs
+++ b/src/primary_selection/selection.rs
@@ -1,8 +1,9 @@
-use crate::reexports::client::{Connection, Dispatch, QueueHandle};
+use crate::dispatch2::Dispatch2;
+use crate::reexports::client::{Connection, QueueHandle};
 use crate::reexports::protocols::wp::primary_selection::zv1::client::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1;
 use crate::{data_device_manager::WritePipe, globals::GlobalData};
 
-use super::{device::PrimarySelectionDevice, PrimarySelectionManagerState};
+use super::device::PrimarySelectionDevice;
 
 /// Handler trait for `PrimarySelectionSource` events.
 ///
@@ -57,16 +58,15 @@ impl Drop for PrimarySelectionSource {
     }
 }
 
-impl<State> Dispatch<ZwpPrimarySelectionSourceV1, GlobalData, State>
-    for PrimarySelectionManagerState
+impl<State> Dispatch2<ZwpPrimarySelectionSourceV1, State> for GlobalData
 where
-    State: Dispatch<ZwpPrimarySelectionSourceV1, GlobalData> + PrimarySelectionSourceHandler,
+    State: PrimarySelectionSourceHandler,
 {
     fn event(
+        &self,
         state: &mut State,
         proxy: &ZwpPrimarySelectionSourceV1,
         event: <ZwpPrimarySelectionSourceV1 as wayland_client::Proxy>::Event,
-        _: &GlobalData,
         conn: &wayland_client::Connection,
         qhandle: &QueueHandle<State>,
     ) {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -278,7 +278,7 @@ impl RegistryState {
 ///
 /// ```
 /// use smithay_client_toolkit::{
-///     delegate_registry, delegate_shm, registry_handlers,
+///     delegate_registry, registry_handlers,
 ///     shm::{ShmHandler, Shm},
 /// };
 ///
@@ -286,14 +286,13 @@ impl RegistryState {
 ///     shm_state: Shm,
 /// }
 ///
-/// // Here is the implementation of wl_shm to compile:
-/// delegate_shm!(ExampleApp);
-///
 /// impl ShmHandler for ExampleApp {
 ///     fn shm_state(&mut self) -> &mut Shm {
 ///         &mut self.shm_state
 ///     }
 /// }
+///
+/// smithay_client_toolkit::delegate_dispatch2!(ExampleApp);
 /// ```
 #[macro_export]
 macro_rules! delegate_registry {
@@ -419,16 +418,6 @@ impl<I: Proxy + Clone, const MAX_VERSION: u32> ProvidesBoundGlobal<I, MAX_VERSIO
     }
 }
 
-impl<D, I, const MAX_VERSION: u32> Dispatch<I, (), D> for SimpleGlobal<I, MAX_VERSION>
-where
-    D: Dispatch<I, ()>,
-    I: Proxy,
-{
-    fn event(_: &mut D, _: &I, _: <I as Proxy>::Event, _: &(), _: &Connection, _: &QueueHandle<D>) {
-        unreachable!("SimpleGlobal is not suitable for {} which has events", I::interface().name);
-    }
-}
-
 /// Binds all globals with a given interface.
 pub(crate) fn bind_all<I, D, U, F>(
     registry: &wl_registry::WlRegistry,
@@ -505,15 +494,6 @@ where
         return Ok(proxy);
     }
     Err(BindError::NotPresent)
-}
-
-#[macro_export]
-macro_rules! delegate_simple {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty:ty, $iface:ty, $max:expr) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [ $iface: () ]
-            => $crate::registry::SimpleGlobal<$iface, $max>
-        );
-    };
 }
 
 /// A helper macro for implementing [`ProvidesRegistryState`].

--- a/src/seat/input_method.rs
+++ b/src/seat/input_method.rs
@@ -45,13 +45,26 @@ impl InputMethodManager {
     /// seat.
     pub fn get_input_method<State>(&self, qh: &QueueHandle<State>, seat: &WlSeat) -> InputMethod
     where
-        State: Dispatch<ZwpInputMethodV2, InputMethodData, State> + 'static,
+        State: Dispatch<ZwpInputMethodV2, InputMethodData<()>, State> + 'static,
+    {
+        self.get_input_method_with_data(qh, seat, ())
+    }
+
+    pub fn get_input_method_with_data<State, U>(
+        &self,
+        qh: &QueueHandle<State>,
+        seat: &WlSeat,
+        udata: U,
+    ) -> InputMethod
+    where
+        State: Dispatch<ZwpInputMethodV2, InputMethodData<U>, State> + 'static,
+        U: Send + Sync + 'static,
     {
         InputMethod {
             input_method: self.manager.get_input_method(
                 seat,
                 qh,
-                InputMethodData::new(seat.clone()),
+                InputMethodData::new(seat.clone(), udata),
             ),
         }
     }
@@ -109,23 +122,23 @@ impl InputMethod {
         self.input_method.delete_surrounding_text(before_length, after_length)
     }
 
-    pub fn commit(&self) {
-        let data = self.input_method.data::<InputMethodData>().unwrap();
+    pub fn commit<U: Send + Sync + 'static>(&self) {
+        let data = self.input_method.data::<InputMethodData<U>>().unwrap();
         let inner = data.inner.lock().unwrap();
         self.input_method.commit(inner.serial.0)
     }
 }
 
 #[derive(Debug)]
-pub struct InputMethodData {
+pub struct InputMethodData<U> {
     seat: WlSeat,
-
     inner: Mutex<InputMethodDataInner>,
+    udata: U,
 }
 
-impl InputMethodData {
+impl<U> InputMethodData<U> {
     /// Create the new input method data associated with the given seat.
-    pub fn new(seat: WlSeat) -> Self {
+    pub fn new(seat: WlSeat, udata: U) -> Self {
         Self {
             seat,
             inner: Mutex::new(InputMethodDataInner {
@@ -133,7 +146,16 @@ impl InputMethodData {
                 current_state: Default::default(),
                 serial: Wrapping(0),
             }),
+            udata,
         }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 
     /// Get the associated seat from the data.
@@ -246,20 +268,10 @@ macro_rules! delegate_input_method {
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::reexports::protocols_misc::zwp_input_method_v2::client::zwp_input_method_manager_v2::ZwpInputMethodManagerV2: $crate::globals::GlobalData
         ] => $crate::seat::input_method::InputMethodManager);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_misc::zwp_input_method_v2::client::zwp_input_method_v2::ZwpInputMethodV2: $crate::seat::input_method::InputMethodData
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty: [
+            $crate::reexports::protocols_misc::zwp_input_method_v2::client::zwp_input_method_v2::ZwpInputMethodV2: $crate::seat::input_method::InputMethodData<U>
         ] => $crate::seat::input_method::InputMethod);
     };
-}
-
-pub trait InputMethodDataExt: Send + Sync {
-    fn input_method_data(&self) -> &InputMethodData;
-}
-
-impl InputMethodDataExt for InputMethodData {
-    fn input_method_data(&self) -> &InputMethodData {
-        self
-    }
 }
 
 pub trait InputMethodHandler: Sized {
@@ -278,21 +290,20 @@ pub trait InputMethodHandler: Sized {
     );
 }
 
-impl<D, U> Dispatch<ZwpInputMethodV2, U, D> for InputMethod
+impl<D, U> Dispatch<ZwpInputMethodV2, InputMethodData<U>, D> for InputMethod
 where
-    D: Dispatch<ZwpInputMethodV2, U> + InputMethodHandler,
-    U: InputMethodDataExt,
+    D: Dispatch<ZwpInputMethodV2, InputMethodData<U>> + InputMethodHandler,
 {
     fn event(
         data: &mut D,
         input_method: &ZwpInputMethodV2,
         event: zwp_input_method_v2::Event,
-        udata: &U,
+        udata: &InputMethodData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
         let mut imdata: std::sync::MutexGuard<'_, InputMethodDataInner> =
-            udata.input_method_data().inner.lock().unwrap();
+            udata.inner.lock().unwrap();
 
         use zwp_input_method_v2::Event;
 
@@ -402,7 +413,7 @@ mod test {
 
     fn assert_is_delegate<T>()
     where
-        T: wayland_client::Dispatch<ZwpInputMethodV2, InputMethodData>,
+        T: wayland_client::Dispatch<ZwpInputMethodV2, InputMethodData<()>>,
     {
     }
 

--- a/src/seat/input_method.rs
+++ b/src/seat/input_method.rs
@@ -26,6 +26,8 @@ use wayland_protocols_misc::zwp_input_method_v2::client::{
     zwp_input_method_v2,
 };
 
+use crate::dispatch2::Dispatch2;
+
 #[derive(Debug)]
 pub struct InputMethodManager {
     manager: ZwpInputMethodManagerV2,
@@ -70,17 +72,15 @@ impl InputMethodManager {
     }
 }
 
-impl<D> Dispatch<zwp_input_method_manager_v2::ZwpInputMethodManagerV2, GlobalData, D>
-    for InputMethodManager
+impl<D> Dispatch2<zwp_input_method_manager_v2::ZwpInputMethodManagerV2, D> for GlobalData
 where
-    D: Dispatch<zwp_input_method_manager_v2::ZwpInputMethodManagerV2, GlobalData>
-        + InputMethodHandler,
+    D: InputMethodHandler,
 {
     fn event(
+        &self,
         _data: &mut D,
         _manager: &zwp_input_method_manager_v2::ZwpInputMethodManagerV2,
         _event: zwp_input_method_manager_v2::Event,
-        _: &GlobalData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
@@ -262,18 +262,6 @@ impl Active {
     }
 }
 
-#[macro_export]
-macro_rules! delegate_input_method {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_misc::zwp_input_method_v2::client::zwp_input_method_manager_v2::ZwpInputMethodManagerV2: $crate::globals::GlobalData
-        ] => $crate::seat::input_method::InputMethodManager);
-        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty: [
-            $crate::reexports::protocols_misc::zwp_input_method_v2::client::zwp_input_method_v2::ZwpInputMethodV2: $crate::seat::input_method::InputMethodData<U>
-        ] => $crate::seat::input_method::InputMethod);
-    };
-}
-
 pub trait InputMethodHandler: Sized {
     fn handle_done(
         &self,
@@ -290,20 +278,20 @@ pub trait InputMethodHandler: Sized {
     );
 }
 
-impl<D, U> Dispatch<ZwpInputMethodV2, InputMethodData<U>, D> for InputMethod
+impl<D, U> Dispatch2<ZwpInputMethodV2, D> for InputMethodData<U>
 where
-    D: Dispatch<ZwpInputMethodV2, InputMethodData<U>> + InputMethodHandler,
+    D: InputMethodHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         input_method: &ZwpInputMethodV2,
         event: zwp_input_method_v2::Event,
-        udata: &InputMethodData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
         let mut imdata: std::sync::MutexGuard<'_, InputMethodDataInner> =
-            udata.inner.lock().unwrap();
+            self.inner.lock().unwrap();
 
         use zwp_input_method_v2::Event;
 
@@ -403,7 +391,7 @@ mod test {
         }
     }
 
-    delegate_input_method!(Handler);
+    crate::delegate_dispatch2!(Handler);
 
     fn assert_is_manager_delegate<T>()
     where

--- a/src/seat/input_method_v3.rs
+++ b/src/seat/input_method_v3.rs
@@ -74,13 +74,26 @@ impl InputMethodManager {
     /// seat.
     pub fn get_input_method<State>(&self, qh: &QueueHandle<State>, seat: &WlSeat) -> InputMethod
     where
-        State: Dispatch<XxInputMethodV1, InputMethodData, State> + 'static,
+        State: Dispatch<XxInputMethodV1, InputMethodData<()>, State> + 'static,
+    {
+        self.get_input_method_with_data(qh, seat, ())
+    }
+
+    pub fn get_input_method_with_data<State, U>(
+        &self,
+        qh: &QueueHandle<State>,
+        seat: &WlSeat,
+        udata: U,
+    ) -> InputMethod
+    where
+        State: Dispatch<XxInputMethodV1, InputMethodData<U>, State> + 'static,
+        U: Send + Sync + 'static,
     {
         InputMethod {
             input_method: self.manager.get_input_method(
                 seat,
                 qh,
-                InputMethodData::new(seat.clone()),
+                InputMethodData::new(seat.clone(), udata),
             ),
         }
     }
@@ -226,13 +239,16 @@ impl InputMethod {
         self.input_method.move_cursor(cursor, anchor)
     }
 
-    pub fn commit(&self) {
-        let data = self.input_method.data::<InputMethodData>().unwrap();
+    pub fn commit<U>(&self)
+    where
+        U: Send + Sync + 'static,
+    {
+        let data = self.input_method.data::<InputMethodData<U>>().unwrap();
         let inner = &data.inner.lock().unwrap();
         self.input_method.commit(inner.serial.0)
     }
 
-    pub fn get_input_popup_surface<D>(
+    pub fn get_input_popup_surface<D, U>(
         &self,
         qh: &QueueHandle<D>,
         surface: impl Into<Surface>,
@@ -240,8 +256,9 @@ impl InputMethod {
     ) -> Popup
     where
         D: Dispatch<XxInputPopupSurfaceV2, PopupData> + 'static,
+        U: Send + Sync + 'static,
     {
-        let data = self.input_method.data::<InputMethodData>().unwrap();
+        let data = self.input_method.data::<InputMethodData<U>>().unwrap();
         let surface = surface.into();
         Popup {
             input_method: self.input_method.clone(),
@@ -257,15 +274,15 @@ impl InputMethod {
 }
 
 #[derive(Debug)]
-pub struct InputMethodData {
+pub struct InputMethodData<U> {
     seat: WlSeat,
-
     inner: Arc<Mutex<InputMethodDataInner>>,
+    udata: U,
 }
 
-impl InputMethodData {
+impl<U> InputMethodData<U> {
     /// Create the new touch data associated with the given seat.
-    pub fn new(seat: WlSeat) -> Self {
+    pub fn new(seat: WlSeat, udata: U) -> Self {
         Self {
             seat,
             inner: Arc::new(Mutex::new(InputMethodDataInner {
@@ -273,7 +290,16 @@ impl InputMethodData {
                 current_state: Default::default(),
                 serial: Wrapping(0),
             })),
+            udata,
         }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 
     /// Get the associated seat from the data.
@@ -594,8 +620,8 @@ macro_rules! delegate_input_method_v3 {
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_method_manager_v2::XxInputMethodManagerV2: $crate::globals::GlobalData
         ] => $crate::seat::input_method_v3::InputMethodManager);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_method_v1::XxInputMethodV1: $crate::seat::input_method_v3::InputMethodData
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty: [
+            $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_method_v1::XxInputMethodV1: $crate::seat::input_method_v3::InputMethodData<U>
         ] => $crate::seat::input_method_v3::InputMethod);
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_popup_surface_v2::XxInputPopupSurfaceV2: $crate::seat::input_method_v3::PopupData
@@ -604,16 +630,6 @@ macro_rules! delegate_input_method_v3 {
             $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_popup_positioner_v1::XxInputPopupPositionerV1: $crate::seat::input_method_v3::PositionerData
         ] => $crate::seat::input_method_v3::PopupPositioner);
     };
-}
-
-pub trait InputMethodDataExt: Send + Sync {
-    fn input_method_data(&self) -> &InputMethodData;
-}
-
-impl InputMethodDataExt for InputMethodData {
-    fn input_method_data(&self) -> &InputMethodData {
-        self
-    }
 }
 
 pub trait InputMethodHandler: Sized {
@@ -633,21 +649,19 @@ pub trait InputMethodHandler: Sized {
     fn handle_unavailable(&mut self, qh: &QueueHandle<Self>, input_method: &XxInputMethodV1);
 }
 
-impl<D, U> Dispatch<XxInputMethodV1, U, D> for InputMethod
+impl<D, U> Dispatch<XxInputMethodV1, InputMethodData<U>, D> for InputMethod
 where
-    D: Dispatch<XxInputMethodV1, U> + InputMethodHandler,
-    U: InputMethodDataExt,
+    D: Dispatch<XxInputMethodV1, InputMethodData<U>> + InputMethodHandler,
 {
     fn event(
         data: &mut D,
         input_method: &XxInputMethodV1,
         event: xx_input_method_v1::Event,
-        udata: &U,
+        udata: &InputMethodData<U>,
         _conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let mut imdata: MutexGuard<'_, InputMethodDataInner> =
-            udata.input_method_data().inner.lock().unwrap();
+        let mut imdata: MutexGuard<'_, InputMethodDataInner> = udata.inner.lock().unwrap();
 
         use xx_input_method_v1::Event;
 
@@ -791,7 +805,10 @@ mod test {
 
     fn assert_is_delegate<T>()
     where
-        T: wayland_client::Dispatch<protocol::xx_input_method_v1::XxInputMethodV1, InputMethodData>,
+        T: wayland_client::Dispatch<
+            protocol::xx_input_method_v1::XxInputMethodV1,
+            InputMethodData<()>,
+        >,
     {
     }
 

--- a/src/seat/input_method_v3.rs
+++ b/src/seat/input_method_v3.rs
@@ -30,6 +30,8 @@ use wayland_client::{Connection, Dispatch, Proxy, QueueHandle};
 
 use crate::reexports::protocols_experimental::input_method::v1::client as protocol;
 
+use crate::dispatch2::Dispatch2;
+
 pub use protocol::xx_input_method_v1::XxInputMethodV1;
 pub use protocol::xx_input_popup_positioner_v1::XxInputPopupPositionerV1;
 pub use protocol::xx_input_popup_surface_v2::XxInputPopupSurfaceV2;
@@ -106,17 +108,15 @@ impl InputMethodManager {
     }
 }
 
-impl<D> Dispatch<xx_input_method_manager_v2::XxInputMethodManagerV2, GlobalData, D>
-    for InputMethodManager
+impl<D> Dispatch2<xx_input_method_manager_v2::XxInputMethodManagerV2, D> for GlobalData
 where
-    D: Dispatch<xx_input_method_manager_v2::XxInputMethodManagerV2, GlobalData>
-        + InputMethodHandler,
+    D: InputMethodHandler,
 {
     fn event(
+        &self,
         _data: &mut D,
         _manager: &xx_input_method_manager_v2::XxInputMethodManagerV2,
         _event: xx_input_method_manager_v2::Event,
-        _: &GlobalData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
@@ -145,15 +145,15 @@ impl Drop for PopupPositioner {
     }
 }
 
-impl<D> Dispatch<XxInputPopupPositionerV1, PositionerData, D> for PopupPositioner
+impl<D> Dispatch2<XxInputPopupPositionerV1, D> for PositionerData
 where
-    D: Dispatch<XxInputPopupPositionerV1, PositionerData> + InputMethodHandler,
+    D: InputMethodHandler,
 {
     fn event(
+        &self,
         _data: &mut D,
         _manager: &XxInputPopupPositionerV1,
         _event: xx_input_popup_positioner_v1::Event,
-        _: &PositionerData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
@@ -506,19 +506,19 @@ impl Popup {
     }
 }
 
-impl<D> Dispatch<XxInputPopupSurfaceV2, PopupData, D> for Popup
+impl<D> Dispatch2<XxInputPopupSurfaceV2, D> for PopupData
 where
-    D: Dispatch<XxInputPopupSurfaceV2, PopupData> + InputMethodHandler,
+    D: InputMethodHandler,
 {
     fn event(
+        &self,
         _data: &mut D,
         popup: &XxInputPopupSurfaceV2,
         event: xx_input_popup_surface_v2::Event,
-        udata: &PopupData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
-        let inner: MutexGuard<'_, PopupDataInner> = udata.inner.lock().unwrap();
+        let inner: MutexGuard<'_, PopupDataInner> = self.inner.lock().unwrap();
         if let Some(im) = inner.im.upgrade() {
             let mut im = im.lock().unwrap();
 
@@ -614,24 +614,6 @@ impl PopupDataInner {
     }
 }
 
-#[macro_export]
-macro_rules! delegate_input_method_v3 {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_method_manager_v2::XxInputMethodManagerV2: $crate::globals::GlobalData
-        ] => $crate::seat::input_method_v3::InputMethodManager);
-        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty: [
-            $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_method_v1::XxInputMethodV1: $crate::seat::input_method_v3::InputMethodData<U>
-        ] => $crate::seat::input_method_v3::InputMethod);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_popup_surface_v2::XxInputPopupSurfaceV2: $crate::seat::input_method_v3::PopupData
-        ] => $crate::seat::input_method_v3::Popup);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_popup_positioner_v1::XxInputPopupPositionerV1: $crate::seat::input_method_v3::PositionerData
-        ] => $crate::seat::input_method_v3::PopupPositioner);
-    };
-}
-
 pub trait InputMethodHandler: Sized {
     fn handle_done(
         &mut self,
@@ -649,19 +631,19 @@ pub trait InputMethodHandler: Sized {
     fn handle_unavailable(&mut self, qh: &QueueHandle<Self>, input_method: &XxInputMethodV1);
 }
 
-impl<D, U> Dispatch<XxInputMethodV1, InputMethodData<U>, D> for InputMethod
+impl<D, U> Dispatch2<XxInputMethodV1, D> for InputMethodData<U>
 where
-    D: Dispatch<XxInputMethodV1, InputMethodData<U>> + InputMethodHandler,
+    D: InputMethodHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         input_method: &XxInputMethodV1,
         event: xx_input_method_v1::Event,
-        udata: &InputMethodData<U>,
         _conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let mut imdata: MutexGuard<'_, InputMethodDataInner> = udata.inner.lock().unwrap();
+        let mut imdata: MutexGuard<'_, InputMethodDataInner> = self.inner.lock().unwrap();
 
         use xx_input_method_v1::Event;
 
@@ -792,7 +774,7 @@ mod test {
         }
     }
 
-    delegate_input_method_v3!(Handler);
+    crate::delegate_dispatch2!(Handler);
 
     fn assert_is_manager_delegate<T>()
     where

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -65,17 +65,24 @@ impl SeatState {
         rmlvo: Option<RMLVO>,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D>>
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, ()>>
             + SeatHandler
             + KeyboardHandler
             + 'static,
     {
         let udata = match rmlvo {
-            Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo)?,
-            None => KeyboardData::new(seat.clone()),
+            Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo, ())?,
+            None => KeyboardData::new(seat.clone(), ()),
         };
 
-        self.get_keyboard_with_data(qh, seat, udata)
+        let inner =
+            self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
+
+        if !inner.data.has_keyboard.load(Ordering::SeqCst) {
+            return Err(SeatError::UnsupportedCapability(Capability::Keyboard).into());
+        }
+
+        Ok(seat.get_keyboard(qh, udata))
     }
 
     /// Creates a keyboard from a seat.
@@ -95,8 +102,11 @@ impl SeatState {
         udata: U,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, U> + SeatHandler + KeyboardHandler + 'static,
-        U: KeyboardDataExt<State = D> + 'static,
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, U>>
+            + SeatHandler
+            + KeyboardHandler
+            + 'static,
+        U: Send + Sync + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -104,6 +114,8 @@ impl SeatState {
         if !inner.data.has_keyboard.load(Ordering::SeqCst) {
             return Err(SeatError::UnsupportedCapability(Capability::Keyboard).into());
         }
+
+        let udata = KeyboardData::new(seat.clone(), udata);
 
         Ok(seat.get_keyboard(qh, udata))
     }
@@ -338,7 +350,7 @@ pub struct RMLVO {
     pub options: Option<String>,
 }
 
-pub struct KeyboardData<T> {
+pub struct KeyboardData<D, U> {
     seat: wl_seat::WlSeat,
     first_event: AtomicBool,
     xkb_context: Mutex<xkb::Context>,
@@ -347,12 +359,13 @@ pub struct KeyboardData<T> {
     xkb_state: Mutex<Option<xkb::State>>,
     xkb_compose: Mutex<Option<xkb::compose::State>>,
     #[cfg(feature = "calloop")]
-    repeat_data: Arc<Mutex<Option<RepeatData<T>>>>,
+    repeat_data: Arc<Mutex<Option<RepeatData<D>>>>,
     focus: Mutex<Option<wl_surface::WlSurface>>,
-    _phantom_data: PhantomData<T>,
+    _phantom_data: PhantomData<D>,
+    udata: U,
 }
 
-impl<T> Debug for KeyboardData<T> {
+impl<T, U> Debug for KeyboardData<T, U> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KeyboardData").finish_non_exhaustive()
     }
@@ -361,32 +374,23 @@ impl<T> Debug for KeyboardData<T> {
 #[macro_export]
 macro_rules! delegate_keyboard {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty:
             [
-                $crate::reexports::client::protocol::wl_keyboard::WlKeyboard: $crate::seat::keyboard::KeyboardData<$ty>
-            ] => $crate::seat::SeatState
-        );
-    };
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, keyboard: [$($udata:ty),* $(,)?]) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $(
-                    $crate::reexports::client::protocol::wl_keyboard::WlKeyboard: $udata,
-                )*
+                $crate::reexports::client::protocol::wl_keyboard::WlKeyboard: $crate::seat::keyboard::KeyboardData<$ty, U>
             ] => $crate::seat::SeatState
         );
     };
 }
 
 // SAFETY: The state does not share state with any other rust types.
-unsafe impl<T> Send for KeyboardData<T> {}
+unsafe impl<T, U: Send> Send for KeyboardData<T, U> {}
 // SAFETY: The state is guarded by a mutex since libxkbcommon has no internal synchronization.
-unsafe impl<T> Sync for KeyboardData<T> {}
+unsafe impl<T, U: Sync> Sync for KeyboardData<T, U> {}
 
-impl<T> KeyboardData<T> {
-    pub fn new(seat: wl_seat::WlSeat) -> Self {
+impl<T, U> KeyboardData<T, U> {
+    pub fn new(seat: wl_seat::WlSeat, udata: U) -> Self {
         let xkb_context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
-        let udata = KeyboardData {
+        let keyboard_data = KeyboardData {
             seat,
             first_event: AtomicBool::new(false),
             xkb_context: Mutex::new(xkb_context),
@@ -397,18 +401,31 @@ impl<T> KeyboardData<T> {
             repeat_data: Arc::new(Mutex::new(None)),
             focus: Mutex::new(None),
             _phantom_data: PhantomData,
+            udata,
         };
 
-        udata.init_compose();
+        keyboard_data.init_compose();
 
-        udata
+        keyboard_data
+    }
+
+    pub fn data(&mut self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &U {
+        &self.udata
     }
 
     pub fn seat(&self) -> &wl_seat::WlSeat {
         &self.seat
     }
 
-    pub fn from_rmlvo(seat: wl_seat::WlSeat, rmlvo: RMLVO) -> Result<Self, KeyboardError> {
+    pub fn from_rmlvo(
+        seat: wl_seat::WlSeat,
+        rmlvo: RMLVO,
+        udata: U,
+    ) -> Result<Self, KeyboardError> {
         let xkb_context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
         let keymap = xkb::Keymap::new_from_names(
             &xkb_context,
@@ -426,7 +443,7 @@ impl<T> KeyboardData<T> {
 
         let xkb_state = Some(xkb::State::new(&keymap.unwrap()));
 
-        let udata = KeyboardData {
+        let keyboard_data = KeyboardData {
             seat,
             first_event: AtomicBool::new(false),
             xkb_context: Mutex::new(xkb_context),
@@ -437,11 +454,12 @@ impl<T> KeyboardData<T> {
             repeat_data: Arc::new(Mutex::new(None)),
             focus: Mutex::new(None),
             _phantom_data: PhantomData,
+            udata,
         };
 
-        udata.init_compose();
+        keyboard_data.init_compose();
 
-        Ok(udata)
+        Ok(keyboard_data)
     }
 
     fn init_compose(&self) {
@@ -484,39 +502,18 @@ impl<T> KeyboardData<T> {
     }
 }
 
-pub trait KeyboardDataExt: Send + Sync {
-    type State: 'static;
-    fn keyboard_data(&self) -> &KeyboardData<Self::State>;
-    fn keyboard_data_mut(&mut self) -> &mut KeyboardData<Self::State>;
-}
-
-impl<T: 'static> KeyboardDataExt for KeyboardData<T> {
-    /// The type of the user defined state
-    type State = T;
-    fn keyboard_data(&self) -> &KeyboardData<T> {
-        self
-    }
-
-    fn keyboard_data_mut(&mut self) -> &mut KeyboardData<T> {
-        self
-    }
-}
-
-impl<D, U> Dispatch<wl_keyboard::WlKeyboard, U, D> for SeatState
+impl<D, U> Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, U>, D> for SeatState
 where
-    D: Dispatch<wl_keyboard::WlKeyboard, U> + KeyboardHandler + 'static,
-    U: KeyboardDataExt<State = D>,
+    D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, U>> + KeyboardHandler + 'static,
 {
     fn event(
         data: &mut D,
         keyboard: &wl_keyboard::WlKeyboard,
         event: wl_keyboard::Event,
-        udata: &U,
+        udata: &KeyboardData<D, U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let udata = udata.keyboard_data();
-
         // The compositor has no way to tell clients if the seat is not version 4 or above.
         // In this case, send a synthetic repeat info event using the default repeat values used by the X
         // server.

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -58,14 +58,14 @@ impl SeatState {
     /// ## Errors
     ///
     /// This will return [`SeatError::UnsupportedCapability`] if the seat does not support a keyboard.
-    pub fn get_keyboard<D, T: 'static>(
+    pub fn get_keyboard<D>(
         &mut self,
         qh: &QueueHandle<D>,
         seat: &wl_seat::WlSeat,
         rmlvo: Option<RMLVO>,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<T>>
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D>>
             + SeatHandler
             + KeyboardHandler
             + 'static,
@@ -96,7 +96,7 @@ impl SeatState {
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
         D: Dispatch<wl_keyboard::WlKeyboard, U> + SeatHandler + KeyboardHandler + 'static,
-        U: KeyboardDataExt + 'static,
+        U: KeyboardDataExt<State = D> + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -504,8 +504,8 @@ impl<T: 'static> KeyboardDataExt for KeyboardData<T> {
 
 impl<D, U> Dispatch<wl_keyboard::WlKeyboard, U, D> for SeatState
 where
-    D: Dispatch<wl_keyboard::WlKeyboard, U> + KeyboardHandler,
-    U: KeyboardDataExt,
+    D: Dispatch<wl_keyboard::WlKeyboard, U> + KeyboardHandler + 'static,
+    U: KeyboardDataExt<State = D>,
 {
     fn event(
         data: &mut D,

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -26,6 +26,8 @@ use xkbcommon::xkb;
 #[cfg(feature = "calloop")]
 use repeat::{RepeatData, RepeatedKey};
 
+use crate::dispatch2::Dispatch2;
+
 use super::{Capability, SeatError, SeatHandler, SeatState};
 
 #[cfg(feature = "calloop")]
@@ -371,17 +373,6 @@ impl<T, U> Debug for KeyboardData<T, U> {
     }
 }
 
-#[macro_export]
-macro_rules! delegate_keyboard {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty:
-            [
-                $crate::reexports::client::protocol::wl_keyboard::WlKeyboard: $crate::seat::keyboard::KeyboardData<$ty, U>
-            ] => $crate::seat::SeatState
-        );
-    };
-}
-
 // SAFETY: The state does not share state with any other rust types.
 unsafe impl<T, U: Send> Send for KeyboardData<T, U> {}
 // SAFETY: The state is guarded by a mutex since libxkbcommon has no internal synchronization.
@@ -502,23 +493,23 @@ impl<T, U> KeyboardData<T, U> {
     }
 }
 
-impl<D, U> Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, U>, D> for SeatState
+impl<D, U> Dispatch2<wl_keyboard::WlKeyboard, D> for KeyboardData<D, U>
 where
-    D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, U>> + KeyboardHandler + 'static,
+    D: KeyboardHandler + 'static,
 {
     fn event(
+        &self,
         data: &mut D,
         keyboard: &wl_keyboard::WlKeyboard,
         event: wl_keyboard::Event,
-        udata: &KeyboardData<D, U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
         // The compositor has no way to tell clients if the seat is not version 4 or above.
         // In this case, send a synthetic repeat info event using the default repeat values used by the X
         // server.
-        if keyboard.version() < 4 && udata.first_event.load(Ordering::SeqCst) {
-            udata.first_event.store(true, Ordering::SeqCst);
+        if keyboard.version() < 4 && self.first_event.load(Ordering::SeqCst) {
+            self.first_event.store(true, Ordering::SeqCst);
 
             data.update_repeat_info(
                 conn,
@@ -537,12 +528,12 @@ where
                         }
 
                         wl_keyboard::KeymapFormat::XkbV1 => {
-                            if udata.user_specified_rmlvo {
+                            if self.user_specified_rmlvo {
                                 // state is locked, ignore keymap updates
                                 return;
                             }
 
-                            let context = udata.xkb_context.lock().unwrap();
+                            let context = self.xkb_context.lock().unwrap();
 
                             // 0.5.0-beta.0 does not mark this function as unsafe but upstream rightly makes
                             // this function unsafe.
@@ -565,7 +556,7 @@ where
                                 Ok(Some(keymap)) => {
                                     let state = xkb::State::new(&keymap);
                                     {
-                                        let mut state_guard = udata.xkb_state.lock().unwrap();
+                                        let mut state_guard = self.xkb_state.lock().unwrap();
                                         *state_guard = Some(state);
                                     }
                                     data.update_keymap(conn, qh, keyboard, Keymap(&keymap));
@@ -591,7 +582,7 @@ where
             }
 
             wl_keyboard::Event::Enter { serial, surface, keys } => {
-                let state_guard = udata.xkb_state.lock().unwrap();
+                let state_guard = self.xkb_state.lock().unwrap();
 
                 if let Some(guard) = state_guard.as_ref() {
                     // Keysyms are encoded as an array of u32
@@ -623,7 +614,7 @@ where
                     );
                 }
 
-                *udata.focus.lock().unwrap() = Some(surface);
+                *self.focus.lock().unwrap() = Some(surface);
             }
 
             wl_keyboard::Event::Leave { serial, surface } => {
@@ -631,19 +622,19 @@ where
                 // sent before entering a new surface.
                 #[cfg(feature = "calloop")]
                 {
-                    if let Some(repeat_data) = udata.repeat_data.lock().unwrap().as_mut() {
+                    if let Some(repeat_data) = self.repeat_data.lock().unwrap().as_mut() {
                         repeat_data.current_repeat.take();
                     }
                 }
 
                 data.leave(conn, qh, keyboard, &surface, serial);
 
-                *udata.focus.lock().unwrap() = None;
+                *self.focus.lock().unwrap() = None;
             }
 
             wl_keyboard::Event::Key { serial, time, key, state } => match state {
                 WEnum::Value(state) => {
-                    let state_guard = udata.xkb_state.lock().unwrap();
+                    let state_guard = self.xkb_state.lock().unwrap();
 
                     if let Some(guard) = state_guard.as_ref() {
                         // We must add 8 to the keycode for any functions we pass the raw keycode into per
@@ -651,7 +642,7 @@ where
                         let keycode = KeyCode::new(key + 8);
                         let keysym = guard.key_get_one_sym(keycode);
                         let utf8 = if state == wl_keyboard::KeyState::Pressed {
-                            let mut compose = udata.xkb_compose.lock().unwrap();
+                            let mut compose = self.xkb_compose.lock().unwrap();
 
                             match compose.as_mut() {
                                 Some(compose) => match compose.feed(keysym) {
@@ -680,7 +671,7 @@ where
                                 #[cfg(feature = "calloop")]
                                 {
                                     if let Some(repeat_data) =
-                                        udata.repeat_data.lock().unwrap().as_mut()
+                                        self.repeat_data.lock().unwrap().as_mut()
                                     {
                                         if Some(event.raw_code)
                                             == repeat_data
@@ -704,10 +695,10 @@ where
                                 #[cfg(feature = "calloop")]
                                 {
                                     if let Some(repeat_data) =
-                                        udata.repeat_data.lock().unwrap().as_mut()
+                                        self.repeat_data.lock().unwrap().as_mut()
                                     {
                                         let loop_handle = &mut repeat_data.loop_handle;
-                                        let state_guard = udata.xkb_state.lock().unwrap();
+                                        let state_guard = self.xkb_state.lock().unwrap();
                                         let key_repeats = state_guard
                                             .as_ref()
                                             .map(|guard| {
@@ -722,17 +713,22 @@ where
                                                 loop_handle.remove(token);
                                             }
 
-                                            let surface =
-                                                match udata.focus.lock().unwrap().as_ref().cloned()
-                                                {
-                                                    Some(surface) => surface,
+                                            let surface = match self
+                                                .focus
+                                                .lock()
+                                                .unwrap()
+                                                .as_ref()
+                                                .cloned()
+                                            {
+                                                Some(surface) => surface,
 
-                                                    None => {
-                                                        log::warn!(
-                                                "wl_keyboard::key with no focused surface");
-                                                        return;
-                                                    }
-                                                };
+                                                None => {
+                                                    log::warn!(
+                                                        "wl_keyboard::key with no focused surface"
+                                                    );
+                                                    return;
+                                                }
+                                            };
 
                                             // Update the current repeat key.
                                             repeat_data.current_repeat.replace(RepeatedKey {
@@ -751,7 +747,7 @@ where
                                             let timer = Timer::from_duration(
                                                 Duration::from_millis(delay as u64),
                                             );
-                                            let repeat_data2 = udata.repeat_data.clone();
+                                            let repeat_data2 = self.repeat_data.clone();
 
                                             // Start the timer.
                                             let kbd = keyboard.clone();
@@ -810,7 +806,7 @@ where
                 mods_locked,
                 group,
             } => {
-                let mut guard = udata.xkb_state.lock().unwrap();
+                let mut guard = self.xkb_state.lock().unwrap();
 
                 let state = match guard.as_mut() {
                     Some(state) => state,
@@ -822,11 +818,11 @@ where
 
                 // Update the currently repeating key if any.
                 #[cfg(feature = "calloop")]
-                if let Some(repeat_data) = udata.repeat_data.lock().unwrap().as_mut() {
+                if let Some(repeat_data) = self.repeat_data.lock().unwrap().as_mut() {
                     if let Some(mut event) = repeat_data.current_repeat.take() {
                         // Apply new modifiers to get new utf8.
                         event.key.utf8 = {
-                            let mut compose = udata.xkb_compose.lock().unwrap();
+                            let mut compose = self.xkb_compose.lock().unwrap();
 
                             match compose.as_mut() {
                                 Some(compose) => match compose.feed(event.key.keysym) {
@@ -863,7 +859,7 @@ where
                 };
 
                 // Always issue the modifiers update for the user.
-                let modifiers = udata.update_modifiers();
+                let modifiers = self.update_modifiers();
                 data.update_modifiers(conn, qh, keyboard, serial, modifiers, raw_modifiers, group);
             }
 
@@ -879,7 +875,7 @@ where
 
                 #[cfg(feature = "calloop")]
                 {
-                    if let Some(repeat_data) = udata.repeat_data.lock().unwrap().as_mut() {
+                    if let Some(repeat_data) = self.repeat_data.lock().unwrap().as_mut() {
                         repeat_data.repeat_info = info;
                     }
                 }

--- a/src/seat/keyboard/repeat.rs
+++ b/src/seat/keyboard/repeat.rs
@@ -55,17 +55,16 @@ impl SeatState {
     /// This will return [`SeatError::UnsupportedCapability`] if the seat does not support a keyboard.
     ///
     /// [`EventSource`]: calloop::EventSource
-    pub fn get_keyboard_with_repeat<D, T>(
+    pub fn get_keyboard_with_repeat<D>(
         &mut self,
         qh: &QueueHandle<D>,
         seat: &wl_seat::WlSeat,
         rmlvo: Option<RMLVO>,
-        loop_handle: LoopHandle<'static, T>,
-        callback: RepeatCallback<T>,
+        loop_handle: LoopHandle<'static, D>,
+        callback: RepeatCallback<D>,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<T>> + KeyboardHandler + 'static,
-        T: 'static,
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D>> + KeyboardHandler + 'static,
     {
         let udata = match rmlvo {
             Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo)?,
@@ -99,7 +98,7 @@ impl SeatState {
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
         D: Dispatch<wl_keyboard::WlKeyboard, U> + KeyboardHandler + 'static,
-        U: KeyboardDataExt + 'static,
+        U: KeyboardDataExt<State = D> + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;

--- a/src/seat/keyboard/repeat.rs
+++ b/src/seat/keyboard/repeat.rs
@@ -10,8 +10,8 @@ use wayland_client::{
 };
 
 use super::{
-    Capability, KeyEvent, KeyboardData, KeyboardDataExt, KeyboardError, KeyboardHandler,
-    RepeatInfo, SeatError, RMLVO,
+    Capability, KeyEvent, KeyboardData, KeyboardError, KeyboardHandler, RepeatInfo, SeatError,
+    RMLVO,
 };
 use crate::seat::SeatState;
 
@@ -64,14 +64,30 @@ impl SeatState {
         callback: RepeatCallback<D>,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D>> + KeyboardHandler + 'static,
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, ()>> + KeyboardHandler + 'static,
     {
         let udata = match rmlvo {
-            Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo)?,
-            None => KeyboardData::new(seat.clone()),
+            Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo, ())?,
+            None => KeyboardData::new(seat.clone(), ()),
         };
 
-        self.get_keyboard_with_repeat_with_data(qh, seat, udata, loop_handle, callback)
+        let inner =
+            self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
+
+        if !inner.data.has_keyboard.load(Ordering::SeqCst) {
+            return Err(SeatError::UnsupportedCapability(Capability::Keyboard).into());
+        }
+
+        udata.repeat_data.lock().unwrap().replace(RepeatData {
+            current_repeat: None,
+            repeat_info: RepeatInfo::Disable,
+            loop_handle: loop_handle.clone(),
+            callback,
+            repeat_token: None,
+        });
+        udata.init_compose();
+
+        Ok(seat.get_keyboard(qh, udata))
     }
 
     /// Creates a keyboard from a seat.
@@ -92,13 +108,13 @@ impl SeatState {
         &mut self,
         qh: &QueueHandle<D>,
         seat: &wl_seat::WlSeat,
-        mut udata: U,
-        loop_handle: LoopHandle<'static, <U as KeyboardDataExt>::State>,
-        callback: RepeatCallback<<U as KeyboardDataExt>::State>,
+        udata: U,
+        loop_handle: LoopHandle<'static, D>,
+        callback: RepeatCallback<D>,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, U> + KeyboardHandler + 'static,
-        U: KeyboardDataExt<State = D> + 'static,
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, U>> + KeyboardHandler + 'static,
+        U: Send + Sync + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -107,15 +123,16 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Keyboard).into());
         }
 
-        let kbd_data = udata.keyboard_data_mut();
-        kbd_data.repeat_data.lock().unwrap().replace(RepeatData {
+        let udata = KeyboardData::new(seat.clone(), udata);
+
+        udata.repeat_data.lock().unwrap().replace(RepeatData {
             current_repeat: None,
             repeat_info: RepeatInfo::Disable,
             loop_handle: loop_handle.clone(),
             callback,
             repeat_token: None,
         });
-        kbd_data.init_compose();
+        udata.init_compose();
 
         Ok(seat.get_keyboard(qh, udata))
     }

--- a/src/seat/keyboard_filter.rs
+++ b/src/seat/keyboard_filter.rs
@@ -11,6 +11,7 @@ use wayland_protocols_experimental::keyboard_filter::v3::client::{
     self as protocol, xx_keyboard_filter_manager_v1, xx_keyboard_filter_v1,
 };
 
+use crate::dispatch2::Dispatch2;
 use crate::globals::GlobalData;
 
 #[derive(Debug)]
@@ -42,21 +43,24 @@ impl KeyboardFilterManager {
         surface: &WlSurface,
     ) -> KeyboardFilter
     where
-        D: Dispatch<XxKeyboardFilterV1, ()> + 'static,
+        D: Dispatch<XxKeyboardFilterV1, GlobalData> + 'static,
     {
-        KeyboardFilter(self.manager.bind_to_input_method(keyboard, input_method, surface, qh, ()))
+        KeyboardFilter(self.manager.bind_to_input_method(
+            keyboard,
+            input_method,
+            surface,
+            qh,
+            GlobalData,
+        ))
     }
 }
 
-impl<D> Dispatch<XxKeyboardFilterManagerV1, GlobalData, D> for KeyboardFilterManager
-where
-    D: Dispatch<XxKeyboardFilterManagerV1, GlobalData>,
-{
+impl<D> Dispatch2<XxKeyboardFilterManagerV1, D> for GlobalData {
     fn event(
+        &self,
         _data: &mut D,
         _manager: &XxKeyboardFilterManagerV1,
         _event: xx_keyboard_filter_manager_v1::Event,
-        _: &GlobalData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
@@ -82,32 +86,17 @@ impl KeyboardFilter {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct KeyboardVersion(pub u32);
 
-impl<D> Dispatch<XxKeyboardFilterV1, (), D> for KeyboardFilter
-where
-    D: Dispatch<XxKeyboardFilterV1, ()>,
-{
+impl<D> Dispatch2<XxKeyboardFilterV1, D> for GlobalData {
     fn event(
+        &self,
         _data: &mut D,
         _keyboard: &XxKeyboardFilterV1,
         _event: xx_keyboard_filter_v1::Event,
-        _: &(),
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
         unreachable!("Filter receives no events")
     }
-}
-
-#[macro_export]
-macro_rules! delegate_keyboard_filter_v1 {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_experimental::keyboard_filter::v3::client::xx_keyboard_filter_manager_v1::XxKeyboardFilterManagerV1: $crate::globals::GlobalData
-        ] => $crate::seat::keyboard_filter::KeyboardFilterManager);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_experimental::keyboard_filter::v3::client::xx_keyboard_filter_v1::XxKeyboardFilterV1: ()
-        ] => $crate::seat::keyboard_filter::KeyboardFilter);
-    };
 }
 
 #[cfg(test)]
@@ -116,7 +105,7 @@ mod test {
 
     struct Handler {}
 
-    delegate_keyboard_filter_v1!(Handler);
+    crate::delegate_dispatch2!(Handler);
 
     fn assert_is_manager_delegate<T>()
     where
@@ -129,7 +118,10 @@ mod test {
 
     fn assert_is_delegate<T>()
     where
-        T: wayland_client::Dispatch<protocol::xx_keyboard_filter_v1::XxKeyboardFilterV1, ()>,
+        T: wayland_client::Dispatch<
+            protocol::xx_keyboard_filter_v1::XxKeyboardFilterV1,
+            crate::globals::GlobalData,
+        >,
     {
     }
 

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -15,7 +15,7 @@ use crate::reexports::client::{
 use crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1;
 use crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1;
 use crate::{
-    compositor::SurfaceDataExt,
+    compositor::SurfaceData,
     globals::GlobalData,
     registry::{ProvidesRegistryState, RegistryHandler},
 };
@@ -31,8 +31,8 @@ pub mod relative_pointer;
 pub mod touch;
 
 use pointer::cursor_shape::CursorShapeManager;
-use pointer::{PointerData, PointerDataExt, PointerHandler, ThemeSpec, ThemedPointer, Themes};
-use touch::{TouchData, TouchDataExt, TouchHandler};
+use pointer::{PointerData, PointerHandler, ThemeSpec, ThemedPointer, Themes};
+use touch::{TouchData, TouchHandler};
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -152,9 +152,9 @@ impl SeatState {
         seat: &wl_seat::WlSeat,
     ) -> Result<wl_pointer::WlPointer, SeatError>
     where
-        D: Dispatch<wl_pointer::WlPointer, PointerData> + PointerHandler + 'static,
+        D: Dispatch<wl_pointer::WlPointer, PointerData<()>> + PointerHandler + 'static,
     {
-        self.get_pointer_with_data(qh, seat, PointerData::new(seat.clone()))
+        self.get_pointer_with_data(qh, seat, ())
     }
 
     /// Creates a pointer from a seat with the provided theme.
@@ -171,24 +171,16 @@ impl SeatState {
         shm: &wl_shm::WlShm,
         surface: wl_surface::WlSurface,
         theme: ThemeSpec,
-    ) -> Result<ThemedPointer<PointerData>, SeatError>
+    ) -> Result<ThemedPointer<()>, SeatError>
     where
-        D: Dispatch<wl_pointer::WlPointer, PointerData>
-            + Dispatch<wl_surface::WlSurface, S>
+        D: Dispatch<wl_pointer::WlPointer, PointerData<()>>
+            + Dispatch<wl_surface::WlSurface, SurfaceData<S>>
             + Dispatch<WpCursorShapeManagerV1, GlobalData>
             + Dispatch<WpCursorShapeDeviceV1, GlobalData>
             + PointerHandler
             + 'static,
-        S: SurfaceDataExt + 'static,
     {
-        self.get_pointer_with_theme_and_data(
-            qh,
-            seat,
-            shm,
-            surface,
-            theme,
-            PointerData::new(seat.clone()),
-        )
+        self.get_pointer_with_theme_and_data(qh, seat, shm, surface, theme, ())
     }
 
     /// Creates a pointer from a seat.
@@ -203,8 +195,8 @@ impl SeatState {
         pointer_data: U,
     ) -> Result<wl_pointer::WlPointer, SeatError>
     where
-        D: Dispatch<wl_pointer::WlPointer, U> + PointerHandler + 'static,
-        U: PointerDataExt + 'static,
+        D: Dispatch<wl_pointer::WlPointer, PointerData<U>> + PointerHandler + 'static,
+        U: Send + Sync + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -213,6 +205,7 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Pointer));
         }
 
+        let pointer_data = PointerData::new(seat.clone(), pointer_data);
         Ok(seat.get_pointer(qh, pointer_data))
     }
 
@@ -231,14 +224,13 @@ impl SeatState {
         pointer_data: U,
     ) -> Result<ThemedPointer<U>, SeatError>
     where
-        D: Dispatch<wl_pointer::WlPointer, U>
-            + Dispatch<wl_surface::WlSurface, S>
+        D: Dispatch<wl_pointer::WlPointer, PointerData<U>>
+            + Dispatch<wl_surface::WlSurface, SurfaceData<S>>
             + Dispatch<WpCursorShapeManagerV1, GlobalData>
             + Dispatch<WpCursorShapeDeviceV1, GlobalData>
             + PointerHandler
             + 'static,
-        S: SurfaceDataExt + 'static,
-        U: PointerDataExt + 'static,
+        U: Send + Sync + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -247,6 +239,7 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Pointer));
         }
 
+        let pointer_data = PointerData::new(seat.clone(), pointer_data);
         let wl_ptr = seat.get_pointer(qh, pointer_data);
 
         if let CursorShapeManagerState::Pending { registry, global } =
@@ -295,9 +288,9 @@ impl SeatState {
         seat: &wl_seat::WlSeat,
     ) -> Result<wl_touch::WlTouch, SeatError>
     where
-        D: Dispatch<wl_touch::WlTouch, TouchData> + TouchHandler + 'static,
+        D: Dispatch<wl_touch::WlTouch, TouchData<()>> + TouchHandler + 'static,
     {
-        self.get_touch_with_data(qh, seat, TouchData::new(seat.clone()))
+        self.get_touch_with_data(qh, seat, ())
     }
 
     /// Creates a touch handle from a seat.
@@ -312,8 +305,8 @@ impl SeatState {
         udata: U,
     ) -> Result<wl_touch::WlTouch, SeatError>
     where
-        D: Dispatch<wl_touch::WlTouch, U> + TouchHandler + 'static,
-        U: TouchDataExt + 'static,
+        D: Dispatch<wl_touch::WlTouch, TouchData<U>> + TouchHandler + 'static,
+        U: Send + Sync + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -322,7 +315,8 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Touch));
         }
 
-        Ok(seat.get_touch(qh, udata))
+        let data = TouchData::new(seat.clone(), udata);
+        Ok(seat.get_touch(qh, data))
     }
 }
 

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -16,6 +16,7 @@ use crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_d
 use crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1;
 use crate::{
     compositor::SurfaceData,
+    dispatch2::Dispatch2,
     globals::GlobalData,
     registry::{ProvidesRegistryState, RegistryHandler},
 };
@@ -214,7 +215,7 @@ impl SeatState {
     /// ## Errors
     ///
     /// This will return [`SeatError::UnsupportedCapability`] if the seat does not support a pointer.
-    pub fn get_pointer_with_theme_and_data<D, S, U>(
+    pub fn get_pointer_with_theme_and_data<D, U>(
         &mut self,
         qh: &QueueHandle<D>,
         seat: &wl_seat::WlSeat,
@@ -225,7 +226,6 @@ impl SeatState {
     ) -> Result<ThemedPointer<U>, SeatError>
     where
         D: Dispatch<wl_pointer::WlPointer, PointerData<U>>
-            + Dispatch<wl_surface::WlSurface, SurfaceData<S>>
             + Dispatch<WpCursorShapeManagerV1, GlobalData>
             + Dispatch<WpCursorShapeDeviceV1, GlobalData>
             + PointerHandler
@@ -419,32 +419,21 @@ pub struct SeatData {
     id: u32,
 }
 
-#[macro_export]
-macro_rules! delegate_seat {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::client::protocol::wl_seat::WlSeat: $crate::seat::SeatData
-            ] => $crate::seat::SeatState
-        );
-    };
-}
-
 #[derive(Debug)]
 struct SeatInner {
     seat: wl_seat::WlSeat,
     data: SeatData,
 }
 
-impl<D> Dispatch<wl_seat::WlSeat, SeatData, D> for SeatState
+impl<D> Dispatch2<wl_seat::WlSeat, D> for SeatData
 where
-    D: Dispatch<wl_seat::WlSeat, SeatData> + SeatHandler,
+    D: SeatHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         seat: &wl_seat::WlSeat,
         event: wl_seat::Event,
-        data: &SeatData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -453,15 +442,15 @@ where
                 let capabilities = wl_seat::Capability::from_bits_truncate(capabilities.into());
 
                 let keyboard = capabilities.contains(wl_seat::Capability::Keyboard);
-                let has_keyboard = data.has_keyboard.load(Ordering::SeqCst);
+                let has_keyboard = self.has_keyboard.load(Ordering::SeqCst);
                 let pointer = capabilities.contains(wl_seat::Capability::Pointer);
-                let has_pointer = data.has_pointer.load(Ordering::SeqCst);
+                let has_pointer = self.has_pointer.load(Ordering::SeqCst);
                 let touch = capabilities.contains(wl_seat::Capability::Touch);
-                let has_touch = data.has_touch.load(Ordering::SeqCst);
+                let has_touch = self.has_touch.load(Ordering::SeqCst);
 
                 // Update capabilities as necessary
                 if keyboard != has_keyboard {
-                    data.has_keyboard.store(keyboard, Ordering::SeqCst);
+                    self.has_keyboard.store(keyboard, Ordering::SeqCst);
 
                     match keyboard {
                         true => state.new_capability(conn, qh, seat.clone(), Capability::Keyboard),
@@ -472,7 +461,7 @@ where
                 }
 
                 if pointer != has_pointer {
-                    data.has_pointer.store(pointer, Ordering::SeqCst);
+                    self.has_pointer.store(pointer, Ordering::SeqCst);
 
                     match pointer {
                         true => state.new_capability(conn, qh, seat.clone(), Capability::Pointer),
@@ -483,7 +472,7 @@ where
                 }
 
                 if touch != has_touch {
-                    data.has_touch.store(touch, Ordering::SeqCst);
+                    self.has_touch.store(touch, Ordering::SeqCst);
 
                     match touch {
                         true => state.new_capability(conn, qh, seat.clone(), Capability::Touch),
@@ -493,7 +482,7 @@ where
             }
 
             wl_seat::Event::Name { name } => {
-                *data.name.lock().unwrap() = Some(name);
+                *self.name.lock().unwrap() = Some(name);
             }
 
             _ => unreachable!(),

--- a/src/seat/pointer/cursor_shape.rs
+++ b/src/seat/pointer/cursor_shape.rs
@@ -1,5 +1,6 @@
 use cursor_icon::CursorIcon;
 
+use crate::dispatch2::Dispatch2;
 use crate::globals::GlobalData;
 use crate::reexports::client::globals::{BindError, GlobalList};
 use crate::reexports::client::protocol::wl_pointer::WlPointer;
@@ -45,15 +46,12 @@ impl CursorShapeManager {
     }
 }
 
-impl<State> Dispatch<WpCursorShapeManagerV1, GlobalData, State> for CursorShapeManager
-where
-    State: Dispatch<WpCursorShapeManagerV1, GlobalData>,
-{
+impl<State> Dispatch2<WpCursorShapeManagerV1, State> for GlobalData {
     fn event(
+        &self,
         _: &mut State,
         _: &WpCursorShapeManagerV1,
         _: <WpCursorShapeManagerV1 as Proxy>::Event,
-        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<State>,
     ) {
@@ -61,15 +59,12 @@ where
     }
 }
 
-impl<State> Dispatch<WpCursorShapeDeviceV1, GlobalData, State> for CursorShapeManager
-where
-    State: Dispatch<WpCursorShapeDeviceV1, GlobalData>,
-{
+impl<State> Dispatch2<WpCursorShapeDeviceV1, State> for GlobalData {
     fn event(
+        &self,
         _: &mut State,
         _: &WpCursorShapeDeviceV1,
         _: <WpCursorShapeDeviceV1 as Proxy>::Event,
-        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<State>,
     ) {

--- a/src/seat/pointer/mod.rs
+++ b/src/seat/pointer/mod.rs
@@ -17,10 +17,7 @@ use wayland_client::{
 use wayland_cursor::{Cursor, CursorTheme};
 use wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1;
 
-use crate::{
-    compositor::{SurfaceData, SurfaceDataExt},
-    error::GlobalError,
-};
+use crate::{compositor::SurfaceData, error::GlobalError};
 
 use super::SeatState;
 
@@ -158,14 +155,23 @@ pub trait PointerHandler: Sized {
 }
 
 #[derive(Debug)]
-pub struct PointerData {
+pub struct PointerData<U> {
     seat: WlSeat,
     pub(crate) inner: Mutex<PointerDataInner>,
+    udata: U,
 }
 
-impl PointerData {
-    pub fn new(seat: WlSeat) -> Self {
-        Self { seat, inner: Default::default() }
+impl<U> PointerData<U> {
+    pub fn new(seat: WlSeat, udata: U) -> Self {
+        Self { seat, inner: Default::default(), udata }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 
     /// The seat associated with this pointer.
@@ -185,48 +191,25 @@ impl PointerData {
     }
 }
 
-pub trait PointerDataExt: Send + Sync {
-    fn pointer_data(&self) -> &PointerData;
-}
-
-impl PointerDataExt for PointerData {
-    fn pointer_data(&self) -> &PointerData {
-        self
-    }
-}
-
 #[macro_export]
 macro_rules! delegate_pointer {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::delegate_pointer!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; pointer: []);
-        $crate::delegate_pointer!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; pointer-only: $crate::seat::pointer::PointerData);
-    };
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, pointer: [$($pointer_data:ty),* $(,)?]) => {
-        $crate::delegate_pointer!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; pointer: [ $($pointer_data),* ]);
-    };
-    (@{$($ty:tt)*}; pointer: []) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
                 $crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1: $crate::globals::GlobalData
             ] => $crate::seat::pointer::cursor_shape::CursorShapeManager
         );
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
                 $crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1: $crate::globals::GlobalData
             ] => $crate::seat::pointer::cursor_shape::CursorShapeManager
         );
-    };
-    (@{$($ty:tt)*}; pointer-only: $pointer_data:ty) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U: Send + Sync + 'static > $ty:
             [
-                $crate::reexports::client::protocol::wl_pointer::WlPointer: $pointer_data
+                $crate::reexports::client::protocol::wl_pointer::WlPointer: $crate::seat::pointer::PointerData<U>
             ] => $crate::seat::SeatState
         );
     };
-    (@$ty:tt; pointer: [$($pointer:ty),*]) => {
-        $crate::delegate_pointer!(@$ty; pointer: []);
-        $( $crate::delegate_pointer!(@$ty; pointer-only: $pointer); )*
-    }
 }
 
 #[derive(Debug, Default)]
@@ -246,20 +229,19 @@ pub(crate) struct PointerDataInner {
     pub(crate) latest_btn: Option<u32>,
 }
 
-impl<D, U> Dispatch<WlPointer, U, D> for SeatState
+impl<D, U> Dispatch<WlPointer, PointerData<U>, D> for SeatState
 where
-    D: Dispatch<WlPointer, U> + PointerHandler,
-    U: PointerDataExt,
+    D: Dispatch<WlPointer, PointerData<U>> + PointerHandler,
+    U: Send + Sync + 'static,
 {
     fn event(
         data: &mut D,
         pointer: &WlPointer,
         event: wl_pointer::Event,
-        udata: &U,
+        udata: &PointerData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let udata = udata.pointer_data();
         let mut guard = udata.inner.lock().unwrap();
         let mut leave_surface = None;
         let kind = match event {
@@ -501,7 +483,7 @@ where
 
 /// Pointer themeing
 #[derive(Debug)]
-pub struct ThemedPointer<U = PointerData, S = SurfaceData> {
+pub struct ThemedPointer<U = (), S = ()> {
     pub(super) themes: Arc<Mutex<Themes>>,
     /// The underlying wl_pointer.
     pub(super) pointer: WlPointer,
@@ -513,19 +495,17 @@ pub struct ThemedPointer<U = PointerData, S = SurfaceData> {
     pub(super) _surface_data: std::marker::PhantomData<S>,
 }
 
-impl<U: PointerDataExt + 'static, S: SurfaceDataExt + 'static> ThemedPointer<U, S> {
+impl<U: Send + Sync + 'static, S: Send + Sync + 'static> ThemedPointer<U, S> {
     /// Set the cursor to the given [`CursorIcon`].
     ///
     /// The cursor icon should be reloaded on every [`PointerEventKind::Enter`] event.
     pub fn set_cursor(&self, conn: &Connection, icon: CursorIcon) -> Result<(), PointerThemeError> {
-        let serial = match self
-            .pointer
-            .data::<U>()
-            .and_then(|data| data.pointer_data().latest_enter_serial())
-        {
-            Some(serial) => serial,
-            None => return Err(PointerThemeError::MissingEnterSerial),
-        };
+        let serial =
+            match self.pointer.data::<PointerData<U>>().and_then(|data| data.latest_enter_serial())
+            {
+                Some(serial) => serial,
+                None => return Err(PointerThemeError::MissingEnterSerial),
+            };
 
         if let Some(shape_device) = self.shape_device.as_ref() {
             shape_device.set_shape(serial, cursor_icon_to_shape(icon, shape_device.version()));
@@ -545,7 +525,7 @@ impl<U: PointerDataExt + 'static, S: SurfaceDataExt + 'static> ThemedPointer<U, 
     ) -> Result<(), PointerThemeError> {
         let mut themes = self.themes.lock().unwrap();
 
-        let scale = self.surface.data::<S>().unwrap().surface_data().scale_factor();
+        let scale = self.surface.data::<SurfaceData<S>>().unwrap().scale_factor();
         for cursor_icon_name in iter::once(&icon.name()).chain(icon.alt_names().iter()) {
             if let Some(cursor) = themes
                 .get_cursor(conn, cursor_icon_name, scale as u32, &self.shm)
@@ -587,8 +567,8 @@ impl<U: PointerDataExt + 'static, S: SurfaceDataExt + 'static> ThemedPointer<U, 
     ///
     /// The cursor should be hidden on every [`PointerEventKind::Enter`] event.
     pub fn hide_cursor(&self) -> Result<(), PointerThemeError> {
-        let data = self.pointer.data::<U>();
-        if let Some(serial) = data.and_then(|data| data.pointer_data().latest_enter_serial()) {
+        let data = self.pointer.data::<PointerData<U>>();
+        if let Some(serial) = data.and_then(|data| data.latest_enter_serial()) {
             self.pointer.set_cursor(serial, None, 0, 0);
             Ok(())
         } else {

--- a/src/seat/pointer/mod.rs
+++ b/src/seat/pointer/mod.rs
@@ -12,14 +12,12 @@ use wayland_client::{
         wl_shm::WlShm,
         wl_surface::WlSurface,
     },
-    Connection, Dispatch, Proxy, QueueHandle, WEnum,
+    Connection, Proxy, QueueHandle, WEnum,
 };
 use wayland_cursor::{Cursor, CursorTheme};
 use wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1;
 
-use crate::{compositor::SurfaceData, error::GlobalError};
-
-use super::SeatState;
+use crate::{compositor::SurfaceData, dispatch2::Dispatch2, error::GlobalError};
 
 #[doc(inline)]
 pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
@@ -191,27 +189,6 @@ impl<U> PointerData<U> {
     }
 }
 
-#[macro_export]
-macro_rules! delegate_pointer {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1: $crate::globals::GlobalData
-            ] => $crate::seat::pointer::cursor_shape::CursorShapeManager
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1: $crate::globals::GlobalData
-            ] => $crate::seat::pointer::cursor_shape::CursorShapeManager
-        );
-        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U: Send + Sync + 'static > $ty:
-            [
-                $crate::reexports::client::protocol::wl_pointer::WlPointer: $crate::seat::pointer::PointerData<U>
-            ] => $crate::seat::SeatState
-        );
-    };
-}
-
 #[derive(Debug, Default)]
 pub(crate) struct PointerDataInner {
     /// Surface the pointer most recently entered
@@ -229,20 +206,20 @@ pub(crate) struct PointerDataInner {
     pub(crate) latest_btn: Option<u32>,
 }
 
-impl<D, U> Dispatch<WlPointer, PointerData<U>, D> for SeatState
+impl<D, U> Dispatch2<WlPointer, D> for PointerData<U>
 where
-    D: Dispatch<WlPointer, PointerData<U>> + PointerHandler,
+    D: PointerHandler,
     U: Send + Sync + 'static,
 {
     fn event(
+        &self,
         data: &mut D,
         pointer: &WlPointer,
         event: wl_pointer::Event,
-        udata: &PointerData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let mut guard = udata.inner.lock().unwrap();
+        let mut guard = self.inner.lock().unwrap();
         let mut leave_surface = None;
         let kind = match event {
             wl_pointer::Event::Enter { surface, surface_x, surface_y, serial } => {

--- a/src/seat/pointer_constraints.rs
+++ b/src/seat/pointer_constraints.rs
@@ -8,6 +8,7 @@ use wayland_protocols::wp::pointer_constraints::zv1::client::{
 };
 
 use crate::{
+    dispatch2::Dispatch2,
     error::GlobalError,
     globals::{GlobalData, ProvidesBoundGlobal},
     registry::GlobalProxy,
@@ -134,17 +135,15 @@ pub struct PointerConstraintData {
     pointer: wl_pointer::WlPointer,
 }
 
-impl<D> Dispatch<zwp_pointer_constraints_v1::ZwpPointerConstraintsV1, GlobalData, D>
-    for PointerConstraintsState
+impl<D> Dispatch2<zwp_pointer_constraints_v1::ZwpPointerConstraintsV1, D> for GlobalData
 where
-    D: Dispatch<zwp_pointer_constraints_v1::ZwpPointerConstraintsV1, GlobalData>
-        + PointerConstraintsHandler,
+    D: PointerConstraintsHandler,
 {
     fn event(
+        &self,
         _data: &mut D,
         _constraints: &zwp_pointer_constraints_v1::ZwpPointerConstraintsV1,
         _event: zwp_pointer_constraints_v1::Event,
-        _: &GlobalData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
@@ -152,69 +151,50 @@ where
     }
 }
 
-impl<D> Dispatch<zwp_confined_pointer_v1::ZwpConfinedPointerV1, PointerConstraintData, D>
-    for PointerConstraintsState
+impl<D> Dispatch2<zwp_confined_pointer_v1::ZwpConfinedPointerV1, D> for PointerConstraintData
 where
-    D: Dispatch<zwp_confined_pointer_v1::ZwpConfinedPointerV1, PointerConstraintData>
-        + PointerConstraintsHandler,
+    D: PointerConstraintsHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         confined_pointer: &zwp_confined_pointer_v1::ZwpConfinedPointerV1,
         event: zwp_confined_pointer_v1::Event,
-        udata: &PointerConstraintData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
         match event {
             zwp_confined_pointer_v1::Event::Confined => {
-                data.confined(conn, qh, confined_pointer, &udata.surface, &udata.pointer)
+                data.confined(conn, qh, confined_pointer, &self.surface, &self.pointer)
             }
             zwp_confined_pointer_v1::Event::Unconfined => {
-                data.unconfined(conn, qh, confined_pointer, &udata.surface, &udata.pointer)
+                data.unconfined(conn, qh, confined_pointer, &self.surface, &self.pointer)
             }
             _ => unreachable!(),
         }
     }
 }
 
-impl<D> Dispatch<zwp_locked_pointer_v1::ZwpLockedPointerV1, PointerConstraintData, D>
-    for PointerConstraintsState
+impl<D> Dispatch2<zwp_locked_pointer_v1::ZwpLockedPointerV1, D> for PointerConstraintData
 where
-    D: Dispatch<zwp_locked_pointer_v1::ZwpLockedPointerV1, PointerConstraintData>
-        + PointerConstraintsHandler,
+    D: PointerConstraintsHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         locked_pointer: &zwp_locked_pointer_v1::ZwpLockedPointerV1,
         event: zwp_locked_pointer_v1::Event,
-        udata: &PointerConstraintData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
         match event {
             zwp_locked_pointer_v1::Event::Locked => {
-                data.locked(conn, qh, locked_pointer, &udata.surface, &udata.pointer)
+                data.locked(conn, qh, locked_pointer, &self.surface, &self.pointer)
             }
             zwp_locked_pointer_v1::Event::Unlocked => {
-                data.unlocked(conn, qh, locked_pointer, &udata.surface, &udata.pointer)
+                data.unlocked(conn, qh, locked_pointer, &self.surface, &self.pointer)
             }
             _ => unreachable!(),
         }
     }
-}
-
-#[macro_export]
-macro_rules! delegate_pointer_constraints {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::wp::pointer_constraints::zv1::client::zwp_pointer_constraints_v1::ZwpPointerConstraintsV1: $crate::globals::GlobalData
-        ] => $crate::seat::pointer_constraints::PointerConstraintsState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::wp::pointer_constraints::zv1::client::zwp_confined_pointer_v1::ZwpConfinedPointerV1: $crate::seat::pointer_constraints::PointerConstraintData
-        ] => $crate::seat::pointer_constraints::PointerConstraintsState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::wp::pointer_constraints::zv1::client::zwp_locked_pointer_v1::ZwpLockedPointerV1: $crate::seat::pointer_constraints::PointerConstraintData
-        ] => $crate::seat::pointer_constraints::PointerConstraintsState);
-    };
 }

--- a/src/seat/relative_pointer.rs
+++ b/src/seat/relative_pointer.rs
@@ -5,7 +5,7 @@ use wayland_protocols::wp::relative_pointer::zv1::client::{
     zwp_relative_pointer_manager_v1, zwp_relative_pointer_v1,
 };
 
-use crate::{error::GlobalError, globals::GlobalData, registry::GlobalProxy};
+use crate::{dispatch2::Dispatch2, error::GlobalError, globals::GlobalData, registry::GlobalProxy};
 
 #[derive(Debug)]
 pub struct RelativePointerState {
@@ -64,17 +64,15 @@ pub struct RelativePointerData {
     wl_pointer: wl_pointer::WlPointer,
 }
 
-impl<D> Dispatch<zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1, GlobalData, D>
-    for RelativePointerState
+impl<D> Dispatch2<zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1, D> for GlobalData
 where
-    D: Dispatch<zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1, GlobalData>
-        + RelativePointerHandler,
+    D: RelativePointerHandler,
 {
     fn event(
+        &self,
         _data: &mut D,
         _manager: &zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
         _event: zwp_relative_pointer_manager_v1::Event,
-        _: &GlobalData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {
@@ -82,17 +80,15 @@ where
     }
 }
 
-impl<D> Dispatch<zwp_relative_pointer_v1::ZwpRelativePointerV1, RelativePointerData, D>
-    for RelativePointerState
+impl<D> Dispatch2<zwp_relative_pointer_v1::ZwpRelativePointerV1, D> for RelativePointerData
 where
-    D: Dispatch<zwp_relative_pointer_v1::ZwpRelativePointerV1, RelativePointerData>
-        + RelativePointerHandler,
+    D: RelativePointerHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         relative_pointer: &zwp_relative_pointer_v1::ZwpRelativePointerV1,
         event: zwp_relative_pointer_v1::Event,
-        udata: &RelativePointerData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -109,7 +105,7 @@ where
                     conn,
                     qh,
                     relative_pointer,
-                    &udata.wl_pointer,
+                    &self.wl_pointer,
                     RelativeMotionEvent {
                         utime: ((utime_hi as u64) << 32) | (utime_lo as u64),
                         delta: (dx, dy),
@@ -120,16 +116,4 @@ where
             _ => unreachable!(),
         }
     }
-}
-
-#[macro_export]
-macro_rules! delegate_relative_pointer {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::wp::relative_pointer::zv1::client::zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1: $crate::globals::GlobalData
-        ] => $crate::seat::relative_pointer::RelativePointerState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::wp::relative_pointer::zv1::client::zwp_relative_pointer_v1::ZwpRelativePointerV1: $crate::seat::relative_pointer::RelativePointerData
-        ] => $crate::seat::relative_pointer::RelativePointerState);
-    };
 }

--- a/src/seat/touch.rs
+++ b/src/seat/touch.rs
@@ -9,16 +9,24 @@ use wayland_client::{Connection, Dispatch, QueueHandle};
 use crate::seat::SeatState;
 
 #[derive(Debug)]
-pub struct TouchData {
+pub struct TouchData<U> {
     seat: WlSeat,
-
     inner: Mutex<TouchDataInner>,
+    udata: U,
 }
 
-impl TouchData {
+impl<U> TouchData<U> {
     /// Create the new touch data associated with the given seat.
-    pub fn new(seat: WlSeat) -> Self {
-        Self { seat, inner: Default::default() }
+    pub fn new(seat: WlSeat, udata: U) -> Self {
+        Self { seat, inner: Default::default(), udata }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 
     /// Get the associated seat from the data.
@@ -44,33 +52,12 @@ pub(crate) struct TouchDataInner {
 #[macro_export]
 macro_rules! delegate_touch {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::delegate_touch!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; touch: $crate::seat::touch::TouchData);
-    };
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, touch: [$($td:ty),* $(,)?]) => {
-        $crate::delegate_touch!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; [ $($td),* ]);
-    };
-    (@{$($ty:tt)*}; touch: $td:ty) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U: Send + Sync + 'static > $ty:
             [
-                $crate::reexports::client::protocol::wl_touch::WlTouch: $td
+                $crate::reexports::client::protocol::wl_touch::WlTouch: $crate::seat::touch::TouchData<U>
             ] => $crate::seat::SeatState
         );
     };
-    (@$ty:tt; [$($td:ty),*] ) => {
-        $(
-            $crate::delegate_touch!(@$ty, touch: $td);
-        )*
-    };
-}
-
-pub trait TouchDataExt: Send + Sync {
-    fn touch_data(&self) -> &TouchData;
-}
-
-impl TouchDataExt for TouchData {
-    fn touch_data(&self) -> &TouchData {
-        self
-    }
 }
 
 pub trait TouchHandler: Sized {
@@ -158,20 +145,18 @@ pub trait TouchHandler: Sized {
     fn cancel(&mut self, conn: &Connection, qh: &QueueHandle<Self>, touch: &WlTouch);
 }
 
-impl<D, U> Dispatch<WlTouch, U, D> for SeatState
+impl<D, U> Dispatch<WlTouch, TouchData<U>, D> for SeatState
 where
-    D: Dispatch<WlTouch, U> + TouchHandler,
-    U: TouchDataExt,
+    D: Dispatch<WlTouch, TouchData<U>> + TouchHandler,
 {
     fn event(
         data: &mut D,
         touch: &WlTouch,
         event: TouchEvent,
-        udata: &U,
+        udata: &TouchData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let udata = udata.touch_data();
         let mut guard: std::sync::MutexGuard<'_, TouchDataInner> = udata.inner.lock().unwrap();
 
         let mut save_event = false;

--- a/src/seat/touch.rs
+++ b/src/seat/touch.rs
@@ -6,7 +6,7 @@ use wayland_client::protocol::wl_surface::WlSurface;
 use wayland_client::protocol::wl_touch::{Event as TouchEvent, WlTouch};
 use wayland_client::{Connection, Dispatch, QueueHandle};
 
-use crate::seat::SeatState;
+use crate::dispatch2::Dispatch2;
 
 #[derive(Debug)]
 pub struct TouchData<U> {
@@ -47,17 +47,6 @@ pub(crate) struct TouchDataInner {
 
     /// The serial of the latest touch down event
     latest_down: Option<u32>,
-}
-
-#[macro_export]
-macro_rules! delegate_touch {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U: Send + Sync + 'static > $ty:
-            [
-                $crate::reexports::client::protocol::wl_touch::WlTouch: $crate::seat::touch::TouchData<U>
-            ] => $crate::seat::SeatState
-        );
-    };
 }
 
 pub trait TouchHandler: Sized {
@@ -145,19 +134,19 @@ pub trait TouchHandler: Sized {
     fn cancel(&mut self, conn: &Connection, qh: &QueueHandle<Self>, touch: &WlTouch);
 }
 
-impl<D, U> Dispatch<WlTouch, TouchData<U>, D> for SeatState
+impl<D, U> Dispatch2<WlTouch, D> for TouchData<U>
 where
     D: Dispatch<WlTouch, TouchData<U>> + TouchHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         touch: &WlTouch,
         event: TouchEvent,
-        udata: &TouchData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let mut guard: std::sync::MutexGuard<'_, TouchDataInner> = udata.inner.lock().unwrap();
+        let mut guard: std::sync::MutexGuard<'_, TouchDataInner> = self.inner.lock().unwrap();
 
         let mut save_event = false;
         let mut process_events = false;

--- a/src/session_lock/dispatch.rs
+++ b/src/session_lock/dispatch.rs
@@ -1,25 +1,21 @@
-use crate::globals::GlobalData;
+use crate::{dispatch2::Dispatch2, globals::GlobalData};
 use std::sync::atomic::Ordering;
-use wayland_client::{Connection, Dispatch, QueueHandle};
+use wayland_client::{Connection, QueueHandle};
 use wayland_protocols::ext::session_lock::v1::client::{
     ext_session_lock_manager_v1, ext_session_lock_surface_v1, ext_session_lock_v1,
 };
 
 use super::{
-    SessionLock, SessionLockData, SessionLockHandler, SessionLockState, SessionLockSurface,
+    SessionLock, SessionLockData, SessionLockHandler, SessionLockSurface,
     SessionLockSurfaceConfigure, SessionLockSurfaceData,
 };
 
-impl<D> Dispatch<ext_session_lock_manager_v1::ExtSessionLockManagerV1, GlobalData, D>
-    for SessionLockState
-where
-    D: Dispatch<ext_session_lock_manager_v1::ExtSessionLockManagerV1, GlobalData>,
-{
+impl<D> Dispatch2<ext_session_lock_manager_v1::ExtSessionLockManagerV1, D> for GlobalData {
     fn event(
+        &self,
         _state: &mut D,
         _proxy: &ext_session_lock_manager_v1::ExtSessionLockManagerV1,
         _event: ext_session_lock_manager_v1::Event,
-        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
@@ -27,15 +23,15 @@ where
     }
 }
 
-impl<D> Dispatch<ext_session_lock_v1::ExtSessionLockV1, SessionLockData, D> for SessionLockState
+impl<D> Dispatch2<ext_session_lock_v1::ExtSessionLockV1, D> for SessionLockData
 where
-    D: Dispatch<ext_session_lock_v1::ExtSessionLockV1, SessionLockData> + SessionLockHandler,
+    D: SessionLockHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         proxy: &ext_session_lock_v1::ExtSessionLockV1,
         event: ext_session_lock_v1::Event,
-        _: &SessionLockData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -54,17 +50,16 @@ where
     }
 }
 
-impl<D> Dispatch<ext_session_lock_surface_v1::ExtSessionLockSurfaceV1, SessionLockSurfaceData, D>
-    for SessionLockState
+impl<D> Dispatch2<ext_session_lock_surface_v1::ExtSessionLockSurfaceV1, D>
+    for SessionLockSurfaceData
 where
-    D: Dispatch<ext_session_lock_surface_v1::ExtSessionLockSurfaceV1, SessionLockSurfaceData>
-        + SessionLockHandler,
+    D: SessionLockHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         proxy: &ext_session_lock_surface_v1::ExtSessionLockSurfaceV1,
         event: ext_session_lock_surface_v1::Event,
-        _: &SessionLockSurfaceData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {

--- a/src/session_lock/mod.rs
+++ b/src/session_lock/mod.rs
@@ -193,24 +193,3 @@ impl SessionLockState {
         Ok(SessionLock(inner))
     }
 }
-
-#[macro_export]
-macro_rules! delegate_session_lock {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::ext::session_lock::v1::client::ext_session_lock_manager_v1::ExtSessionLockManagerV1: $crate::globals::GlobalData
-            ] => $crate::session_lock::SessionLockState
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::ext::session_lock::v1::client::ext_session_lock_v1::ExtSessionLockV1: $crate::session_lock::SessionLockData
-            ] => $crate::session_lock::SessionLockState
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::ext::session_lock::v1::client::ext_session_lock_surface_v1::ExtSessionLockSurfaceV1: $crate::session_lock::SessionLockSurfaceData
-            ] => $crate::session_lock::SessionLockState
-        );
-    };
-}

--- a/src/shell/wlr_layer/dispatch.rs
+++ b/src/shell/wlr_layer/dispatch.rs
@@ -1,7 +1,8 @@
-use wayland_client::{Connection, Dispatch, QueueHandle};
+use wayland_client::{Connection, QueueHandle};
 use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
 
 use crate::{
+    dispatch2::Dispatch2,
     error::GlobalError,
     globals::{GlobalData, ProvidesBoundGlobal},
 };
@@ -34,15 +35,15 @@ impl ProvidesBoundGlobal<zwlr_layer_shell_v1::ZwlrLayerShellV1, 4> for LayerShel
     }
 }
 
-impl<D> Dispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, GlobalData, D> for LayerShell
+impl<D> Dispatch2<zwlr_layer_shell_v1::ZwlrLayerShellV1, D> for GlobalData
 where
-    D: Dispatch<zwlr_layer_shell_v1::ZwlrLayerShellV1, GlobalData> + LayerShellHandler + 'static,
+    D: LayerShellHandler + 'static,
 {
     fn event(
+        &self,
         _: &mut D,
         _: &zwlr_layer_shell_v1::ZwlrLayerShellV1,
         _: zwlr_layer_shell_v1::Event,
-        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
@@ -50,17 +51,15 @@ where
     }
 }
 
-impl<D> Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, LayerSurfaceData, D> for LayerShell
+impl<D> Dispatch2<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, D> for LayerSurfaceData
 where
-    D: Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, LayerSurfaceData>
-        + LayerShellHandler
-        + 'static,
+    D: LayerShellHandler + 'static,
 {
     fn event(
+        &self,
         data: &mut D,
         surface: &zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
         event: zwlr_layer_surface_v1::Event,
-        _udata: &LayerSurfaceData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {

--- a/src/shell/wlr_layer/mod.rs
+++ b/src/shell/wlr_layer/mod.rs
@@ -275,18 +275,6 @@ impl LayerSurfaceData {
     }
 }
 
-#[macro_export]
-macro_rules! delegate_layer {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::ZwlrLayerShellV1: $crate::globals::GlobalData
-        ] => $crate::shell::wlr_layer::LayerShell);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrLayerSurfaceV1: $crate::shell::wlr_layer::LayerSurfaceData
-        ] => $crate::shell::wlr_layer::LayerShell);
-    };
-}
-
 #[derive(Debug)]
 struct LayerSurfaceInner {
     wl_surface: Surface,

--- a/src/shell/xdg/fallback_frame.rs
+++ b/src/shell/xdg/fallback_frame.rs
@@ -91,7 +91,7 @@ pub struct FallbackFrame<State> {
 
 impl<State> FallbackFrame<State>
 where
-    State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+    State: Dispatch<WlSurface, SurfaceData<()>> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
 {
     pub fn new(
         parent: &impl WaylandSurface,
@@ -327,7 +327,7 @@ where
 
 impl<State> DecorationsFrame for FallbackFrame<State>
 where
-    State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+    State: Dispatch<WlSurface, SurfaceData<()>> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
 {
     fn set_scaling_factor(&mut self, scale_factor: f64) {
         self.scale_factor = scale_factor;
@@ -621,7 +621,8 @@ impl FrameRenderData {
         queue_handle: &QueueHandle<State>,
     ) -> Self
     where
-        State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+        State:
+            Dispatch<WlSurface, SurfaceData<()>> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
     {
         let parts = [
             // Header.

--- a/src/shell/xdg/mod.rs
+++ b/src/shell/xdg/mod.rs
@@ -17,6 +17,7 @@ use crate::reexports::protocols::xdg::shell::client::{
 };
 
 use crate::compositor::Surface;
+use crate::dispatch2::Dispatch2;
 use crate::error::GlobalError;
 use crate::globals::{GlobalData, ProvidesBoundGlobal};
 use crate::registry::GlobalProxy;
@@ -291,21 +292,6 @@ impl XdgSurface for XdgShellSurface {
     }
 }
 
-#[macro_export]
-macro_rules! delegate_xdg_shell {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::xdg::shell::client::xdg_wm_base::XdgWmBase: $crate::globals::GlobalData
-        ] => $crate::shell::xdg::XdgShell);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-        $crate::reexports::protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1: $crate::globals::GlobalData
-        ] => $crate::shell::xdg::XdgShell);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1: $crate::shell::xdg::window::WindowData
-        ] => $crate::shell::xdg::XdgShell);
-    };
-}
-
 impl Drop for XdgShellSurface {
     fn drop(&mut self) {
         // Surface role must be destroyed before the wl_surface
@@ -326,15 +312,12 @@ impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, { XdgShell::API_VERSION_MAX }> 
     }
 }
 
-impl<D> Dispatch<xdg_wm_base::XdgWmBase, GlobalData, D> for XdgShell
-where
-    D: Dispatch<xdg_wm_base::XdgWmBase, GlobalData>,
-{
+impl<D> Dispatch2<xdg_wm_base::XdgWmBase, D> for GlobalData {
     fn event(
+        &self,
         _state: &mut D,
         xdg_wm_base: &xdg_wm_base::XdgWmBase,
         event: xdg_wm_base::Event,
-        _data: &GlobalData,
         _conn: &Connection,
         _qh: &QueueHandle<D>,
     ) {

--- a/src/shell/xdg/popup.rs
+++ b/src/shell/xdg/popup.rs
@@ -54,7 +54,7 @@ impl Popup {
         wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 5>,
     ) -> Result<Popup, GlobalError>
     where
-        D: Dispatch<wl_surface::WlSurface, SurfaceData>
+        D: Dispatch<wl_surface::WlSurface, SurfaceData<()>>
             + Dispatch<xdg_surface::XdgSurface, PopupData>
             + Dispatch<xdg_popup::XdgPopup, PopupData>
             + PopupHandler

--- a/src/shell/xdg/popup.rs
+++ b/src/shell/xdg/popup.rs
@@ -1,5 +1,6 @@
 use crate::{
     compositor::{Surface, SurfaceData},
+    dispatch2::Dispatch2,
     error::GlobalError,
     globals::ProvidesBoundGlobal,
     shell::xdg::XdgShellSurface,
@@ -196,19 +197,19 @@ pub trait PopupHandler: Sized {
     fn done(&mut self, conn: &Connection, qh: &QueueHandle<Self>, popup: &Popup);
 }
 
-impl<D> Dispatch<xdg_surface::XdgSurface, PopupData, D> for PopupData
+impl<D> Dispatch2<xdg_surface::XdgSurface, D> for PopupData
 where
-    D: Dispatch<xdg_surface::XdgSurface, PopupData> + PopupHandler,
+    D: PopupHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         xdg_surface: &xdg_surface::XdgSurface,
         event: xdg_surface::Event,
-        pdata: &PopupData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let popup = match pdata.popup() {
+        let popup = match self.popup() {
             Some(popup) => popup,
             None => return,
         };
@@ -239,19 +240,19 @@ where
     }
 }
 
-impl<D> Dispatch<xdg_popup::XdgPopup, PopupData, D> for PopupData
+impl<D> Dispatch2<xdg_popup::XdgPopup, D> for PopupData
 where
-    D: Dispatch<xdg_popup::XdgPopup, PopupData> + PopupHandler,
+    D: PopupHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         _: &xdg_popup::XdgPopup,
         event: xdg_popup::Event,
-        pdata: &PopupData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let popup = match pdata.popup() {
+        let popup = match self.popup() {
             Some(popup) => popup,
             None => return,
         };
@@ -273,16 +274,4 @@ where
             _ => unreachable!(),
         }
     }
-}
-
-#[macro_export]
-macro_rules! delegate_xdg_popup {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::xdg::shell::client::xdg_popup::XdgPopup: $crate::shell::xdg::popup::PopupData
-        ] => $crate::shell::xdg::popup::PopupData);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::xdg::shell::client::xdg_surface::XdgSurface: $crate::shell::xdg::popup::PopupData
-        ] => $crate::shell::xdg::popup::PopupData);
-    };
 }

--- a/src/shell/xdg/window/inner.rs
+++ b/src/shell/xdg/window/inner.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Mutex,
 };
 
-use wayland_client::{Connection, Dispatch, QueueHandle};
+use wayland_client::{Connection, QueueHandle};
 use wayland_protocols::{
     xdg::decoration::zv1::client::{
         zxdg_decoration_manager_v1,
@@ -17,6 +17,7 @@ use wayland_protocols::{
 };
 
 use crate::{
+    dispatch2::Dispatch2,
     error::GlobalError,
     globals::{GlobalData, ProvidesBoundGlobal},
     shell::xdg::{XdgShell, XdgShellSurface},
@@ -57,15 +58,15 @@ impl ProvidesBoundGlobal<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, 1>
     }
 }
 
-impl<D> Dispatch<xdg_surface::XdgSurface, WindowData, D> for XdgShell
+impl<D> Dispatch2<xdg_surface::XdgSurface, D> for WindowData
 where
-    D: Dispatch<xdg_surface::XdgSurface, WindowData> + WindowHandler,
+    D: WindowHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         xdg_surface: &xdg_surface::XdgSurface,
         event: xdg_surface::Event,
-        _: &WindowData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -85,15 +86,15 @@ where
     }
 }
 
-impl<D> Dispatch<xdg_toplevel::XdgToplevel, WindowData, D> for XdgShell
+impl<D> Dispatch2<xdg_toplevel::XdgToplevel, D> for WindowData
 where
-    D: Dispatch<xdg_toplevel::XdgToplevel, WindowData> + WindowHandler,
+    D: WindowHandler,
 {
     fn event(
+        &self,
         data: &mut D,
         toplevel: &xdg_toplevel::XdgToplevel,
         event: xdg_toplevel::Event,
-        _: &WindowData,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
@@ -179,15 +180,15 @@ where
 
 // XDG decoration
 
-impl<D> Dispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, GlobalData, D> for XdgShell
+impl<D> Dispatch2<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, D> for GlobalData
 where
-    D: Dispatch<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1, GlobalData> + WindowHandler,
+    D: WindowHandler,
 {
     fn event(
+        &self,
         _: &mut D,
         _: &zxdg_decoration_manager_v1::ZxdgDecorationManagerV1,
         _: zxdg_decoration_manager_v1::Event,
-        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
@@ -195,15 +196,15 @@ where
     }
 }
 
-impl<D> Dispatch<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1, WindowData, D> for XdgShell
+impl<D> Dispatch2<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1, D> for WindowData
 where
-    D: Dispatch<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1, WindowData> + WindowHandler,
+    D: WindowHandler,
 {
     fn event(
+        &self,
         _: &mut D,
         decoration: &zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1,
         event: zxdg_toplevel_decoration_v1::Event,
-        _: &WindowData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {

--- a/src/shell/xdg/window/mod.rs
+++ b/src/shell/xdg/window/mod.rs
@@ -307,15 +307,3 @@ impl PartialEq for Window {
 
 #[derive(Debug, Clone)]
 pub struct WindowData(pub(crate) Weak<WindowInner>);
-
-#[macro_export]
-macro_rules! delegate_xdg_window {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::xdg::shell::client::xdg_surface::XdgSurface: $crate::shell::xdg::window::WindowData
-        ] => $crate::shell::xdg::XdgShell);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols::xdg::shell::client::xdg_toplevel::XdgToplevel: $crate::shell::xdg::window::WindowData
-        ] => $crate::shell::xdg::XdgShell);
-    };
-}

--- a/src/shm/mod.rs
+++ b/src/shm/mod.rs
@@ -11,6 +11,7 @@ use wayland_client::{
 };
 
 use crate::{
+    dispatch2::Dispatch2,
     error::GlobalError,
     globals::{GlobalData, ProvidesBoundGlobal},
 };
@@ -69,49 +70,15 @@ pub enum CreatePoolError {
     Create(#[from] io::Error),
 }
 
-/// Delegates the handling of [`wl_shm`] to some [`Shm`].
-///
-/// This macro requires two things, the type that will delegate to [`Shm`] and a closure specifying how
-/// to obtain the state object.
-///
-/// ```
-/// use smithay_client_toolkit::shm::{ShmHandler, Shm};
-/// use smithay_client_toolkit::delegate_shm;
-///
-/// struct ExampleApp {
-///     /// The state object that will be our delegate.
-///     shm: Shm,
-/// }
-///
-/// // Use the macro to delegate wl_shm to Shm.
-/// delegate_shm!(ExampleApp);
-///
-/// // You must implement the ShmHandler trait to provide a way to access the Shm from your data type.
-/// impl ShmHandler for ExampleApp {
-///     fn shm_state(&mut self) -> &mut Shm {
-///         &mut self.shm
-///     }
-/// }
-#[macro_export]
-macro_rules! delegate_shm {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::client::protocol::wl_shm::WlShm: $crate::globals::GlobalData
-            ] => $crate::shm::Shm
-        );
-    };
-}
-
-impl<D> Dispatch<wl_shm::WlShm, GlobalData, D> for Shm
+impl<D> Dispatch2<wl_shm::WlShm, D> for GlobalData
 where
-    D: Dispatch<wl_shm::WlShm, GlobalData> + ShmHandler,
+    D: ShmHandler,
 {
     fn event(
+        &self,
         state: &mut D,
         _proxy: &wl_shm::WlShm,
         event: wl_shm::Event,
-        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {

--- a/src/subcompositor.rs
+++ b/src/subcompositor.rs
@@ -6,6 +6,7 @@ use crate::reexports::client::protocol::wl_surface::WlSurface;
 use crate::reexports::client::{Connection, Dispatch, Proxy, QueueHandle};
 
 use crate::compositor::SurfaceData;
+use crate::dispatch2::Dispatch2;
 use crate::globals::GlobalData;
 
 #[derive(Debug)]
@@ -61,15 +62,12 @@ impl SubcompositorState {
     }
 }
 
-impl<D> Dispatch<WlSubsurface, SubsurfaceData, D> for SubcompositorState
-where
-    D: Dispatch<WlSubsurface, SubsurfaceData>,
-{
+impl<D> Dispatch2<WlSubsurface, D> for SubsurfaceData {
     fn event(
+        &self,
         _: &mut D,
         _: &WlSubsurface,
         _: <WlSubsurface as Proxy>::Event,
-        _: &SubsurfaceData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
@@ -77,15 +75,12 @@ where
     }
 }
 
-impl<D> Dispatch<WlSubcompositor, GlobalData, D> for SubcompositorState
-where
-    D: Dispatch<WlSubcompositor, GlobalData>,
-{
+impl<D> Dispatch2<WlSubcompositor, D> for GlobalData {
     fn event(
+        &self,
         _: &mut D,
         _: &WlSubcompositor,
         _: <WlSubcompositor as Proxy>::Event,
-        _: &GlobalData,
         _: &Connection,
         _: &QueueHandle<D>,
     ) {
@@ -109,33 +104,4 @@ impl SubsurfaceData {
     pub fn surface(&self) -> &WlSurface {
         &self.surface
     }
-}
-
-#[macro_export]
-macro_rules! delegate_subcompositor {
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::delegate_subcompositor!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; subsurface: []);
-        $crate::delegate_subcompositor!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; subsurface-only: $crate::subcompositor::SubsurfaceData);
-    };
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, subsurface: [$($subsurface: ty),*$(,)?]) => {
-        $crate::delegate_subcompositor!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; subsurface: [ $($subsurface),* ]);
-    };
-    (@{$($ty:tt)*}; subsurface: []) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
-            [
-                $crate::reexports::client::protocol::wl_subcompositor::WlSubcompositor: $crate::globals::GlobalData
-            ] => $crate::subcompositor::SubcompositorState
-        );
-    };
-    (@{$($ty:tt)*}; subsurface-only: $subsurface:ty) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
-            [
-                    $crate::reexports::client::protocol::wl_subsurface::WlSubsurface: $subsurface
-            ] => $crate::subcompositor::SubcompositorState
-        );
-    };
-    (@$ty:tt; subsurface: [ $($subsurface:ty),+ ]) => {
-        $crate::delegate_subcompositor!(@$ty; subsurface: []);
-        $( $crate::delegate_subcompositor!(@$ty; subsurface-only: $subsurface); )*
-    };
 }

--- a/src/subcompositor.rs
+++ b/src/subcompositor.rs
@@ -33,9 +33,10 @@ impl SubcompositorState {
         queue_handle: &QueueHandle<State>,
     ) -> (WlSubsurface, WlSurface)
     where
-        State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+        State:
+            Dispatch<WlSurface, SurfaceData<()>> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
     {
-        let surface_data = SurfaceData::new(Some(parent.clone()), 1);
+        let surface_data = SurfaceData::new(Some(parent.clone()), 1, ());
         let surface = self.compositor.create_surface(queue_handle, surface_data);
         let subsurface_data = SubsurfaceData::new(surface.clone());
         let subsurface =
@@ -49,9 +50,10 @@ impl SubcompositorState {
         queue_handle: &QueueHandle<State>,
     ) -> Option<WlSubsurface>
     where
-        State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+        State:
+            Dispatch<WlSurface, SurfaceData<()>> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
     {
-        let parent = surface.data::<SurfaceData>().unwrap().parent_surface();
+        let parent = surface.data::<SurfaceData<()>>().unwrap().parent_surface();
         let subsurface_data = SubsurfaceData::new(surface.clone());
         parent.map(|parent| {
             self.subcompositor.get_subsurface(surface, parent, queue_handle, subsurface_data)


### PR DESCRIPTION
I've though of some alternate ways to define [`Dispatch`](https://docs.rs/wayland-client/latest/wayland_client/trait.Dispatch.html) (as an alternative to the change in https://github.com/Smithay/smithay/pull/1327). Today I had an idea for a way to prototype such a thing outside of `wayland-rs`. Due to the orphan rule, we can't create any blanket impls of `Dispatch` that are generic over the `State` the trait is implemented for (unless our crate is the one that defined the type `I`). But we can provide a `delegate_dispatch2!` macro that will add such a blanket impl for a particular concrete type.

`Dispatch2` is similar to `wayland_client::Dispatch`, but it's now implemented for the object user data type instead of the state type, uses `&self` for the argument pointer to the user data, and removes the extra `State = Self` type bound.

Implementing this for the user data seems reasonable, since we already need to pass a user data when sending a request that creates an object. So the type passed there indicates what dispatch implementation to use. (It would also work to use `State: Dispatch<UserData, I>` instead of `UserData: Dispatch<I, State>`; but it would *not* work to use `State: Dispatch<I, UserData>` where `I` is a type from a different crate and `State` is generic. That isn't allowed under the orphan rule. So of the alternatives that work, this draft uses the one that seemed best to me.)

This draft uses `Dispatch2` and eliminates the dispatch macros used in the `simple_window` example, except:
- We can't make this generic over `KeyboardDataExt`, `PointerDataExt`, `SurfaceDataExt`, `RequestDataExt` (at least if this trait were part of wayland-rs, and not the same crate)
  * We can change the API to instead wrap the user data in a type provided by sctk. This would actually be potentially simpler anyway, since a trait impl wouldn't be needed. That isn't done here.
- For registries, we likewise can't implement for the `GlobalList` type, since that is a `wayland-client` type, not an sctk one

`event_created_child()` is unchanged, but we should think of better ways to handle that too.

It is still necessary to have `Dispatch` bounds in methods of the `*State` types that create objects, but not in the implementations of `Dispatch2`. Though type bounds shouldn't be needed anymore if this were moved to wayland-rs and replaced `Dispatch`.

If an API change like this is good, it could be incorporated in the next breaking update to wayland-rs. Does anyone see non-obvious issues with this?