### PR TITLE
example/wgpu: Fix `required-feature` to use `system`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4"
 memmap2 = "0.9.0"
 rustix = { version = "1.0.7", features = ["fs", "pipe", "shm"] }
 thiserror = "2.0.12"
-wayland-client = "0.31.1"
+wayland-client = "0.31.14"
 wayland-cursor = "0.31.0"
 wayland-protocols = { version = "0.32.9", features = ["client", "staging", "unstable"] }
 wayland-protocols-experimental = { version = "20251230.0.1", features = ["client"] }
@@ -61,4 +61,4 @@ pollster = "0.3.0"
 
 [[example]]
 name = "wgpu"
-required-features = ["wayland-backend/client_system"]
+required-features = ["system"]


### PR DESCRIPTION
This can't reference `wayland-backend` now that is no longer an explicit dependency.

Also update `wayland-client` version to require version that has `system` feature.