### PR TITLE
Udata `*Data` types wrap user provided `U` instead of having a `*DataExt` trait

### DIFF
--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -85,6 +85,7 @@ fn main() {
                 seat_and_serial: None,
                 surface: Some(window.wl_surface().clone()),
                 app_id: Some(String::from("io.github.smithay.client-toolkit.SimpleWindow")),
+                udata: (),
             },
         )
     }
@@ -258,9 +259,9 @@ impl WindowHandler for SimpleWindow {
 }
 
 impl ActivationHandler for SimpleWindow {
-    type RequestData = RequestData;
+    type RequestUdata = ();
 
-    fn new_token(&mut self, token: String, _data: &Self::RequestData) {
+    fn new_token(&mut self, token: String, _data: &RequestData<()>) {
         self.xdg_activation
             .as_ref()
             .unwrap()

--- a/examples/themed_window.rs
+++ b/examples/themed_window.rs
@@ -387,7 +387,7 @@ impl SeatHandler for SimpleWindow {
             let surface = self.compositor_state.create_surface(qh);
             let themed_pointer = self
                 .seat_state
-                .get_pointer_with_theme(
+                .get_pointer_with_theme::<_, ()>(
                     qh,
                     &seat,
                     self.shm_state.wl_shm(),
@@ -563,7 +563,7 @@ impl PointerHandler for SimpleWindow {
 
 impl SimpleWindow {
     fn frame_action(&mut self, pointer: &wl_pointer::WlPointer, serial: u32, action: FrameAction) {
-        let pointer_data = pointer.data::<PointerData>().unwrap();
+        let pointer_data = pointer.data::<PointerData<()>>().unwrap();
         let seat = pointer_data.seat();
         match action {
             FrameAction::Close => self.exit = true,

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -15,7 +15,7 @@ use crate::{
 /// Use a custom type implementing [`RequestDataExt`] to store more data with a token request
 /// e.g. to identify which request produced which token.
 #[derive(Debug, Clone)]
-pub struct RequestData {
+pub struct RequestData<U> {
     /// App_id of the application requesting the token, if applicable
     pub app_id: Option<String>,
     /// Seat and serial of the window requesting the token, if applicable.
@@ -28,44 +28,17 @@ pub struct RequestData {
     /// *Warning*: Many compositors will issue invalid tokens for requests from
     /// unfocused surfaces. There is no way to detect this from the client-side.
     pub surface: Option<wl_surface::WlSurface>,
-}
 
-/// Data attached to a token request
-pub trait RequestDataExt: Send + Sync {
-    /// App_id of the application requesting the token, if applicable
-    fn app_id(&self) -> Option<&str>;
-    /// Seat and serial of the window requesting the token, if applicable.
-    ///
-    /// *Warning*: Many compositors will issue invalid tokens for requests without
-    /// recent serials. There is no way to detect this from the client-side.
-    fn seat_and_serial(&self) -> Option<(&wl_seat::WlSeat, u32)>;
-    /// Surface of the window requesting the token, if applicable.
-    ///
-    /// *Warning*: Many compositors will issue invalid tokens for requests from
-    /// unfocused surfaces. There is no way to detect this from the client-side.
-    fn surface(&self) -> Option<&wl_surface::WlSurface>;
-}
-
-impl RequestDataExt for RequestData {
-    fn app_id(&self) -> Option<&str> {
-        self.app_id.as_deref()
-    }
-
-    fn seat_and_serial(&self) -> Option<(&wl_seat::WlSeat, u32)> {
-        self.seat_and_serial.as_ref().map(|(seat, serial)| (seat, *serial))
-    }
-
-    fn surface(&self) -> Option<&wl_surface::WlSurface> {
-        self.surface.as_ref()
-    }
+    pub udata: U,
 }
 
 /// Handler for xdg-activation
 pub trait ActivationHandler: Sized {
     /// Data type used for requesting activation tokens
-    type RequestData: RequestDataExt;
+    // TODO: Default to `()` if default associated types are ever supported
+    type RequestUdata;
     /// A token was issued for a previous request with `data`.
-    fn new_token(&mut self, token: String, data: &Self::RequestData);
+    fn new_token(&mut self, token: String, data: &RequestData<Self::RequestUdata>);
 }
 
 /// State for xdg-activation
@@ -96,33 +69,21 @@ impl ActivationState {
     ///
     /// To attach custom data to the request implement [`RequestDataExt`] on a custom type
     /// and use [`Self::request_token_with_data`] instead.
-    pub fn request_token<D>(&self, qh: &QueueHandle<D>, request_data: RequestData)
+    pub fn request_token<D, U>(&self, qh: &QueueHandle<D>, request_data: RequestData<U>)
     where
-        D: ActivationHandler<RequestData = RequestData>,
-        D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData> + 'static,
-    {
-        Self::request_token_with_data::<D, RequestData>(self, qh, request_data)
-    }
-
-    /// Request a token for surface activation with user data.
-    ///
-    /// To use this method you need to provide [`delegate_activation`][crate::delegate_activation] with your custom type.
-    /// E.g. `delegate_activation!(SimpleWindow, MyRequestData);`
-    pub fn request_token_with_data<D, R>(&self, qh: &QueueHandle<D>, request_data: R)
-    where
-        D: ActivationHandler<RequestData = R>,
-        D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, R> + 'static,
-        R: RequestDataExt + 'static,
+        D: ActivationHandler<RequestUdata = U>,
+        D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData<U>> + 'static,
+        U: Send + Sync + 'static,
     {
         let token = self.xdg_activation.get_activation_token(qh, request_data);
-        let data = token.data::<R>().unwrap();
-        if let Some(app_id) = data.app_id() {
+        let data = token.data::<RequestData<U>>().unwrap();
+        if let Some(app_id) = &data.app_id {
             token.set_app_id(String::from(app_id));
         }
-        if let Some((seat, serial)) = data.seat_and_serial() {
-            token.set_serial(serial, seat);
+        if let Some((seat, serial)) = &data.seat_and_serial {
+            token.set_serial(*serial, seat);
         }
-        if let Some(surface) = data.surface() {
+        if let Some(surface) = &data.surface {
             token.set_surface(surface);
         }
         token.commit();
@@ -151,17 +112,17 @@ impl ProvidesBoundGlobal<xdg_activation_v1::XdgActivationV1, 1> for ActivationSt
     }
 }
 
-impl<D, R> Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, R, D> for ActivationState
+impl<D, U> Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData<U>, D>
+    for ActivationState
 where
-    D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, R>
-        + ActivationHandler<RequestData = R>,
-    R: RequestDataExt,
+    D: Dispatch<xdg_activation_token_v1::XdgActivationTokenV1, RequestData<U>>
+        + ActivationHandler<RequestUdata = U>,
 {
     fn event(
         state: &mut D,
         _proxy: &xdg_activation_token_v1::XdgActivationTokenV1,
         event: <xdg_activation_token_v1::XdgActivationTokenV1 as Proxy>::Event,
-        data: &R,
+        data: &RequestData<U>,
         _conn: &wayland_client::Connection,
         _qhandle: &QueueHandle<D>,
     ) {
@@ -174,17 +135,8 @@ where
 #[macro_export]
 macro_rules! delegate_activation {
    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_v1::XdgActivationV1: $crate::globals::GlobalData
-            ] => $crate::activation::ActivationState
-        );
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_token_v1::XdgActivationTokenV1: $crate::activation::RequestData
-            ] => $crate::activation::ActivationState
-        );
-    };
+       $crate::delegate_activation!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty, ());
+   };
    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, $data: ty) => {
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
@@ -193,7 +145,7 @@ macro_rules! delegate_activation {
         );
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
-                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_token_v1::XdgActivationTokenV1: $data
+                $crate::reexports::protocols::xdg::activation::v1::client::xdg_activation_token_v1::XdgActivationTokenV1: $crate::activation::RequestData<$data>
             ] => $crate::activation::ActivationState
         );
     };

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -77,16 +77,6 @@ pub trait CompositorHandler: Sized {
     );
 }
 
-pub trait SurfaceDataExt: Send + Sync {
-    fn surface_data(&self) -> &SurfaceData;
-}
-
-impl SurfaceDataExt for SurfaceData {
-    fn surface_data(&self) -> &SurfaceData {
-        self
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct CompositorState {
     wl_compositor: wl_compositor::WlCompositor,
@@ -116,27 +106,30 @@ impl CompositorState {
 
     pub fn create_surface<D>(&self, qh: &QueueHandle<D>) -> wl_surface::WlSurface
     where
-        D: Dispatch<wl_surface::WlSurface, SurfaceData> + 'static,
+        D: Dispatch<wl_surface::WlSurface, SurfaceData<()>> + 'static,
     {
-        self.create_surface_with_data(qh, Default::default())
+        self.create_surface_with_data(qh, None, 1, ())
     }
 
     pub fn create_surface_with_data<D, U>(
         &self,
         qh: &QueueHandle<D>,
+        parent_surface: Option<WlSurface>,
+        scale_factor: i32,
         data: U,
     ) -> wl_surface::WlSurface
     where
-        D: Dispatch<wl_surface::WlSurface, U> + 'static,
-        U: SurfaceDataExt + 'static,
+        D: Dispatch<wl_surface::WlSurface, SurfaceData<U>> + 'static,
+        U: Send + Sync + 'static,
     {
+        let data = SurfaceData::new(parent_surface, scale_factor, data);
         self.wl_compositor.create_surface(qh, data)
     }
 }
 
 /// Data associated with a [`WlSurface`].
 #[derive(Debug)]
-pub struct SurfaceData {
+pub struct SurfaceData<U> {
     /// The scale factor of the output with the highest scale factor.
     pub(crate) scale_factor: AtomicI32,
 
@@ -147,16 +140,27 @@ pub struct SurfaceData {
 
     /// The inner mutable storage.
     inner: Mutex<SurfaceDataInner>,
+
+    udata: U,
 }
 
-impl SurfaceData {
+impl<U> SurfaceData<U> {
     /// Create a new surface that initially reports the given scale factor and parent.
-    pub fn new(parent_surface: Option<WlSurface>, scale_factor: i32) -> Self {
+    pub fn new(parent_surface: Option<WlSurface>, scale_factor: i32, udata: U) -> Self {
         Self {
             scale_factor: AtomicI32::new(scale_factor),
             parent_surface,
             inner: Default::default(),
+            udata,
         }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 
     /// The scale factor of the output with the highest scale factor.
@@ -183,11 +187,13 @@ impl SurfaceData {
     }
 }
 
+/* XXX
 impl Default for SurfaceData {
     fn default() -> Self {
         Self::new(None, 1)
     }
 }
+*/
 
 #[derive(Debug)]
 struct SurfaceDataInner {
@@ -222,9 +228,9 @@ impl Surface {
         qh: &QueueHandle<D>,
     ) -> Result<Self, GlobalError>
     where
-        D: Dispatch<wl_surface::WlSurface, SurfaceData> + 'static,
+        D: Dispatch<wl_surface::WlSurface, SurfaceData<()>> + 'static,
     {
-        Self::with_data(compositor, qh, Default::default())
+        Self::with_data(compositor, qh, None, 1, ())
     }
 
     pub fn with_data<D, U>(
@@ -233,12 +239,15 @@ impl Surface {
             { CompositorState::API_VERSION_MAX },
         >,
         qh: &QueueHandle<D>,
+        parent_surface: Option<WlSurface>,
+        scale_factor: i32,
         data: U,
     ) -> Result<Self, GlobalError>
     where
-        D: Dispatch<wl_surface::WlSurface, U> + 'static,
+        D: Dispatch<wl_surface::WlSurface, SurfaceData<U>> + 'static,
         U: Send + Sync + 'static,
     {
+        let data = SurfaceData::new(parent_surface, scale_factor, data);
         Ok(Surface(compositor.bound_global()?.create_surface(qh, data)))
     }
 
@@ -262,53 +271,40 @@ impl Drop for Surface {
 #[macro_export]
 macro_rules! delegate_compositor {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::delegate_compositor!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; surface: []);
-        $crate::delegate_compositor!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; surface-only: $crate::compositor::SurfaceData);
-    };
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, surface: [$($surface: ty),*$(,)?]) => {
-        $crate::delegate_compositor!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; surface: [ $($surface),* ]);
-    };
-    (@{$($ty:tt)*}; surface: []) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
                 $crate::reexports::client::protocol::wl_compositor::WlCompositor: $crate::globals::GlobalData
             ] => $crate::compositor::CompositorState
         );
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
                 $crate::reexports::client::protocol::wl_callback::WlCallback: $crate::reexports::client::protocol::wl_surface::WlSurface
             ] => $crate::compositor::CompositorState
         );
-    };
-    (@{$($ty:tt)*}; surface-only: $surface:ty) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U: Send + Sync + 'static > $ty:
             [
-                    $crate::reexports::client::protocol::wl_surface::WlSurface: $surface
+                $crate::reexports::client::protocol::wl_surface::WlSurface: $crate::compositor::SurfaceData<U>
             ] => $crate::compositor::CompositorState
         );
     };
-    (@$ty:tt; surface: [ $($surface:ty),+ ]) => {
-        $crate::delegate_compositor!(@$ty; surface: []);
-        $(
-            $crate::delegate_compositor!(@$ty; surface-only: $surface);
-        )*
-    };
 }
 
-impl<D, U> Dispatch<wl_surface::WlSurface, U, D> for CompositorState
+impl<D, U> Dispatch<wl_surface::WlSurface, SurfaceData<U>, D> for CompositorState
 where
-    D: Dispatch<wl_surface::WlSurface, U> + CompositorHandler + OutputHandler + 'static,
-    U: SurfaceDataExt + 'static,
+    D: Dispatch<wl_surface::WlSurface, SurfaceData<U>>
+        + CompositorHandler
+        + OutputHandler
+        + 'static,
+    U: Send + Sync + 'static,
 {
     fn event(
         state: &mut D,
         surface: &wl_surface::WlSurface,
         event: wl_surface::Event,
-        data: &U,
+        data: &SurfaceData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let data = data.surface_data();
         let mut inner = data.inner.lock().unwrap();
 
         let mut enter_or_leave_output: Option<(wl_output::WlOutput, bool)> = None;
@@ -365,8 +361,7 @@ where
             OutputState::add_scale_watcher(state, move |state, conn, qh, _| {
                 let id = id.clone();
                 if let Ok(surface) = wl_surface::WlSurface::from_id(conn, id) {
-                    if let Some(data) = surface.data::<U>() {
-                        let data = data.surface_data();
+                    if let Some(data) = surface.data::<SurfaceData<U>>() {
                         let inner = data.inner.lock().unwrap();
                         dispatch_surface_state_updates(state, conn, qh, &surface, data, inner);
                     }
@@ -389,11 +384,13 @@ fn dispatch_surface_state_updates<D, U>(
     conn: &Connection,
     qh: &QueueHandle<D>,
     surface: &WlSurface,
-    data: &SurfaceData,
+    data: &SurfaceData<U>,
     mut inner: MutexGuard<SurfaceDataInner>,
 ) where
-    D: Dispatch<wl_surface::WlSurface, U> + CompositorHandler + OutputHandler + 'static,
-    U: SurfaceDataExt + 'static,
+    D: Dispatch<wl_surface::WlSurface, SurfaceData<U>>
+        + CompositorHandler
+        + OutputHandler
+        + 'static,
 {
     let current_scale = data.scale_factor.load(Ordering::Relaxed);
     let (factor, transform) = match inner

--- a/src/data_device_manager/data_source.rs
+++ b/src/data_device_manager/data_source.rs
@@ -10,15 +10,21 @@ use crate::reexports::client::{
 use super::{data_device::DataDevice, DataDeviceManagerState, WritePipe};
 
 #[derive(Debug, Default)]
-pub struct DataSourceData {}
-
-pub trait DataSourceDataExt: Send + Sync {
-    fn data_source_data(&self) -> &DataSourceData;
+pub struct DataSourceData<U> {
+    udata: U,
 }
 
-impl DataSourceDataExt for DataSourceData {
-    fn data_source_data(&self) -> &DataSourceData {
-        self
+impl<U> DataSourceData<U> {
+    pub fn new(udata: U) -> Self {
+        Self { udata }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 }
 
@@ -68,16 +74,15 @@ pub trait DataSourceHandler: Sized {
     );
 }
 
-impl<D, U> Dispatch<wl_data_source::WlDataSource, U, D> for DataDeviceManagerState
+impl<D, U> Dispatch<wl_data_source::WlDataSource, DataSourceData<U>, D> for DataDeviceManagerState
 where
-    D: Dispatch<wl_data_source::WlDataSource, U> + DataSourceHandler,
-    U: DataSourceDataExt,
+    D: Dispatch<wl_data_source::WlDataSource, DataSourceData<U>> + DataSourceHandler,
 {
     fn event(
         state: &mut D,
         source: &wl_data_source::WlDataSource,
         event: <wl_data_source::WlDataSource as wayland_client::Proxy>::Event,
-        _data: &U,
+        _data: &DataSourceData<U>,
         conn: &wayland_client::Connection,
         qh: &wayland_client::QueueHandle<D>,
     ) {

--- a/src/data_device_manager/mod.rs
+++ b/src/data_device_manager/mod.rs
@@ -48,7 +48,7 @@ impl DataDeviceManagerState {
         mime_types: impl IntoIterator<Item = T>,
     ) -> CopyPasteSource
     where
-        D: Dispatch<WlDataSource, DataSourceData> + 'static,
+        D: Dispatch<WlDataSource, DataSourceData<()>> + 'static,
     {
         CopyPasteSource { inner: self.create_data_source(qh, mime_types, None) }
     }
@@ -61,7 +61,7 @@ impl DataDeviceManagerState {
         dnd_actions: DndAction,
     ) -> DragSource
     where
-        D: Dispatch<WlDataSource, DataSourceData> + 'static,
+        D: Dispatch<WlDataSource, DataSourceData<()>> + 'static,
     {
         DragSource { inner: self.create_data_source(qh, mime_types, Some(dnd_actions)) }
     }
@@ -74,7 +74,7 @@ impl DataDeviceManagerState {
         dnd_actions: Option<DndAction>,
     ) -> WlDataSource
     where
-        D: Dispatch<WlDataSource, DataSourceData> + 'static,
+        D: Dispatch<WlDataSource, DataSourceData<()>> + 'static,
     {
         let source = self.manager.create_data_source(qh, Default::default());
 
@@ -135,9 +135,9 @@ macro_rules! delegate_data_device {
             [
                 $crate::reexports::client::protocol::wl_data_offer::WlDataOffer: $crate::data_device_manager::data_offer::DataOfferData
             ] => $crate::data_device_manager::DataDeviceManagerState);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty:
             [
-                $crate::reexports::client::protocol::wl_data_source::WlDataSource: $crate::data_device_manager::data_source::DataSourceData
+                $crate::reexports::client::protocol::wl_data_source::WlDataSource: $crate::data_device_manager::data_source::DataSourceData<U>
             ] => $crate::data_device_manager::DataDeviceManagerState
         );
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:

--- a/src/seat/input_method.rs
+++ b/src/seat/input_method.rs
@@ -45,13 +45,26 @@ impl InputMethodManager {
     /// seat.
     pub fn get_input_method<State>(&self, qh: &QueueHandle<State>, seat: &WlSeat) -> InputMethod
     where
-        State: Dispatch<ZwpInputMethodV2, InputMethodData, State> + 'static,
+        State: Dispatch<ZwpInputMethodV2, InputMethodData<()>, State> + 'static,
+    {
+        self.get_input_method_with_data(qh, seat, ())
+    }
+
+    pub fn get_input_method_with_data<State, U>(
+        &self,
+        qh: &QueueHandle<State>,
+        seat: &WlSeat,
+        udata: U,
+    ) -> InputMethod
+    where
+        State: Dispatch<ZwpInputMethodV2, InputMethodData<U>, State> + 'static,
+        U: Send + Sync + 'static,
     {
         InputMethod {
             input_method: self.manager.get_input_method(
                 seat,
                 qh,
-                InputMethodData::new(seat.clone()),
+                InputMethodData::new(seat.clone(), udata),
             ),
         }
     }
@@ -109,23 +122,23 @@ impl InputMethod {
         self.input_method.delete_surrounding_text(before_length, after_length)
     }
 
-    pub fn commit(&self) {
-        let data = self.input_method.data::<InputMethodData>().unwrap();
+    pub fn commit<U: Send + Sync + 'static>(&self) {
+        let data = self.input_method.data::<InputMethodData<U>>().unwrap();
         let inner = data.inner.lock().unwrap();
         self.input_method.commit(inner.serial.0)
     }
 }
 
 #[derive(Debug)]
-pub struct InputMethodData {
+pub struct InputMethodData<U> {
     seat: WlSeat,
-
     inner: Mutex<InputMethodDataInner>,
+    udata: U,
 }
 
-impl InputMethodData {
+impl<U> InputMethodData<U> {
     /// Create the new input method data associated with the given seat.
-    pub fn new(seat: WlSeat) -> Self {
+    pub fn new(seat: WlSeat, udata: U) -> Self {
         Self {
             seat,
             inner: Mutex::new(InputMethodDataInner {
@@ -133,7 +146,16 @@ impl InputMethodData {
                 current_state: Default::default(),
                 serial: Wrapping(0),
             }),
+            udata,
         }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 
     /// Get the associated seat from the data.
@@ -246,20 +268,10 @@ macro_rules! delegate_input_method {
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::reexports::protocols_misc::zwp_input_method_v2::client::zwp_input_method_manager_v2::ZwpInputMethodManagerV2: $crate::globals::GlobalData
         ] => $crate::seat::input_method::InputMethodManager);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_misc::zwp_input_method_v2::client::zwp_input_method_v2::ZwpInputMethodV2: $crate::seat::input_method::InputMethodData
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty: [
+            $crate::reexports::protocols_misc::zwp_input_method_v2::client::zwp_input_method_v2::ZwpInputMethodV2: $crate::seat::input_method::InputMethodData<U>
         ] => $crate::seat::input_method::InputMethod);
     };
-}
-
-pub trait InputMethodDataExt: Send + Sync {
-    fn input_method_data(&self) -> &InputMethodData;
-}
-
-impl InputMethodDataExt for InputMethodData {
-    fn input_method_data(&self) -> &InputMethodData {
-        self
-    }
 }
 
 pub trait InputMethodHandler: Sized {
@@ -278,21 +290,20 @@ pub trait InputMethodHandler: Sized {
     );
 }
 
-impl<D, U> Dispatch<ZwpInputMethodV2, U, D> for InputMethod
+impl<D, U> Dispatch<ZwpInputMethodV2, InputMethodData<U>, D> for InputMethod
 where
-    D: Dispatch<ZwpInputMethodV2, U> + InputMethodHandler,
-    U: InputMethodDataExt,
+    D: Dispatch<ZwpInputMethodV2, InputMethodData<U>> + InputMethodHandler,
 {
     fn event(
         data: &mut D,
         input_method: &ZwpInputMethodV2,
         event: zwp_input_method_v2::Event,
-        udata: &U,
+        udata: &InputMethodData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
         let mut imdata: std::sync::MutexGuard<'_, InputMethodDataInner> =
-            udata.input_method_data().inner.lock().unwrap();
+            udata.inner.lock().unwrap();
 
         use zwp_input_method_v2::Event;
 
@@ -402,7 +413,7 @@ mod test {
 
     fn assert_is_delegate<T>()
     where
-        T: wayland_client::Dispatch<ZwpInputMethodV2, InputMethodData>,
+        T: wayland_client::Dispatch<ZwpInputMethodV2, InputMethodData<()>>,
     {
     }
 

--- a/src/seat/input_method_v3.rs
+++ b/src/seat/input_method_v3.rs
@@ -74,13 +74,26 @@ impl InputMethodManager {
     /// seat.
     pub fn get_input_method<State>(&self, qh: &QueueHandle<State>, seat: &WlSeat) -> InputMethod
     where
-        State: Dispatch<XxInputMethodV1, InputMethodData, State> + 'static,
+        State: Dispatch<XxInputMethodV1, InputMethodData<()>, State> + 'static,
+    {
+        self.get_input_method_with_data(qh, seat, ())
+    }
+
+    pub fn get_input_method_with_data<State, U>(
+        &self,
+        qh: &QueueHandle<State>,
+        seat: &WlSeat,
+        udata: U,
+    ) -> InputMethod
+    where
+        State: Dispatch<XxInputMethodV1, InputMethodData<U>, State> + 'static,
+        U: Send + Sync + 'static,
     {
         InputMethod {
             input_method: self.manager.get_input_method(
                 seat,
                 qh,
-                InputMethodData::new(seat.clone()),
+                InputMethodData::new(seat.clone(), udata),
             ),
         }
     }
@@ -226,13 +239,16 @@ impl InputMethod {
         self.input_method.move_cursor(cursor, anchor)
     }
 
-    pub fn commit(&self) {
-        let data = self.input_method.data::<InputMethodData>().unwrap();
+    pub fn commit<U>(&self)
+    where
+        U: Send + Sync + 'static,
+    {
+        let data = self.input_method.data::<InputMethodData<U>>().unwrap();
         let inner = &data.inner.lock().unwrap();
         self.input_method.commit(inner.serial.0)
     }
 
-    pub fn get_input_popup_surface<D>(
+    pub fn get_input_popup_surface<D, U>(
         &self,
         qh: &QueueHandle<D>,
         surface: impl Into<Surface>,
@@ -240,8 +256,9 @@ impl InputMethod {
     ) -> Popup
     where
         D: Dispatch<XxInputPopupSurfaceV2, PopupData> + 'static,
+        U: Send + Sync + 'static,
     {
-        let data = self.input_method.data::<InputMethodData>().unwrap();
+        let data = self.input_method.data::<InputMethodData<U>>().unwrap();
         let surface = surface.into();
         Popup {
             input_method: self.input_method.clone(),
@@ -257,15 +274,15 @@ impl InputMethod {
 }
 
 #[derive(Debug)]
-pub struct InputMethodData {
+pub struct InputMethodData<U> {
     seat: WlSeat,
-
     inner: Arc<Mutex<InputMethodDataInner>>,
+    udata: U,
 }
 
-impl InputMethodData {
+impl<U> InputMethodData<U> {
     /// Create the new touch data associated with the given seat.
-    pub fn new(seat: WlSeat) -> Self {
+    pub fn new(seat: WlSeat, udata: U) -> Self {
         Self {
             seat,
             inner: Arc::new(Mutex::new(InputMethodDataInner {
@@ -273,7 +290,16 @@ impl InputMethodData {
                 current_state: Default::default(),
                 serial: Wrapping(0),
             })),
+            udata,
         }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 
     /// Get the associated seat from the data.
@@ -594,8 +620,8 @@ macro_rules! delegate_input_method_v3 {
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_method_manager_v2::XxInputMethodManagerV2: $crate::globals::GlobalData
         ] => $crate::seat::input_method_v3::InputMethodManager);
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
-            $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_method_v1::XxInputMethodV1: $crate::seat::input_method_v3::InputMethodData
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty: [
+            $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_method_v1::XxInputMethodV1: $crate::seat::input_method_v3::InputMethodData<U>
         ] => $crate::seat::input_method_v3::InputMethod);
         $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
             $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_popup_surface_v2::XxInputPopupSurfaceV2: $crate::seat::input_method_v3::PopupData
@@ -604,16 +630,6 @@ macro_rules! delegate_input_method_v3 {
             $crate::reexports::protocols_experimental::input_method::v1::client::xx_input_popup_positioner_v1::XxInputPopupPositionerV1: $crate::seat::input_method_v3::PositionerData
         ] => $crate::seat::input_method_v3::PopupPositioner);
     };
-}
-
-pub trait InputMethodDataExt: Send + Sync {
-    fn input_method_data(&self) -> &InputMethodData;
-}
-
-impl InputMethodDataExt for InputMethodData {
-    fn input_method_data(&self) -> &InputMethodData {
-        self
-    }
 }
 
 pub trait InputMethodHandler: Sized {
@@ -633,21 +649,19 @@ pub trait InputMethodHandler: Sized {
     fn handle_unavailable(&mut self, qh: &QueueHandle<Self>, input_method: &XxInputMethodV1);
 }
 
-impl<D, U> Dispatch<XxInputMethodV1, U, D> for InputMethod
+impl<D, U> Dispatch<XxInputMethodV1, InputMethodData<U>, D> for InputMethod
 where
-    D: Dispatch<XxInputMethodV1, U> + InputMethodHandler,
-    U: InputMethodDataExt,
+    D: Dispatch<XxInputMethodV1, InputMethodData<U>> + InputMethodHandler,
 {
     fn event(
         data: &mut D,
         input_method: &XxInputMethodV1,
         event: xx_input_method_v1::Event,
-        udata: &U,
+        udata: &InputMethodData<U>,
         _conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let mut imdata: MutexGuard<'_, InputMethodDataInner> =
-            udata.input_method_data().inner.lock().unwrap();
+        let mut imdata: MutexGuard<'_, InputMethodDataInner> = udata.inner.lock().unwrap();
 
         use xx_input_method_v1::Event;
 
@@ -791,7 +805,10 @@ mod test {
 
     fn assert_is_delegate<T>()
     where
-        T: wayland_client::Dispatch<protocol::xx_input_method_v1::XxInputMethodV1, InputMethodData>,
+        T: wayland_client::Dispatch<
+            protocol::xx_input_method_v1::XxInputMethodV1,
+            InputMethodData<()>,
+        >,
     {
     }
 

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -65,17 +65,24 @@ impl SeatState {
         rmlvo: Option<RMLVO>,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D>>
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, ()>>
             + SeatHandler
             + KeyboardHandler
             + 'static,
     {
         let udata = match rmlvo {
-            Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo)?,
-            None => KeyboardData::new(seat.clone()),
+            Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo, ())?,
+            None => KeyboardData::new(seat.clone(), ()),
         };
 
-        self.get_keyboard_with_data(qh, seat, udata)
+        let inner =
+            self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
+
+        if !inner.data.has_keyboard.load(Ordering::SeqCst) {
+            return Err(SeatError::UnsupportedCapability(Capability::Keyboard).into());
+        }
+
+        Ok(seat.get_keyboard(qh, udata))
     }
 
     /// Creates a keyboard from a seat.
@@ -95,8 +102,11 @@ impl SeatState {
         udata: U,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, U> + SeatHandler + KeyboardHandler + 'static,
-        U: KeyboardDataExt<State = D> + 'static,
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, U>>
+            + SeatHandler
+            + KeyboardHandler
+            + 'static,
+        U: Send + Sync + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -104,6 +114,8 @@ impl SeatState {
         if !inner.data.has_keyboard.load(Ordering::SeqCst) {
             return Err(SeatError::UnsupportedCapability(Capability::Keyboard).into());
         }
+
+        let udata = KeyboardData::new(seat.clone(), udata);
 
         Ok(seat.get_keyboard(qh, udata))
     }
@@ -338,7 +350,7 @@ pub struct RMLVO {
     pub options: Option<String>,
 }
 
-pub struct KeyboardData<T> {
+pub struct KeyboardData<D, U> {
     seat: wl_seat::WlSeat,
     first_event: AtomicBool,
     xkb_context: Mutex<xkb::Context>,
@@ -347,12 +359,13 @@ pub struct KeyboardData<T> {
     xkb_state: Mutex<Option<xkb::State>>,
     xkb_compose: Mutex<Option<xkb::compose::State>>,
     #[cfg(feature = "calloop")]
-    repeat_data: Arc<Mutex<Option<RepeatData<T>>>>,
+    repeat_data: Arc<Mutex<Option<RepeatData<D>>>>,
     focus: Mutex<Option<wl_surface::WlSurface>>,
-    _phantom_data: PhantomData<T>,
+    _phantom_data: PhantomData<D>,
+    udata: U,
 }
 
-impl<T> Debug for KeyboardData<T> {
+impl<T, U> Debug for KeyboardData<T, U> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KeyboardData").finish_non_exhaustive()
     }
@@ -361,32 +374,23 @@ impl<T> Debug for KeyboardData<T> {
 #[macro_export]
 macro_rules! delegate_keyboard {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U > $ty:
             [
-                $crate::reexports::client::protocol::wl_keyboard::WlKeyboard: $crate::seat::keyboard::KeyboardData<$ty>
-            ] => $crate::seat::SeatState
-        );
-    };
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, keyboard: [$($udata:ty),* $(,)?]) => {
-        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
-            [
-                $(
-                    $crate::reexports::client::protocol::wl_keyboard::WlKeyboard: $udata,
-                )*
+                $crate::reexports::client::protocol::wl_keyboard::WlKeyboard: $crate::seat::keyboard::KeyboardData<$ty, U>
             ] => $crate::seat::SeatState
         );
     };
 }
 
 // SAFETY: The state does not share state with any other rust types.
-unsafe impl<T> Send for KeyboardData<T> {}
+unsafe impl<T, U: Send> Send for KeyboardData<T, U> {}
 // SAFETY: The state is guarded by a mutex since libxkbcommon has no internal synchronization.
-unsafe impl<T> Sync for KeyboardData<T> {}
+unsafe impl<T, U: Sync> Sync for KeyboardData<T, U> {}
 
-impl<T> KeyboardData<T> {
-    pub fn new(seat: wl_seat::WlSeat) -> Self {
+impl<T, U> KeyboardData<T, U> {
+    pub fn new(seat: wl_seat::WlSeat, udata: U) -> Self {
         let xkb_context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
-        let udata = KeyboardData {
+        let keyboard_data = KeyboardData {
             seat,
             first_event: AtomicBool::new(false),
             xkb_context: Mutex::new(xkb_context),
@@ -397,18 +401,31 @@ impl<T> KeyboardData<T> {
             repeat_data: Arc::new(Mutex::new(None)),
             focus: Mutex::new(None),
             _phantom_data: PhantomData,
+            udata,
         };
 
-        udata.init_compose();
+        keyboard_data.init_compose();
 
-        udata
+        keyboard_data
+    }
+
+    pub fn data(&mut self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &U {
+        &self.udata
     }
 
     pub fn seat(&self) -> &wl_seat::WlSeat {
         &self.seat
     }
 
-    pub fn from_rmlvo(seat: wl_seat::WlSeat, rmlvo: RMLVO) -> Result<Self, KeyboardError> {
+    pub fn from_rmlvo(
+        seat: wl_seat::WlSeat,
+        rmlvo: RMLVO,
+        udata: U,
+    ) -> Result<Self, KeyboardError> {
         let xkb_context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
         let keymap = xkb::Keymap::new_from_names(
             &xkb_context,
@@ -426,7 +443,7 @@ impl<T> KeyboardData<T> {
 
         let xkb_state = Some(xkb::State::new(&keymap.unwrap()));
 
-        let udata = KeyboardData {
+        let keyboard_data = KeyboardData {
             seat,
             first_event: AtomicBool::new(false),
             xkb_context: Mutex::new(xkb_context),
@@ -437,11 +454,12 @@ impl<T> KeyboardData<T> {
             repeat_data: Arc::new(Mutex::new(None)),
             focus: Mutex::new(None),
             _phantom_data: PhantomData,
+            udata,
         };
 
-        udata.init_compose();
+        keyboard_data.init_compose();
 
-        Ok(udata)
+        Ok(keyboard_data)
     }
 
     fn init_compose(&self) {
@@ -484,39 +502,18 @@ impl<T> KeyboardData<T> {
     }
 }
 
-pub trait KeyboardDataExt: Send + Sync {
-    type State: 'static;
-    fn keyboard_data(&self) -> &KeyboardData<Self::State>;
-    fn keyboard_data_mut(&mut self) -> &mut KeyboardData<Self::State>;
-}
-
-impl<T: 'static> KeyboardDataExt for KeyboardData<T> {
-    /// The type of the user defined state
-    type State = T;
-    fn keyboard_data(&self) -> &KeyboardData<T> {
-        self
-    }
-
-    fn keyboard_data_mut(&mut self) -> &mut KeyboardData<T> {
-        self
-    }
-}
-
-impl<D, U> Dispatch<wl_keyboard::WlKeyboard, U, D> for SeatState
+impl<D, U> Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, U>, D> for SeatState
 where
-    D: Dispatch<wl_keyboard::WlKeyboard, U> + KeyboardHandler + 'static,
-    U: KeyboardDataExt<State = D>,
+    D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, U>> + KeyboardHandler + 'static,
 {
     fn event(
         data: &mut D,
         keyboard: &wl_keyboard::WlKeyboard,
         event: wl_keyboard::Event,
-        udata: &U,
+        udata: &KeyboardData<D, U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let udata = udata.keyboard_data();
-
         // The compositor has no way to tell clients if the seat is not version 4 or above.
         // In this case, send a synthetic repeat info event using the default repeat values used by the X
         // server.

--- a/src/seat/keyboard/mod.rs
+++ b/src/seat/keyboard/mod.rs
@@ -58,14 +58,14 @@ impl SeatState {
     /// ## Errors
     ///
     /// This will return [`SeatError::UnsupportedCapability`] if the seat does not support a keyboard.
-    pub fn get_keyboard<D, T: 'static>(
+    pub fn get_keyboard<D>(
         &mut self,
         qh: &QueueHandle<D>,
         seat: &wl_seat::WlSeat,
         rmlvo: Option<RMLVO>,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<T>>
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D>>
             + SeatHandler
             + KeyboardHandler
             + 'static,
@@ -96,7 +96,7 @@ impl SeatState {
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
         D: Dispatch<wl_keyboard::WlKeyboard, U> + SeatHandler + KeyboardHandler + 'static,
-        U: KeyboardDataExt + 'static,
+        U: KeyboardDataExt<State = D> + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -504,8 +504,8 @@ impl<T: 'static> KeyboardDataExt for KeyboardData<T> {
 
 impl<D, U> Dispatch<wl_keyboard::WlKeyboard, U, D> for SeatState
 where
-    D: Dispatch<wl_keyboard::WlKeyboard, U> + KeyboardHandler,
-    U: KeyboardDataExt,
+    D: Dispatch<wl_keyboard::WlKeyboard, U> + KeyboardHandler + 'static,
+    U: KeyboardDataExt<State = D>,
 {
     fn event(
         data: &mut D,

--- a/src/seat/keyboard/repeat.rs
+++ b/src/seat/keyboard/repeat.rs
@@ -55,17 +55,16 @@ impl SeatState {
     /// This will return [`SeatError::UnsupportedCapability`] if the seat does not support a keyboard.
     ///
     /// [`EventSource`]: calloop::EventSource
-    pub fn get_keyboard_with_repeat<D, T>(
+    pub fn get_keyboard_with_repeat<D>(
         &mut self,
         qh: &QueueHandle<D>,
         seat: &wl_seat::WlSeat,
         rmlvo: Option<RMLVO>,
-        loop_handle: LoopHandle<'static, T>,
-        callback: RepeatCallback<T>,
+        loop_handle: LoopHandle<'static, D>,
+        callback: RepeatCallback<D>,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<T>> + KeyboardHandler + 'static,
-        T: 'static,
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D>> + KeyboardHandler + 'static,
     {
         let udata = match rmlvo {
             Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo)?,
@@ -99,7 +98,7 @@ impl SeatState {
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
         D: Dispatch<wl_keyboard::WlKeyboard, U> + KeyboardHandler + 'static,
-        U: KeyboardDataExt + 'static,
+        U: KeyboardDataExt<State = D> + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;

--- a/src/seat/keyboard/repeat.rs
+++ b/src/seat/keyboard/repeat.rs
@@ -10,8 +10,8 @@ use wayland_client::{
 };
 
 use super::{
-    Capability, KeyEvent, KeyboardData, KeyboardDataExt, KeyboardError, KeyboardHandler,
-    RepeatInfo, SeatError, RMLVO,
+    Capability, KeyEvent, KeyboardData, KeyboardError, KeyboardHandler, RepeatInfo, SeatError,
+    RMLVO,
 };
 use crate::seat::SeatState;
 
@@ -64,14 +64,30 @@ impl SeatState {
         callback: RepeatCallback<D>,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D>> + KeyboardHandler + 'static,
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, ()>> + KeyboardHandler + 'static,
     {
         let udata = match rmlvo {
-            Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo)?,
-            None => KeyboardData::new(seat.clone()),
+            Some(rmlvo) => KeyboardData::from_rmlvo(seat.clone(), rmlvo, ())?,
+            None => KeyboardData::new(seat.clone(), ()),
         };
 
-        self.get_keyboard_with_repeat_with_data(qh, seat, udata, loop_handle, callback)
+        let inner =
+            self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
+
+        if !inner.data.has_keyboard.load(Ordering::SeqCst) {
+            return Err(SeatError::UnsupportedCapability(Capability::Keyboard).into());
+        }
+
+        udata.repeat_data.lock().unwrap().replace(RepeatData {
+            current_repeat: None,
+            repeat_info: RepeatInfo::Disable,
+            loop_handle: loop_handle.clone(),
+            callback,
+            repeat_token: None,
+        });
+        udata.init_compose();
+
+        Ok(seat.get_keyboard(qh, udata))
     }
 
     /// Creates a keyboard from a seat.
@@ -92,13 +108,13 @@ impl SeatState {
         &mut self,
         qh: &QueueHandle<D>,
         seat: &wl_seat::WlSeat,
-        mut udata: U,
-        loop_handle: LoopHandle<'static, <U as KeyboardDataExt>::State>,
-        callback: RepeatCallback<<U as KeyboardDataExt>::State>,
+        udata: U,
+        loop_handle: LoopHandle<'static, D>,
+        callback: RepeatCallback<D>,
     ) -> Result<wl_keyboard::WlKeyboard, KeyboardError>
     where
-        D: Dispatch<wl_keyboard::WlKeyboard, U> + KeyboardHandler + 'static,
-        U: KeyboardDataExt<State = D> + 'static,
+        D: Dispatch<wl_keyboard::WlKeyboard, KeyboardData<D, U>> + KeyboardHandler + 'static,
+        U: Send + Sync + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -107,15 +123,16 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Keyboard).into());
         }
 
-        let kbd_data = udata.keyboard_data_mut();
-        kbd_data.repeat_data.lock().unwrap().replace(RepeatData {
+        let udata = KeyboardData::new(seat.clone(), udata);
+
+        udata.repeat_data.lock().unwrap().replace(RepeatData {
             current_repeat: None,
             repeat_info: RepeatInfo::Disable,
             loop_handle: loop_handle.clone(),
             callback,
             repeat_token: None,
         });
-        kbd_data.init_compose();
+        udata.init_compose();
 
         Ok(seat.get_keyboard(qh, udata))
     }

--- a/src/seat/mod.rs
+++ b/src/seat/mod.rs
@@ -15,7 +15,7 @@ use crate::reexports::client::{
 use crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1;
 use crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1;
 use crate::{
-    compositor::SurfaceDataExt,
+    compositor::SurfaceData,
     globals::GlobalData,
     registry::{ProvidesRegistryState, RegistryHandler},
 };
@@ -31,8 +31,8 @@ pub mod relative_pointer;
 pub mod touch;
 
 use pointer::cursor_shape::CursorShapeManager;
-use pointer::{PointerData, PointerDataExt, PointerHandler, ThemeSpec, ThemedPointer, Themes};
-use touch::{TouchData, TouchDataExt, TouchHandler};
+use pointer::{PointerData, PointerHandler, ThemeSpec, ThemedPointer, Themes};
+use touch::{TouchData, TouchHandler};
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -152,9 +152,9 @@ impl SeatState {
         seat: &wl_seat::WlSeat,
     ) -> Result<wl_pointer::WlPointer, SeatError>
     where
-        D: Dispatch<wl_pointer::WlPointer, PointerData> + PointerHandler + 'static,
+        D: Dispatch<wl_pointer::WlPointer, PointerData<()>> + PointerHandler + 'static,
     {
-        self.get_pointer_with_data(qh, seat, PointerData::new(seat.clone()))
+        self.get_pointer_with_data(qh, seat, ())
     }
 
     /// Creates a pointer from a seat with the provided theme.
@@ -171,24 +171,16 @@ impl SeatState {
         shm: &wl_shm::WlShm,
         surface: wl_surface::WlSurface,
         theme: ThemeSpec,
-    ) -> Result<ThemedPointer<PointerData>, SeatError>
+    ) -> Result<ThemedPointer<()>, SeatError>
     where
-        D: Dispatch<wl_pointer::WlPointer, PointerData>
-            + Dispatch<wl_surface::WlSurface, S>
+        D: Dispatch<wl_pointer::WlPointer, PointerData<()>>
+            + Dispatch<wl_surface::WlSurface, SurfaceData<S>>
             + Dispatch<WpCursorShapeManagerV1, GlobalData>
             + Dispatch<WpCursorShapeDeviceV1, GlobalData>
             + PointerHandler
             + 'static,
-        S: SurfaceDataExt + 'static,
     {
-        self.get_pointer_with_theme_and_data(
-            qh,
-            seat,
-            shm,
-            surface,
-            theme,
-            PointerData::new(seat.clone()),
-        )
+        self.get_pointer_with_theme_and_data(qh, seat, shm, surface, theme, ())
     }
 
     /// Creates a pointer from a seat.
@@ -203,8 +195,8 @@ impl SeatState {
         pointer_data: U,
     ) -> Result<wl_pointer::WlPointer, SeatError>
     where
-        D: Dispatch<wl_pointer::WlPointer, U> + PointerHandler + 'static,
-        U: PointerDataExt + 'static,
+        D: Dispatch<wl_pointer::WlPointer, PointerData<U>> + PointerHandler + 'static,
+        U: Send + Sync + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -213,6 +205,7 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Pointer));
         }
 
+        let pointer_data = PointerData::new(seat.clone(), pointer_data);
         Ok(seat.get_pointer(qh, pointer_data))
     }
 
@@ -231,14 +224,13 @@ impl SeatState {
         pointer_data: U,
     ) -> Result<ThemedPointer<U>, SeatError>
     where
-        D: Dispatch<wl_pointer::WlPointer, U>
-            + Dispatch<wl_surface::WlSurface, S>
+        D: Dispatch<wl_pointer::WlPointer, PointerData<U>>
+            + Dispatch<wl_surface::WlSurface, SurfaceData<S>>
             + Dispatch<WpCursorShapeManagerV1, GlobalData>
             + Dispatch<WpCursorShapeDeviceV1, GlobalData>
             + PointerHandler
             + 'static,
-        S: SurfaceDataExt + 'static,
-        U: PointerDataExt + 'static,
+        U: Send + Sync + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -247,6 +239,7 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Pointer));
         }
 
+        let pointer_data = PointerData::new(seat.clone(), pointer_data);
         let wl_ptr = seat.get_pointer(qh, pointer_data);
 
         if let CursorShapeManagerState::Pending { registry, global } =
@@ -295,9 +288,9 @@ impl SeatState {
         seat: &wl_seat::WlSeat,
     ) -> Result<wl_touch::WlTouch, SeatError>
     where
-        D: Dispatch<wl_touch::WlTouch, TouchData> + TouchHandler + 'static,
+        D: Dispatch<wl_touch::WlTouch, TouchData<()>> + TouchHandler + 'static,
     {
-        self.get_touch_with_data(qh, seat, TouchData::new(seat.clone()))
+        self.get_touch_with_data(qh, seat, ())
     }
 
     /// Creates a touch handle from a seat.
@@ -312,8 +305,8 @@ impl SeatState {
         udata: U,
     ) -> Result<wl_touch::WlTouch, SeatError>
     where
-        D: Dispatch<wl_touch::WlTouch, U> + TouchHandler + 'static,
-        U: TouchDataExt + 'static,
+        D: Dispatch<wl_touch::WlTouch, TouchData<U>> + TouchHandler + 'static,
+        U: Send + Sync + 'static,
     {
         let inner =
             self.seats.iter().find(|inner| &inner.seat == seat).ok_or(SeatError::DeadObject)?;
@@ -322,7 +315,8 @@ impl SeatState {
             return Err(SeatError::UnsupportedCapability(Capability::Touch));
         }
 
-        Ok(seat.get_touch(qh, udata))
+        let data = TouchData::new(seat.clone(), udata);
+        Ok(seat.get_touch(qh, data))
     }
 }
 

--- a/src/seat/pointer/mod.rs
+++ b/src/seat/pointer/mod.rs
@@ -17,10 +17,7 @@ use wayland_client::{
 use wayland_cursor::{Cursor, CursorTheme};
 use wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1;
 
-use crate::{
-    compositor::{SurfaceData, SurfaceDataExt},
-    error::GlobalError,
-};
+use crate::{compositor::SurfaceData, error::GlobalError};
 
 use super::SeatState;
 
@@ -158,14 +155,23 @@ pub trait PointerHandler: Sized {
 }
 
 #[derive(Debug)]
-pub struct PointerData {
+pub struct PointerData<U> {
     seat: WlSeat,
     pub(crate) inner: Mutex<PointerDataInner>,
+    udata: U,
 }
 
-impl PointerData {
-    pub fn new(seat: WlSeat) -> Self {
-        Self { seat, inner: Default::default() }
+impl<U> PointerData<U> {
+    pub fn new(seat: WlSeat, udata: U) -> Self {
+        Self { seat, inner: Default::default(), udata }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 
     /// The seat associated with this pointer.
@@ -185,48 +191,25 @@ impl PointerData {
     }
 }
 
-pub trait PointerDataExt: Send + Sync {
-    fn pointer_data(&self) -> &PointerData;
-}
-
-impl PointerDataExt for PointerData {
-    fn pointer_data(&self) -> &PointerData {
-        self
-    }
-}
-
 #[macro_export]
 macro_rules! delegate_pointer {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::delegate_pointer!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; pointer: []);
-        $crate::delegate_pointer!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; pointer-only: $crate::seat::pointer::PointerData);
-    };
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, pointer: [$($pointer_data:ty),* $(,)?]) => {
-        $crate::delegate_pointer!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; pointer: [ $($pointer_data),* ]);
-    };
-    (@{$($ty:tt)*}; pointer: []) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
                 $crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_manager_v1::WpCursorShapeManagerV1: $crate::globals::GlobalData
             ] => $crate::seat::pointer::cursor_shape::CursorShapeManager
         );
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
             [
                 $crate::reexports::protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::WpCursorShapeDeviceV1: $crate::globals::GlobalData
             ] => $crate::seat::pointer::cursor_shape::CursorShapeManager
         );
-    };
-    (@{$($ty:tt)*}; pointer-only: $pointer_data:ty) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U: Send + Sync + 'static > $ty:
             [
-                $crate::reexports::client::protocol::wl_pointer::WlPointer: $pointer_data
+                $crate::reexports::client::protocol::wl_pointer::WlPointer: $crate::seat::pointer::PointerData<U>
             ] => $crate::seat::SeatState
         );
     };
-    (@$ty:tt; pointer: [$($pointer:ty),*]) => {
-        $crate::delegate_pointer!(@$ty; pointer: []);
-        $( $crate::delegate_pointer!(@$ty; pointer-only: $pointer); )*
-    }
 }
 
 #[derive(Debug, Default)]
@@ -246,20 +229,19 @@ pub(crate) struct PointerDataInner {
     pub(crate) latest_btn: Option<u32>,
 }
 
-impl<D, U> Dispatch<WlPointer, U, D> for SeatState
+impl<D, U> Dispatch<WlPointer, PointerData<U>, D> for SeatState
 where
-    D: Dispatch<WlPointer, U> + PointerHandler,
-    U: PointerDataExt,
+    D: Dispatch<WlPointer, PointerData<U>> + PointerHandler,
+    U: Send + Sync + 'static,
 {
     fn event(
         data: &mut D,
         pointer: &WlPointer,
         event: wl_pointer::Event,
-        udata: &U,
+        udata: &PointerData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let udata = udata.pointer_data();
         let mut guard = udata.inner.lock().unwrap();
         let mut leave_surface = None;
         let kind = match event {
@@ -501,7 +483,7 @@ where
 
 /// Pointer themeing
 #[derive(Debug)]
-pub struct ThemedPointer<U = PointerData, S = SurfaceData> {
+pub struct ThemedPointer<U = (), S = ()> {
     pub(super) themes: Arc<Mutex<Themes>>,
     /// The underlying wl_pointer.
     pub(super) pointer: WlPointer,
@@ -513,19 +495,17 @@ pub struct ThemedPointer<U = PointerData, S = SurfaceData> {
     pub(super) _surface_data: std::marker::PhantomData<S>,
 }
 
-impl<U: PointerDataExt + 'static, S: SurfaceDataExt + 'static> ThemedPointer<U, S> {
+impl<U: Send + Sync + 'static, S: Send + Sync + 'static> ThemedPointer<U, S> {
     /// Set the cursor to the given [`CursorIcon`].
     ///
     /// The cursor icon should be reloaded on every [`PointerEventKind::Enter`] event.
     pub fn set_cursor(&self, conn: &Connection, icon: CursorIcon) -> Result<(), PointerThemeError> {
-        let serial = match self
-            .pointer
-            .data::<U>()
-            .and_then(|data| data.pointer_data().latest_enter_serial())
-        {
-            Some(serial) => serial,
-            None => return Err(PointerThemeError::MissingEnterSerial),
-        };
+        let serial =
+            match self.pointer.data::<PointerData<U>>().and_then(|data| data.latest_enter_serial())
+            {
+                Some(serial) => serial,
+                None => return Err(PointerThemeError::MissingEnterSerial),
+            };
 
         if let Some(shape_device) = self.shape_device.as_ref() {
             shape_device.set_shape(serial, cursor_icon_to_shape(icon, shape_device.version()));
@@ -545,7 +525,7 @@ impl<U: PointerDataExt + 'static, S: SurfaceDataExt + 'static> ThemedPointer<U, 
     ) -> Result<(), PointerThemeError> {
         let mut themes = self.themes.lock().unwrap();
 
-        let scale = self.surface.data::<S>().unwrap().surface_data().scale_factor();
+        let scale = self.surface.data::<SurfaceData<S>>().unwrap().scale_factor();
         for cursor_icon_name in iter::once(&icon.name()).chain(icon.alt_names().iter()) {
             if let Some(cursor) = themes
                 .get_cursor(conn, cursor_icon_name, scale as u32, &self.shm)
@@ -587,8 +567,8 @@ impl<U: PointerDataExt + 'static, S: SurfaceDataExt + 'static> ThemedPointer<U, 
     ///
     /// The cursor should be hidden on every [`PointerEventKind::Enter`] event.
     pub fn hide_cursor(&self) -> Result<(), PointerThemeError> {
-        let data = self.pointer.data::<U>();
-        if let Some(serial) = data.and_then(|data| data.pointer_data().latest_enter_serial()) {
+        let data = self.pointer.data::<PointerData<U>>();
+        if let Some(serial) = data.and_then(|data| data.latest_enter_serial()) {
             self.pointer.set_cursor(serial, None, 0, 0);
             Ok(())
         } else {

--- a/src/seat/touch.rs
+++ b/src/seat/touch.rs
@@ -9,16 +9,24 @@ use wayland_client::{Connection, Dispatch, QueueHandle};
 use crate::seat::SeatState;
 
 #[derive(Debug)]
-pub struct TouchData {
+pub struct TouchData<U> {
     seat: WlSeat,
-
     inner: Mutex<TouchDataInner>,
+    udata: U,
 }
 
-impl TouchData {
+impl<U> TouchData<U> {
     /// Create the new touch data associated with the given seat.
-    pub fn new(seat: WlSeat) -> Self {
-        Self { seat, inner: Default::default() }
+    pub fn new(seat: WlSeat, udata: U) -> Self {
+        Self { seat, inner: Default::default(), udata }
+    }
+
+    pub fn data(&self) -> &U {
+        &self.udata
+    }
+
+    pub fn data_mut(&mut self) -> &mut U {
+        &mut self.udata
     }
 
     /// Get the associated seat from the data.
@@ -44,33 +52,12 @@ pub(crate) struct TouchDataInner {
 #[macro_export]
 macro_rules! delegate_touch {
     ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
-        $crate::delegate_touch!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; touch: $crate::seat::touch::TouchData);
-    };
-    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, touch: [$($td:ty),* $(,)?]) => {
-        $crate::delegate_touch!(@{ $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty }; [ $($td),* ]);
-    };
-    (@{$($ty:tt)*}; touch: $td:ty) => {
-        $crate::reexports::client::delegate_dispatch!($($ty)*:
+        $crate::reexports::client::delegate_dispatch!(@< $( $( $lt $( : $clt $(+ $dlt )* )? ,)+ )? U: Send + Sync + 'static > $ty:
             [
-                $crate::reexports::client::protocol::wl_touch::WlTouch: $td
+                $crate::reexports::client::protocol::wl_touch::WlTouch: $crate::seat::touch::TouchData<U>
             ] => $crate::seat::SeatState
         );
     };
-    (@$ty:tt; [$($td:ty),*] ) => {
-        $(
-            $crate::delegate_touch!(@$ty, touch: $td);
-        )*
-    };
-}
-
-pub trait TouchDataExt: Send + Sync {
-    fn touch_data(&self) -> &TouchData;
-}
-
-impl TouchDataExt for TouchData {
-    fn touch_data(&self) -> &TouchData {
-        self
-    }
 }
 
 pub trait TouchHandler: Sized {
@@ -158,20 +145,18 @@ pub trait TouchHandler: Sized {
     fn cancel(&mut self, conn: &Connection, qh: &QueueHandle<Self>, touch: &WlTouch);
 }
 
-impl<D, U> Dispatch<WlTouch, U, D> for SeatState
+impl<D, U> Dispatch<WlTouch, TouchData<U>, D> for SeatState
 where
-    D: Dispatch<WlTouch, U> + TouchHandler,
-    U: TouchDataExt,
+    D: Dispatch<WlTouch, TouchData<U>> + TouchHandler,
 {
     fn event(
         data: &mut D,
         touch: &WlTouch,
         event: TouchEvent,
-        udata: &U,
+        udata: &TouchData<U>,
         conn: &Connection,
         qh: &QueueHandle<D>,
     ) {
-        let udata = udata.touch_data();
         let mut guard: std::sync::MutexGuard<'_, TouchDataInner> = udata.inner.lock().unwrap();
 
         let mut save_event = false;

--- a/src/shell/xdg/fallback_frame.rs
+++ b/src/shell/xdg/fallback_frame.rs
@@ -91,7 +91,7 @@ pub struct FallbackFrame<State> {
 
 impl<State> FallbackFrame<State>
 where
-    State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+    State: Dispatch<WlSurface, SurfaceData<()>> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
 {
     pub fn new(
         parent: &impl WaylandSurface,
@@ -327,7 +327,7 @@ where
 
 impl<State> DecorationsFrame for FallbackFrame<State>
 where
-    State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+    State: Dispatch<WlSurface, SurfaceData<()>> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
 {
     fn set_scaling_factor(&mut self, scale_factor: f64) {
         self.scale_factor = scale_factor;
@@ -621,7 +621,8 @@ impl FrameRenderData {
         queue_handle: &QueueHandle<State>,
     ) -> Self
     where
-        State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+        State:
+            Dispatch<WlSurface, SurfaceData<()>> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
     {
         let parts = [
             // Header.

--- a/src/shell/xdg/popup.rs
+++ b/src/shell/xdg/popup.rs
@@ -54,7 +54,7 @@ impl Popup {
         wm_base: &impl ProvidesBoundGlobal<xdg_wm_base::XdgWmBase, 5>,
     ) -> Result<Popup, GlobalError>
     where
-        D: Dispatch<wl_surface::WlSurface, SurfaceData>
+        D: Dispatch<wl_surface::WlSurface, SurfaceData<()>>
             + Dispatch<xdg_surface::XdgSurface, PopupData>
             + Dispatch<xdg_popup::XdgPopup, PopupData>
             + PopupHandler

--- a/src/subcompositor.rs
+++ b/src/subcompositor.rs
@@ -33,9 +33,10 @@ impl SubcompositorState {
         queue_handle: &QueueHandle<State>,
     ) -> (WlSubsurface, WlSurface)
     where
-        State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+        State:
+            Dispatch<WlSurface, SurfaceData<()>> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
     {
-        let surface_data = SurfaceData::new(Some(parent.clone()), 1);
+        let surface_data = SurfaceData::new(Some(parent.clone()), 1, ());
         let surface = self.compositor.create_surface(queue_handle, surface_data);
         let subsurface_data = SubsurfaceData::new(surface.clone());
         let subsurface =
@@ -49,9 +50,10 @@ impl SubcompositorState {
         queue_handle: &QueueHandle<State>,
     ) -> Option<WlSubsurface>
     where
-        State: Dispatch<WlSurface, SurfaceData> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
+        State:
+            Dispatch<WlSurface, SurfaceData<()>> + Dispatch<WlSubsurface, SubsurfaceData> + 'static,
     {
-        let parent = surface.data::<SurfaceData>().unwrap().parent_surface();
+        let parent = surface.data::<SurfaceData<()>>().unwrap().parent_surface();
         let subsurface_data = SubsurfaceData::new(surface.clone());
         parent.map(|parent| {
             self.subcompositor.get_subsurface(surface, parent, queue_handle, subsurface_data)


### PR DESCRIPTION
For https://github.com/Smithay/client-toolkit/pull/519, we need to remove the `*DataExt` traits, and instead make `*Data` wrap `U` so we can provide blanket implementations of the future `wayland_client::Dispatch` 

This probably doesn't need to be merged before https://github.com/Smithay/client-toolkit/pull/519, which can then be based on this, but it seems good to keep these changes in clean separate commits, and verify everything works here. May as well have a draft PR before this part is done.

The various `get_keyboard_*` methods are made a bit more redundant in implementation here, but maybe they could now use a builder pattern.

This is a breaking change to code that uses `.data::<...>` to get the udata, since the type has changed. Though maybe it would be best to replace use of that with helper `from_resource()` methods as smithay has for a couple things.